### PR TITLE
feat: integrate basic LLM client

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -9,6 +9,7 @@ from app.core.evaluator import QualityGate
 from app.core.memory import Memory
 from app.core.planner import Planner
 from app.tools.scaffold import create_python_cli
+from app.llm.client import LLMClient
 
 
 class Engine:
@@ -20,6 +21,7 @@ class Engine:
         self.qg = QualityGate()
         self.bench = Bench()
         self.planner = Planner()
+        self.client = LLMClient()
         self.start_msg = self._bootstrap()
 
     def _bootstrap(self) -> str:
@@ -68,9 +70,11 @@ class Engine:
         return ctx
 
     def chat(self, prompt: str) -> str:
-        """Record a chat message and return a placeholder response."""
+        """Record a chat message, generate a reply and store it."""
         self.mem.add("chat", prompt)
-        return "ping"
+        reply = self.client.generate(prompt)
+        self.mem.add("chat", reply)
+        return reply
 
     def run_briefing(self) -> str:
         """Generate a project brief and persist it to the data directory."""

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -1,0 +1,35 @@
+import http.client
+import json
+
+
+class LLMClient:
+    """Simple client for a local language model API."""
+
+    def __init__(self, host: str = "127.0.0.1", port: int = 11434, model: str = "llama3.2:3b"):
+        self.host = host
+        self.port = port
+        self.model = model
+
+    def generate(self, prompt: str) -> str:
+        """Return a completion for the given prompt."""
+        try:
+            conn = http.client.HTTPConnection(self.host, self.port, timeout=30)
+            payload = json.dumps({"model": self.model, "prompt": prompt})
+            conn.request(
+                "POST",
+                "/api/generate",
+                body=payload,
+                headers={"Content-Type": "application/json"},
+            )
+            resp = conn.getresponse()
+            data = resp.read()
+            if resp.status != 200:
+                raise RuntimeError(f"LLM request failed: {resp.status}")
+            return json.loads(data).get("response", "")
+        except Exception as e:  # pragma: no cover - network
+            raise RuntimeError(f"Generation request failed: {e}")
+        finally:
+            try:
+                conn.close()
+            except Exception:  # pragma: no cover - defensive
+                pass


### PR DESCRIPTION
## Summary
- add local LLM client with generate function
- use LLM client in Engine to answer chat messages

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7526d5cf88320849dd03a3ad9459c