### PR TITLE
Add Black check to quality gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Exécuter les vérifications locales avant de proposer du code :
 ```bash
 ruff check .
 black --check .
+mypy .
+bandit -q -r .
+semgrep --quiet --error --config config/semgrep.yml .
 pytest -q
 ```
 

--- a/app/core/evaluator.py
+++ b/app/core/evaluator.py
@@ -6,6 +6,7 @@ class QualityGate:
         results = {
             "pytest": self._cmd(["pytest", "-q"]),
             "ruff": self._cmd(["ruff", "."]),
+            "black": self._cmd(["black", "--check", "."]),
             "mypy": self._cmd(["mypy", "."]),
             "bandit": self._cmd(["bandit", "-q", "-r", "."]),
             "semgrep": self._cmd(

--- a/app/llm/prompts/coder.md
+++ b/app/llm/prompts/coder.md
@@ -1,2 +1,2 @@
-﻿- TDD d'abord. Diffs <= 200 lignes. Respect ruff/mypy. Générer README/exemples.
+- TDD d'abord. Diffs <= 200 lignes. Respect ruff/black/mypy. Générer README/exemples.
 - Si 2 approches viables: produire A et B, puis bench et garder la meilleure.


### PR DESCRIPTION
## Summary
- run Black in QualityGate.run_all
- document Black and other quality tools in README and coding prompt

## Testing
- `python - <<'PY'
from app.core.evaluator import QualityGate
print(QualityGate().run_all()['results'].keys())
PY`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b753d70784832091bbcd81bd2f5438