### PR TITLE
Integrate basic LLM client into Engine

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -8,6 +8,7 @@ from app.core.benchmark import Bench
 from app.core.evaluator import QualityGate
 from app.core.memory import Memory
 from app.core.planner import Planner
+from app.llm.client import Client
 from app.tools.scaffold import create_python_cli
 
 
@@ -20,6 +21,7 @@ class Engine:
         self.qg = QualityGate()
         self.bench = Bench()
         self.planner = Planner()
+        self.client = Client()
         self.start_msg = self._bootstrap()
 
     def _bootstrap(self) -> str:
@@ -68,9 +70,11 @@ class Engine:
         return ctx
 
     def chat(self, prompt: str) -> str:
-        """Record a chat message and return a placeholder response."""
+        """Generate a response to *prompt* using the LLM client."""
         self.mem.add("chat", prompt)
-        return "ping"
+        answer = self.client.generate(prompt)
+        self.mem.add("chat", answer)
+        return answer
 
     def run_briefing(self) -> str:
         """Generate a project brief and persist it to the data directory."""

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -1,0 +1,20 @@
+"""Simple LLM client interface for Watcher."""
+
+
+class Client:
+    """Minimal client returning a deterministic response.
+
+    This is a placeholder for a real language model backend. Replace the
+    implementation of :meth:`generate` with an actual model call when
+    integrating a true LLM.
+    """
+
+    def generate(self, prompt: str) -> str:
+        """Return a response for *prompt*.
+
+        Parameters
+        ----------
+        prompt:
+            Input text to send to the model.
+        """
+        return f"Echo: {prompt}"


### PR DESCRIPTION
## Summary
- add a minimal LLM client with a `generate` method
- initialize the client in `Engine` and use it for chat replies
- store both user and model messages in memory

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b754e9f1908320961e1551d7464c8b