### PR TITLE
Ensure permission writes create directory

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -69,6 +69,24 @@ class Engine:
 
         return ctx
 
+    def _ask_permission(self, question: str, consent_file: Path) -> bool:
+        """Ask *question* to the user and persist the answer.
+
+        If ``consent_file`` already exists, its stored value (``"y"`` or
+        ``"n"``) is returned.  Otherwise the user is prompted and the response
+        is written to ``consent_file``.  The parent directory is created on the
+        fly to avoid ``FileNotFoundError`` when persisting the choice.
+        """
+
+        if consent_file.exists():
+            stored = consent_file.read_text(encoding="utf-8").strip().lower()
+            return stored.startswith("y")
+
+        answer = input(f"{question} [y/N]: ").strip().lower()
+        consent_file.parent.mkdir(parents=True, exist_ok=True)
+        consent_file.write_text("y" if answer.startswith("y") else "n", encoding="utf-8")
+        return answer.startswith("y")
+
     def chat(self, prompt: str) -> str:
         """Generate a response to *prompt* using the LLM client."""
         self.mem.add("chat", prompt)

--- a/tests/test_permission.py
+++ b/tests/test_permission.py
@@ -1,0 +1,37 @@
+"""Tests for the Engine._ask_permission helper."""
+
+from pathlib import Path
+import sys
+import types
+
+# Ensure repository root is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide a light-weight stub for numpy to avoid heavy dependency during tests
+sys.modules.setdefault("numpy", types.ModuleType("numpy"))
+
+from app.core.engine import Engine
+
+
+def test_ask_permission_creates_directory_and_persists_answer(tmp_path, monkeypatch):
+    """_ask_permission should persist the answer and create parent dirs."""
+
+    # Instantiate Engine without triggering _bootstrap
+    engine = Engine.__new__(Engine)
+
+    consent_file = tmp_path / "perm" / "consent.txt"
+
+    # Simulate user answering "y"
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    assert engine._ask_permission("Proceed?", consent_file) is True
+
+    # Directory and file should now exist with the stored answer
+    assert consent_file.parent.is_dir()
+    assert consent_file.read_text() == "y"
+
+    # Second call should reuse the stored value without prompting
+    def _fail_prompt(_: str) -> str:  # pragma: no cover - should not be called
+        raise AssertionError("input() was called again")
+
+    monkeypatch.setattr("builtins.input", _fail_prompt)
+    assert engine._ask_permission("Proceed?", consent_file) is True


### PR DESCRIPTION
## Summary
- add `_ask_permission` helper to persist consent answers and create missing parent directories
- cover `_ask_permission` with regression test ensuring directory creation and persistence

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7574ebf808320947885de179d7170