### PR TITLE
Use sandbox for pytest and secure task paths

### DIFF
--- a/app/core/sandbox.py
+++ b/app/core/sandbox.py
@@ -1,6 +1,12 @@
-﻿# Sandbox: point d'entrée pour exécutions confinées (TODO quotas/temps)
-def run(cmd: list[str]) -> dict:
+# Sandbox: point d'entrée pour exécutions confinées (TODO quotas/temps)
+
+def run(
+    cmd: list[str], *, cwd: str | None = None, timeout: int = 30
+) -> dict:
     import subprocess
 
-    p = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    p = subprocess.run(
+        cmd, capture_output=True, text=True, cwd=cwd, timeout=timeout
+    )
     return {"code": p.returncode, "out": p.stdout, "err": p.stderr}
+


### PR DESCRIPTION
## Summary
- run pytest via sandbox with stdout/stderr and exit code reporting
- validate dataset task names to stay within DATASETS
- allow sandbox.run to set working directory and timeout

## Testing
- `pytest -q`
- `ruff check app/core/autograder.py app/core/sandbox.py`


------
https://chatgpt.com/codex/tasks/task_e_68b808c37dac83209c3f263a2f3d1242