### PR TITLE
Add resource quota controls to sandbox

### DIFF
--- a/app/core/sandbox.py
+++ b/app/core/sandbox.py
@@ -1,6 +1,65 @@
-﻿# Sandbox: point d'entrée pour exécutions confinées (TODO quotas/temps)
-def run(cmd: list[str]) -> dict:
+# Sandbox: point d'entrée pour exécutions confinées avec quotas
+
+
+def run(
+    cmd: list[str],
+    *,
+    cpu_seconds: int | None = None,
+    memory_bytes: int | None = None,
+    timeout: float | None = 30,
+) -> dict:
+    """Exécute ``cmd`` avec quotas optionnels.
+
+    Args:
+        cmd: Commande à lancer.
+        cpu_seconds: Limite de temps CPU en secondes.
+        memory_bytes: Limite mémoire maximale en octets.
+        timeout: Temps d'expiration mur (timeout) pour ``subprocess.run``.
+
+    Returns:
+        dict: Informations d'exécution comprenant codes et dépassements.
+    """
+
+    import resource
+    import signal
     import subprocess
 
-    p = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    return {"code": p.returncode, "out": p.stdout, "err": p.stderr}
+    def _limits() -> None:
+        if cpu_seconds is not None:
+            resource.setrlimit(resource.RLIMIT_CPU, (cpu_seconds, cpu_seconds))
+        if memory_bytes is not None:
+            resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
+
+    result = {
+        "code": None,
+        "out": "",
+        "err": "",
+        "timeout": False,
+        "cpu_exceeded": False,
+        "memory_exceeded": False,
+    }
+
+    try:
+        p = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            preexec_fn=_limits if cpu_seconds or memory_bytes else None,
+        )
+        result.update({"code": p.returncode, "out": p.stdout, "err": p.stderr})
+        if p.returncode and p.returncode < 0:
+            sig = -p.returncode
+            if sig == signal.SIGXCPU:
+                result["cpu_exceeded"] = True
+            elif sig == signal.SIGKILL:
+                result["memory_exceeded"] = True
+    except subprocess.TimeoutExpired as e:
+        result.update(
+            {
+                "timeout": True,
+                "out": e.stdout or "",
+                "err": e.stderr or "",
+            }
+        )
+    return result


### PR DESCRIPTION
## Summary
- allow specifying CPU time, memory limit, and timeout for sandboxed commands
- enforce limits using resource.setrlimit before subprocess execution
- report timeouts and quota overruns in sandbox results

## Testing
- `ruff check app/core/sandbox.py`
- `black app/core/sandbox.py --check`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b808d63c18832085320c00c58478f2