### PR TITLE
feat: load settings from TOML

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,15 @@ Sous Windows :
 python -m app.ui.main
 ```
 
+## Configuration
+
+Les principaux réglages se trouvent dans `config/settings.toml` :
+
+- `[llm]` : backend (`backend`) et modèle (`model`) pour le client LLM.
+- `[dev.test_timeout_sec]` : délai maximal des tests et linters.
+- `[memory.db_path]` : chemin de la base SQLite des souvenirs de l'agent.
+- `[memory.top_k]` : nombre de résultats retournés lors d'une recherche.
+
 ## Tests & Qualité
 
 Exécuter les vérifications locales avant de proposer du code :

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Configuration loader for Watcher."""
+
+from functools import lru_cache
+from pathlib import Path
+import tomllib
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "settings.toml"
+
+
+@lru_cache
+def load_settings() -> dict:
+    """Load settings from the TOML configuration file.
+
+    Returns
+    -------
+    dict
+        Parsed settings as a nested dictionary.
+    """
+    with CONFIG_PATH.open("rb") as f:
+        return tomllib.load(f)

--- a/app/core/autograder.py
+++ b/app/core/autograder.py
@@ -2,11 +2,15 @@ import pathlib
 import subprocess
 import time
 
+from app.config import load_settings
+
 
 DATASETS = pathlib.Path("datasets/python")
 
 
-def _run_pytest(task_dir: pathlib.Path, timeout: int = 60) -> dict:
+def _run_pytest(task_dir: pathlib.Path, timeout: int | None = None) -> dict:
+    if timeout is None:
+        timeout = load_settings()["dev"].get("test_timeout_sec", 60)
     t0 = time.time()
     p = subprocess.run(
         ["pytest", "-q"],

--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -10,6 +10,7 @@ from app.core.memory import Memory
 from app.core.planner import Planner
 from app.llm.client import Client
 from app.tools.scaffold import create_python_cli
+from app.config import load_settings
 
 
 class Engine:
@@ -17,11 +18,15 @@ class Engine:
 
     def __init__(self) -> None:
         self.base = Path(__file__).resolve().parents[2]
-        self.mem = Memory(self.base / "memory" / "mem.db")
+        settings = load_settings()
+        mem_cfg = settings.get("memory", {})
+        mem_path = self.base / mem_cfg.get("db_path", "memory/mem.db")
+        top_k = mem_cfg.get("top_k", 8)
+        self.mem = Memory(mem_path, top_k=top_k)
         self.qg = QualityGate()
         self.bench = Bench()
         self.planner = Planner()
-        self.client = Client()
+        self.client = Client(settings.get("llm", {}))
         self.start_msg = self._bootstrap()
 
     def _bootstrap(self) -> str:

--- a/app/core/evaluator.py
+++ b/app/core/evaluator.py
@@ -1,31 +1,40 @@
 import subprocess
 
+from app.config import load_settings
+
 
 class QualityGate:
+    def __init__(self) -> None:
+        self.settings = load_settings()
+
     def run_all(self) -> dict:
+        dev = self.settings.get("dev", {})
+        timeout = dev.get("test_timeout_sec", 60)
+        semgrep_cfg = dev.get("semgrep_ruleset", "config/semgrep.yml")
         results = {
-            "pytest": self._cmd(["pytest", "-q"]),
-            "ruff": self._cmd(["ruff", "."]),
-            "black": self._cmd(["black", "--check", "."]),
-            "mypy": self._cmd(["mypy", "."]),
-            "bandit": self._cmd(["bandit", "-q", "-r", "."]),
+            "pytest": self._cmd(["pytest", "-q"], timeout),
+            "ruff": self._cmd(["ruff", "."], timeout),
+            "black": self._cmd(["black", "--check", "."], timeout),
+            "mypy": self._cmd(["mypy", "."], timeout),
+            "bandit": self._cmd(["bandit", "-q", "-r", "."], timeout),
             "semgrep": self._cmd(
                 [
                     "semgrep",
                     "--quiet",
                     "--error",
                     "--config",
-                    "config/semgrep.yml",
+                    semgrep_cfg,
                     ".",
-                ]
+                ],
+                timeout,
             ),
         }
         ok = all(r["ok"] for r in results.values())
         return {"ok": ok, "results": results}
 
-    def _cmd(self, args: list[str]) -> dict:
+    def _cmd(self, args: list[str], timeout: int) -> dict:
         try:
-            p = subprocess.run(args, capture_output=True, text=True, timeout=60)
+            p = subprocess.run(args, capture_output=True, text=True, timeout=timeout)
             return {
                 "ok": p.returncode == 0,
                 "out": p.stdout[-4000:],

--- a/app/core/memory.py
+++ b/app/core/memory.py
@@ -8,8 +8,9 @@ from app.tools.embeddings import embed_ollama
 
 
 class Memory:
-    def __init__(self, db_path: Path):
+    def __init__(self, db_path: Path, top_k: int = 8):
         self.db_path = Path(db_path)
+        self.top_k = top_k
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         self._init()
 
@@ -34,7 +35,9 @@ class Memory:
         con.commit()
         con.close()
 
-    def search(self, query: str, top_k: int = 8):
+    def search(self, query: str, top_k: int | None = None):
+        if top_k is None:
+            top_k = self.top_k
         q = embed_ollama([query])[0].astype("float32")
         con = sqlite3.connect(self.db_path)
         c = con.cursor()

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -4,10 +4,18 @@
 class Client:
     """Minimal client returning a deterministic response.
 
+    Parameters
+    ----------
+    config:
+        Optional configuration dictionary from ``settings.toml``.
+
     This is a placeholder for a real language model backend. Replace the
     implementation of :meth:`generate` with an actual model call when
     integrating a true LLM.
     """
+
+    def __init__(self, config: dict | None = None) -> None:
+        self.config = config or {}
 
     def generate(self, prompt: str) -> str:
         """Return a response for *prompt*.


### PR DESCRIPTION
## Summary
- add reusable `load_settings` to parse `config/settings.toml`
- drive engine, quality gate and autograder from configuration values
- document key configuration parameters in README

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b808f2811c832096a62b1f92d68f50