### PR TITLE
Handle connection errors in embed_ollama

### DIFF
--- a/app/tools/embeddings.py
+++ b/app/tools/embeddings.py
@@ -5,6 +5,7 @@ import numpy as np
 
 
 def embed_ollama(texts, model: str = "nomic-embed-text"):
+    conn: http.client.HTTPConnection | None = None
     try:
         conn = http.client.HTTPConnection("127.0.0.1", 11434, timeout=30)
         payload = json.dumps({"model": model, "input": texts})
@@ -22,7 +23,8 @@ def embed_ollama(texts, model: str = "nomic-embed-text"):
     except Exception as e:  # pragma: no cover - network
         raise RuntimeError(f"Embedding request failed: {e}")
     finally:
-        try:
-            conn.close()
-        except Exception:  # pragma: no cover - defensive
-            pass
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:  # pragma: no cover - defensive
+                pass

--- a/app/tools/tests/test_embeddings.py
+++ b/app/tools/tests/test_embeddings.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[3]))
+sys.modules.setdefault("numpy", SimpleNamespace(array=lambda *_, **__: None))
+from app.tools.embeddings import embed_ollama
+
+
+def test_embed_ollama_connection_failure():
+    with mock.patch(
+        "app.tools.embeddings.http.client.HTTPConnection",
+        side_effect=OSError("fail"),
+    ):
+        with pytest.raises(RuntimeError):
+            embed_ollama(["test"])


### PR DESCRIPTION
## Summary
- Guard HTTP connection cleanup in `embed_ollama`
- Add test verifying connection failures raise `RuntimeError`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b811a4e5208320a36385ff2580fcbe