### PR TITLE
Resolve semgrep config path from repository root

### DIFF
--- a/app/core/evaluator.py
+++ b/app/core/evaluator.py
@@ -1,8 +1,11 @@
 import subprocess
+from pathlib import Path
 
 
 class QualityGate:
     def run_all(self) -> dict:
+        repo_root = Path(__file__).resolve().parents[2]
+        semgrep_config = repo_root / "config" / "semgrep.yml"
         results = {
             "pytest": self._cmd(["pytest", "-q"]),
             "ruff": self._cmd(["ruff", "."]),
@@ -15,7 +18,7 @@ class QualityGate:
                     "--quiet",
                     "--error",
                     "--config",
-                    "config/semgrep.yml",
+                    str(semgrep_config),
                     ".",
                 ]
             ),

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -1,0 +1,27 @@
+import os
+from pathlib import Path
+
+from app.core.evaluator import QualityGate
+
+
+def test_semgrep_config_path_is_absolute_when_run_from_subdir(monkeypatch):
+    calls = []
+
+    def fake_cmd(self, args):
+        calls.append(args)
+        return {"ok": True, "out": "", "err": ""}
+
+    monkeypatch.setattr(QualityGate, "_cmd", fake_cmd)
+
+    cwd = os.getcwd()
+    try:
+        os.chdir("app")
+        gate = QualityGate()
+        gate.run_all()
+    finally:
+        os.chdir(cwd)
+
+    semgrep_args = next(args for args in calls if args and args[0] == "semgrep")
+    cfg_path = semgrep_args[semgrep_args.index("--config") + 1]
+    assert Path(cfg_path).is_absolute()
+    assert Path(cfg_path).exists()


### PR DESCRIPTION
## Summary
- Resolve repository root using `Path(__file__).resolve().parents[2]`
- Pass absolute `config/semgrep.yml` to the Semgrep command
- Add regression test to ensure `QualityGate` works from subdirectories

## Testing
- `python -m pytest -q`
- `ruff check .`
- `black --check .`
- `mypy .` *(fails: Source file found twice under different module names)*
- `bandit -q -r .` *(command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b811b9864c832096d9f94005130910