### PR TITLE
Handle Windows in sandbox

### DIFF
--- a/app/core/sandbox.py
+++ b/app/core/sandbox.py
@@ -19,7 +19,13 @@ def run(
     Returns:
         dict: Informations d'exécution comprenant codes et dépassements.
     """
-
+    import sys
+    if sys.platform == "win32":
+        msg = (
+            "Resource limits are not implemented on Windows. "
+            "Use subprocess.CREATE_JOB_OBJECT to enforce limits."
+        )
+        raise NotImplementedError(msg)
     import resource
     import signal
     import subprocess

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from app.core import sandbox
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="non-Windows only")
+def test_run_unix_executes_command():
+    result = sandbox.run(["python", "-c", "print('hi')"])
+    assert result["code"] == 0
+    assert result["out"].strip() == "hi"
+    assert result["timeout"] is False
+    assert result["cpu_exceeded"] is False
+    assert result["memory_exceeded"] is False
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
+def test_run_windows_notimplemented():
+    with pytest.raises(NotImplementedError):
+        sandbox.run(["python", "-c", "print('hi')"])


### PR DESCRIPTION
## Summary
- raise NotImplementedError on Windows for sandbox resource limits
- add cross-platform tests for sandbox.run

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b811bed0408320be7ea2ea6a6c85e2