### PR TITLE
feat: enhance planner and llm client

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -76,9 +76,9 @@ class Engine:
         self.mem.add("chat", answer)
         return answer
 
-    def run_briefing(self) -> str:
+    def run_briefing(self, objective: str = "Projet démo") -> str:
         """Generate a project brief and persist it to the data directory."""
-        spec = self.planner.briefing()
+        spec = self.planner.briefing(objective)
         (self.base / "data").mkdir(exist_ok=True, parents=True)
         (self.base / "data" / "brief.yaml").write_text(spec, encoding="utf-8")
         self.mem.add("brief", spec)

--- a/app/core/planner.py
+++ b/app/core/planner.py
@@ -1,14 +1,58 @@
-﻿# Planner: clarification obligatoire
+"""Simple planner returning a structured project brief."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
 class Planner:
-    def briefing(self) -> str:
-        template = [
-            "objectif: ...",
-            "entrees: ...",
-            "sorties: ...",
-            "plateforme: windows",
-            "contraintes: ...",
-            "licence: MIT",
-            "livrables: ...",
-            "critere_succes: ...",
-        ]
-        return "\n".join(template)
+    """Build YAML-like project specifications.
+
+    The planner validates the provided *objective* and generates a minimal
+    briefing including common sections (inputs, outputs, constraints...).
+    """
+
+    def briefing(
+        self,
+        objective: str,
+        *,
+        inputs: Iterable[str] | None = None,
+        outputs: Iterable[str] | None = None,
+        platform: str = "windows",
+        constraints: Iterable[str] | None = None,
+        license: str = "MIT",
+        deliverables: Iterable[str] | None = None,
+        success: Iterable[str] | None = None,
+    ) -> str:
+        """Return a YAML-formatted project brief.
+
+        Parameters
+        ----------
+        objective:
+            Main goal of the project. Must be non-empty.
+        inputs/outputs/platform/constraints/license/deliverables/success:
+            Optional sections used to enrich the generated brief.
+        """
+
+        if not objective.strip():
+            raise ValueError("objective must be a non-empty string")
+
+        def fmt(section: str, values: Iterable[str] | None) -> list[str]:
+            if not values:
+                return [f"{section}: []"]
+            lines = [f"{section}:"]
+            lines.extend(f"  - {v}" for v in values)
+            return lines
+
+        lines = [f"objectif: {objective}"]
+        lines += fmt("entrees", inputs)
+        lines += fmt("sorties", outputs)
+        lines.append("taches:")
+        lines.extend(f"  - {t}" for t in ["analyser", "implementer", "tester"])
+        lines.append(f"plateforme: {platform}")
+        lines += fmt("contraintes", constraints)
+        lines.append(f"licence: {license}")
+        lines += fmt("livrables", deliverables)
+        lines += fmt("critere_succes", success)
+        return "\n".join(lines)
+

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -1,20 +1,41 @@
-"""Simple LLM client interface for Watcher."""
+"""LLM client with optional OpenAI integration."""
+
+from __future__ import annotations
+
+import os
 
 
 class Client:
-    """Minimal client returning a deterministic response.
+    """Generate text using an LLM backend.
 
-    This is a placeholder for a real language model backend. Replace the
-    implementation of :meth:`generate` with an actual model call when
-    integrating a true LLM.
+    If an OpenAI API key is available the client will attempt to call the
+    `openai` package. Otherwise a deterministic echo response is returned.
     """
+
+    def __init__(self) -> None:
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        self.model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
 
     def generate(self, prompt: str) -> str:
         """Return a response for *prompt*.
 
-        Parameters
-        ----------
-        prompt:
-            Input text to send to the model.
+        When the OpenAI SDK or API key is missing, a simple echo is produced so
+        the rest of the application can continue to function in offline mode.
         """
+
+        if self.api_key:
+            try:  # pragma: no cover - network path
+                import openai
+
+                openai.api_key = self.api_key
+                resp = openai.ChatCompletion.create(
+                    model=self.model,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                return resp["choices"][0]["message"]["content"].strip()
+            except Exception:
+                # Fall back to a deterministic response in case of errors
+                pass
+
         return f"Echo: {prompt}"
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,12 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.llm.client import Client
+
+
+def test_client_fallback_echo() -> None:
+    client = Client()
+    assert client.generate("salut") == "Echo: salut"
+

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,25 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.core.planner import Planner
+import pytest
+
+
+def test_briefing_includes_sections() -> None:
+    plan = Planner().briefing(
+        "Créer un outil",
+        inputs=["spec"],
+        outputs=["code"],
+    )
+    assert "objectif: Créer un outil" in plan
+    assert "taches:" in plan
+    assert "  - analyser" in plan
+
+
+def test_briefing_requires_objective() -> None:
+    planner = Planner()
+    with pytest.raises(ValueError):
+        planner.briefing("   ")
+


### PR DESCRIPTION
## Summary
- expand planner to produce structured YAML briefs with basic validation
- add optional OpenAI-backed LLM client with graceful fallback
- cover planner and client with new tests

## Testing
- `ruff check app tests`
- `python -m compileall app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b82f32296c8320866640abf5318811