### PR TITLE
feat: enhance planner and llm client

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -8,6 +8,7 @@ from app.core.benchmark import Bench
 from app.core.evaluator import QualityGate
 from app.core.memory import Memory
 from app.core.planner import Planner
+from app.core.learner import Learner
 from app.llm.client import Client
 from app.tools.scaffold import create_python_cli
 
@@ -20,6 +21,7 @@ class Engine:
         self.mem = Memory(self.base / "memory" / "mem.db")
         self.qg = QualityGate()
         self.bench = Bench()
+        self.learner = Learner(self.bench, self.base / "data")
         self.planner = Planner()
         self.client = Client()
         self.start_msg = self._bootstrap()
@@ -76,9 +78,9 @@ class Engine:
         self.mem.add("chat", answer)
         return answer
 
-    def run_briefing(self) -> str:
+    def run_briefing(self, objective: str = "Projet démo") -> str:
         """Generate a project brief and persist it to the data directory."""
-        spec = self.planner.briefing()
+        spec = self.planner.briefing(objective)
         (self.base / "data").mkdir(exist_ok=True, parents=True)
         (self.base / "data" / "brief.yaml").write_text(spec, encoding="utf-8")
         self.mem.add("brief", spec)
@@ -101,8 +103,9 @@ class Engine:
         """Train on datasets and perform a simple A/B benchmark."""
         rep = AG.grade_all()
         self.mem.add("train", json.dumps(rep))
-        a = self.bench.run_variant("A")
-        b = self.bench.run_variant("B")
-        keep = "A" if a >= b else "B"
-        self.mem.add("decision", json.dumps({"A": a, "B": b, "keep": keep}))
+        comp = self.learner.compare("A", "B")
+        self.mem.add("decision", json.dumps(comp))
+        a = comp["A"]
+        b = comp["B"]
+        keep = comp["best"]["name"]
         return f"train_ok={rep.get('ok', False)} A={a:.3f} B={b:.3f} keep={keep}"

--- a/app/core/learner.py
+++ b/app/core/learner.py
@@ -1,0 +1,38 @@
+"""Persistent benchmark-based learner for simple self-improvement."""
+from __future__ import annotations
+
+from pathlib import Path
+import json
+
+from app.core.benchmark import Bench
+
+
+class Learner:
+    """Track benchmark results and remember the best variant."""
+
+    def __init__(self, bench: Bench, data_dir: Path) -> None:
+        self.bench = bench
+        self.file = data_dir / "best_variant.json"
+        self.file.parent.mkdir(parents=True, exist_ok=True)
+
+    def compare(self, a: str, b: str) -> dict:
+        """Benchmark two variants and persist the best result."""
+        score_a = self.bench.run_variant(a)
+        score_b = self.bench.run_variant(b)
+        name, score = (a, score_a) if score_a >= score_b else (b, score_b)
+        best = self._load_best()
+        if not best or score > best.get("score", -1.0):
+            best = {"name": name, "score": score}
+            self._save_best(best)
+        return {"A": score_a, "B": score_b, "best": best}
+
+    def _load_best(self) -> dict | None:
+        if self.file.exists():
+            try:
+                return json.loads(self.file.read_text(encoding="utf-8"))
+            except Exception:  # pragma: no cover - defensive
+                return None
+        return None
+
+    def _save_best(self, best: dict) -> None:
+        self.file.write_text(json.dumps(best), encoding="utf-8")

--- a/app/core/planner.py
+++ b/app/core/planner.py
@@ -1,14 +1,58 @@
-﻿# Planner: clarification obligatoire
+"""Simple planner returning a structured project brief."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
 class Planner:
-    def briefing(self) -> str:
-        template = [
-            "objectif: ...",
-            "entrees: ...",
-            "sorties: ...",
-            "plateforme: windows",
-            "contraintes: ...",
-            "licence: MIT",
-            "livrables: ...",
-            "critere_succes: ...",
-        ]
-        return "\n".join(template)
+    """Build YAML-like project specifications.
+
+    The planner validates the provided *objective* and generates a minimal
+    briefing including common sections (inputs, outputs, constraints...).
+    """
+
+    def briefing(
+        self,
+        objective: str,
+        *,
+        inputs: Iterable[str] | None = None,
+        outputs: Iterable[str] | None = None,
+        platform: str = "windows",
+        constraints: Iterable[str] | None = None,
+        license: str = "MIT",
+        deliverables: Iterable[str] | None = None,
+        success: Iterable[str] | None = None,
+    ) -> str:
+        """Return a YAML-formatted project brief.
+
+        Parameters
+        ----------
+        objective:
+            Main goal of the project. Must be non-empty.
+        inputs/outputs/platform/constraints/license/deliverables/success:
+            Optional sections used to enrich the generated brief.
+        """
+
+        if not objective.strip():
+            raise ValueError("objective must be a non-empty string")
+
+        def fmt(section: str, values: Iterable[str] | None) -> list[str]:
+            if not values:
+                return [f"{section}: []"]
+            lines = [f"{section}:"]
+            lines.extend(f"  - {v}" for v in values)
+            return lines
+
+        lines = [f"objectif: {objective}"]
+        lines += fmt("entrees", inputs)
+        lines += fmt("sorties", outputs)
+        lines.append("taches:")
+        lines.extend(f"  - {t}" for t in ["analyser", "implementer", "tester"])
+        lines.append(f"plateforme: {platform}")
+        lines += fmt("contraintes", constraints)
+        lines.append(f"licence: {license}")
+        lines += fmt("livrables", deliverables)
+        lines += fmt("critere_succes", success)
+        return "\n".join(lines)
+

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -1,20 +1,41 @@
-"""Simple LLM client interface for Watcher."""
+"""LLM client with optional OpenAI integration."""
+
+from __future__ import annotations
+
+import os
 
 
 class Client:
-    """Minimal client returning a deterministic response.
+    """Generate text using an LLM backend.
 
-    This is a placeholder for a real language model backend. Replace the
-    implementation of :meth:`generate` with an actual model call when
-    integrating a true LLM.
+    If an OpenAI API key is available the client will attempt to call the
+    `openai` package. Otherwise a deterministic echo response is returned.
     """
+
+    def __init__(self) -> None:
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        self.model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
 
     def generate(self, prompt: str) -> str:
         """Return a response for *prompt*.
 
-        Parameters
-        ----------
-        prompt:
-            Input text to send to the model.
+        When the OpenAI SDK or API key is missing, a simple echo is produced so
+        the rest of the application can continue to function in offline mode.
         """
+
+        if self.api_key:
+            try:  # pragma: no cover - network path
+                import openai
+
+                openai.api_key = self.api_key
+                resp = openai.ChatCompletion.create(
+                    model=self.model,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                return resp["choices"][0]["message"]["content"].strip()
+            except Exception:
+                # Fall back to a deterministic response in case of errors
+                pass
+
         return f"Echo: {prompt}"
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,12 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.llm.client import Client
+
+
+def test_client_fallback_echo() -> None:
+    client = Client()
+    assert client.generate("salut") == "Echo: salut"
+

--- a/tests/test_learner.py
+++ b/tests/test_learner.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import json
+
+from app.core.learner import Learner
+from app.core.benchmark import Bench
+
+
+class DummyBench(Bench):
+    def __init__(self, scores: dict[str, float]):
+        self.scores = scores
+
+    def run_variant(self, name: str) -> float:  # type: ignore[override]
+        return self.scores[name]
+
+
+def test_compare_persists_best(tmp_path: Path) -> None:
+    bench = DummyBench({"A": 0.1, "B": 0.9})
+    learner = Learner(bench, tmp_path)
+    res = learner.compare("A", "B")
+    assert res["best"]["name"] == "B"
+    saved = json.loads((tmp_path / "best_variant.json").read_text())
+    assert saved["name"] == "B"
+
+    bench.scores["A"] = 0.8
+    res2 = learner.compare("A", "B")
+    assert res2["best"]["name"] == "B"

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,25 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.core.planner import Planner
+import pytest
+
+
+def test_briefing_includes_sections() -> None:
+    plan = Planner().briefing(
+        "Créer un outil",
+        inputs=["spec"],
+        outputs=["code"],
+    )
+    assert "objectif: Créer un outil" in plan
+    assert "taches:" in plan
+    assert "  - analyser" in plan
+
+
+def test_briefing_requires_objective() -> None:
+    planner = Planner()
+    with pytest.raises(ValueError):
+        planner.briefing("   ")
+


### PR DESCRIPTION
## Summary
- expand planner to produce structured YAML briefs with basic validation
- add optional OpenAI-backed LLM client with graceful fallback
- persist best benchmark variant for simple self-improvement
- cover planner, client and learner with tests

## Testing
- `ruff check .`
- `python -m compileall app tests`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b82f32296c8320866640abf5318811