### PR TITLE
feat: enhance planner and llm client

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,2 @@
+"""Watcher application package."""
+

--- a/app/core/__init__.py
+++ b/app/core/__init__.py
@@ -1,0 +1,2 @@
+"""Core components of the Watcher agent."""
+

--- a/app/core/learner.py
+++ b/app/core/learner.py
@@ -1,0 +1,103 @@
+"""Persistent benchmark-based learner for simple self-improvement."""
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import time
+
+from app.core.benchmark import Bench
+
+
+class Learner:
+    """Track benchmark results and remember the best variant.
+
+    The learner persists the best-performing variant and keeps a history of all
+    benchmark comparisons to enable basic long-term self-improvement.
+    """
+
+    def __init__(self, bench: Bench, data_dir: Path) -> None:
+        self.bench = bench
+        self.data_dir = data_dir
+        self.file = data_dir / "best_variant.json"
+        self.history_file = data_dir / "history.jsonl"
+        self.counter_file = data_dir / "variant_counter.txt"
+        self.data_dir.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Variant management
+    # ------------------------------------------------------------------
+    def current_best(self) -> str:
+        """Return the currently best known variant name."""
+        best = self._load_best()
+        return best["name"] if best else "base"
+
+    def suggest(self) -> str:
+        """Suggest a new variant name derived from the current best."""
+        base = self.current_best()
+        n = self._next_counter()
+        return f"{base}_{n}"
+
+    def _next_counter(self) -> int:
+        n = 0
+        if self.counter_file.exists():
+            try:
+                n = int(self.counter_file.read_text())
+            except Exception:  # pragma: no cover - defensive
+                n = 0
+        n += 1
+        self.counter_file.write_text(str(n))
+        return n
+
+    # ------------------------------------------------------------------
+    # Benchmarking
+    # ------------------------------------------------------------------
+    def compare(self, a: str, b: str) -> dict:
+        """Benchmark two variants, persist the best result and log history."""
+        score_a = self.bench.run_variant(a)
+        score_b = self.bench.run_variant(b)
+        name, score = (a, score_a) if score_a >= score_b else (b, score_b)
+        best = self._load_best()
+        if not best or score > best.get("score", -1.0):
+            best = {"name": name, "score": score}
+            self._save_best(best)
+        self._append_history(a, score_a, b, score_b, best)
+        return {"A": score_a, "B": score_b, "best": best}
+
+    def optimize(self, iterations: int = 3) -> dict:
+        """Run successive comparisons to seek better variants.
+
+        The learner will repeatedly benchmark the current best variant against a
+        newly suggested one. After *iterations* rounds, the result of the final
+        comparison is returned and the best variant is persisted.
+        """
+
+        last: dict = {}
+        for _ in range(iterations):
+            base = self.current_best()
+            cand = self.suggest()
+            last = self.compare(base, cand)
+        last["iterations"] = iterations
+        return last
+
+    def _append_history(
+        self, a: str, score_a: float, b: str, score_b: float, best: dict
+    ) -> None:
+        rec = {
+            "ts": time.time(),
+            "a": {"name": a, "score": score_a},
+            "b": {"name": b, "score": score_b},
+            "best": best,
+        }
+        with self.history_file.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec) + "\n")
+
+    def _load_best(self) -> dict | None:
+        if self.file.exists():
+            try:
+                return json.loads(self.file.read_text(encoding="utf-8"))
+            except Exception:  # pragma: no cover - defensive
+                return None
+        return None
+
+    def _save_best(self, best: dict) -> None:
+        self.file.write_text(json.dumps(best), encoding="utf-8")

--- a/app/core/memory.py
+++ b/app/core/memory.py
@@ -3,7 +3,7 @@ import time
 import logging
 from pathlib import Path
 
-import numpy as np
+import numpy as np  # type: ignore[import-not-found]
 
 from app.tools.embeddings import embed_ollama
 

--- a/app/core/planner.py
+++ b/app/core/planner.py
@@ -1,14 +1,58 @@
-﻿# Planner: clarification obligatoire
+"""Simple planner returning a structured project brief."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
 class Planner:
-    def briefing(self) -> str:
-        template = [
-            "objectif: ...",
-            "entrees: ...",
-            "sorties: ...",
-            "plateforme: windows",
-            "contraintes: ...",
-            "licence: MIT",
-            "livrables: ...",
-            "critere_succes: ...",
-        ]
-        return "\n".join(template)
+    """Build YAML-like project specifications.
+
+    The planner validates the provided *objective* and generates a minimal
+    briefing including common sections (inputs, outputs, constraints...).
+    """
+
+    def briefing(
+        self,
+        objective: str,
+        *,
+        inputs: Iterable[str] | None = None,
+        outputs: Iterable[str] | None = None,
+        platform: str = "windows",
+        constraints: Iterable[str] | None = None,
+        license: str = "MIT",
+        deliverables: Iterable[str] | None = None,
+        success: Iterable[str] | None = None,
+    ) -> str:
+        """Return a YAML-formatted project brief.
+
+        Parameters
+        ----------
+        objective:
+            Main goal of the project. Must be non-empty.
+        inputs/outputs/platform/constraints/license/deliverables/success:
+            Optional sections used to enrich the generated brief.
+        """
+
+        if not objective.strip():
+            raise ValueError("objective must be a non-empty string")
+
+        def fmt(section: str, values: Iterable[str] | None) -> list[str]:
+            if not values:
+                return [f"{section}: []"]
+            lines = [f"{section}:"]
+            lines.extend(f"  - {v}" for v in values)
+            return lines
+
+        lines = [f"objectif: {objective}"]
+        lines += fmt("entrees", inputs)
+        lines += fmt("sorties", outputs)
+        lines.append("taches:")
+        lines.extend(f"  - {t}" for t in ["analyser", "implementer", "tester"])
+        lines.append(f"plateforme: {platform}")
+        lines += fmt("contraintes", constraints)
+        lines.append(f"licence: {license}")
+        lines += fmt("livrables", deliverables)
+        lines += fmt("critere_succes", success)
+        return "\n".join(lines)
+

--- a/app/core/sandbox.py
+++ b/app/core/sandbox.py
@@ -1,5 +1,15 @@
 # Sandbox: point d'entrée pour exécutions confinées avec quotas
 
+from typing import TypedDict
+
+class RunResult(TypedDict):
+    code: int | None
+    out: str
+    err: str
+    timeout: bool
+    cpu_exceeded: bool
+    memory_exceeded: bool
+
 
 def run(
     cmd: list[str],
@@ -7,7 +17,7 @@ def run(
     cpu_seconds: int | None = None,
     memory_bytes: int | None = None,
     timeout: float | None = 30,
-) -> dict:
+) -> RunResult:
     """Exécute ``cmd`` avec quotas optionnels.
 
     Args:
@@ -30,7 +40,7 @@ def run(
         if memory_bytes is not None:
             resource.setrlimit(resource.RLIMIT_AS, (memory_bytes, memory_bytes))
 
-    result = {
+    result: RunResult = {
         "code": None,
         "out": "",
         "err": "",
@@ -58,8 +68,8 @@ def run(
         result.update(
             {
                 "timeout": True,
-                "out": e.stdout or "",
-                "err": e.stderr or "",
+                "out": str(e.stdout or ""),
+                "err": str(e.stderr or ""),
             }
         )
     return result

--- a/app/llm/__init__.py
+++ b/app/llm/__init__.py
@@ -1,0 +1,2 @@
+"""Language model client and prompts."""
+

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -1,20 +1,41 @@
-"""Simple LLM client interface for Watcher."""
+"""LLM client with optional OpenAI integration."""
+
+from __future__ import annotations
+
+import os
 
 
 class Client:
-    """Minimal client returning a deterministic response.
+    """Generate text using an LLM backend.
 
-    This is a placeholder for a real language model backend. Replace the
-    implementation of :meth:`generate` with an actual model call when
-    integrating a true LLM.
+    If an OpenAI API key is available the client will attempt to call the
+    `openai` package. Otherwise a deterministic echo response is returned.
     """
+
+    def __init__(self) -> None:
+        self.api_key = os.getenv("OPENAI_API_KEY")
+        self.model = os.getenv("OPENAI_MODEL", "gpt-3.5-turbo")
 
     def generate(self, prompt: str) -> str:
         """Return a response for *prompt*.
 
-        Parameters
-        ----------
-        prompt:
-            Input text to send to the model.
+        When the OpenAI SDK or API key is missing, a simple echo is produced so
+        the rest of the application can continue to function in offline mode.
         """
+
+        if self.api_key:
+            try:  # pragma: no cover - network path
+                import openai  # type: ignore[import-not-found]
+
+                openai.api_key = self.api_key
+                resp = openai.ChatCompletion.create(
+                    model=self.model,
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                return resp["choices"][0]["message"]["content"].strip()
+            except Exception:
+                # Fall back to a deterministic response in case of errors
+                pass
+
         return f"Echo: {prompt}"
+

--- a/app/tools/__init__.py
+++ b/app/tools/__init__.py
@@ -1,0 +1,2 @@
+"""Utility helpers used by the Watcher project."""
+

--- a/app/tools/embeddings.py
+++ b/app/tools/embeddings.py
@@ -1,7 +1,7 @@
 import http.client
 import json
 
-import numpy as np
+import numpy as np  # type: ignore[import-not-found]
 
 
 def embed_ollama(texts, model: str = "nomic-embed-text"):

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,0 +1,2 @@
+"""User interface components for Watcher."""
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,12 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.llm.client import Client
+
+
+def test_client_fallback_echo() -> None:
+    client = Client()
+    assert client.generate("salut") == "Echo: salut"
+

--- a/tests/test_learner.py
+++ b/tests/test_learner.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+import json
+
+from app.core.learner import Learner
+from app.core.benchmark import Bench
+
+
+class DummyBench(Bench):
+    def __init__(self, scores: dict[str, float]):
+        self.scores = scores
+
+    def run_variant(self, name: str) -> float:  # type: ignore[override]
+        return self.scores[name]
+
+
+def test_compare_persists_best(tmp_path: Path) -> None:
+    bench = DummyBench({"A": 0.1, "B": 0.9})
+    learner = Learner(bench, tmp_path)
+    res = learner.compare("A", "B")
+    assert res["best"]["name"] == "B"
+    saved = json.loads((tmp_path / "best_variant.json").read_text())
+    assert saved["name"] == "B"
+
+    bench.scores["A"] = 0.8
+    res2 = learner.compare("A", "B")
+    assert res2["best"]["name"] == "B"
+
+
+def test_suggest_and_history(tmp_path: Path) -> None:
+    bench = DummyBench({"base": 0.2, "base_1": 0.3, "base_1_2": 0.4})
+    learner = Learner(bench, tmp_path)
+    assert learner.current_best() == "base"
+    v1 = learner.suggest()
+    assert v1 == "base_1"
+    learner.compare("base", v1)
+    history = (tmp_path / "history.jsonl").read_text().strip().splitlines()
+    assert len(history) == 1
+    rec = json.loads(history[0])
+    assert rec["best"]["name"] == v1
+    v2 = learner.suggest()
+    assert v2 == "base_1_2"
+
+
+def test_optimize_runs_multiple_iterations(tmp_path: Path) -> None:
+    bench = DummyBench({"base": 0.1, "base_1": 0.2, "base_1_2": 0.3})
+    learner = Learner(bench, tmp_path)
+    res = learner.optimize(iterations=2)
+    assert res["best"]["name"] == "base_1_2"
+    assert res["iterations"] == 2
+    assert learner.current_best() == "base_1_2"

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,25 @@
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from app.core.planner import Planner
+import pytest
+
+
+def test_briefing_includes_sections() -> None:
+    plan = Planner().briefing(
+        "Créer un outil",
+        inputs=["spec"],
+        outputs=["code"],
+    )
+    assert "objectif: Créer un outil" in plan
+    assert "taches:" in plan
+    assert "  - analyser" in plan
+
+
+def test_briefing_requires_objective() -> None:
+    planner = Planner()
+    with pytest.raises(ValueError):
+        planner.briefing("   ")
+


### PR DESCRIPTION
## Summary
- expand planner to produce structured YAML briefs with basic validation
- add optional OpenAI-backed LLM client with graceful fallback
- persist best benchmark variant and log history for simple self-improvement
- iterate learner through multiple benchmark rounds for deeper autonomous improvement
- cover planner, client and learner with tests
- add package initializers and stricter sandbox typing to satisfy mypy

## Testing
- `python -m compileall app tests`
- `ruff check app tests`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b82f32296c8320866640abf5318811