### PR TITLE
Remove BOM from Python and config files

### DIFF
--- a/app/core/benchmark.py
+++ b/app/core/benchmark.py
@@ -1,4 +1,4 @@
-﻿class Bench:
+class Bench:
     def run_variant(self, name: str) -> float:
         # Stub bench: renvoie un score pseudo aléatoire stable par nom
         import hashlib

--- a/app/tools/scaffold.py
+++ b/app/tools/scaffold.py
@@ -1,4 +1,4 @@
-﻿from pathlib import Path
+from pathlib import Path
 import textwrap
 
 

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -1,4 +1,4 @@
-﻿[ui]
+[ui]
 theme = "dark"
 wizard_autostart = true
 mode = "Sur"                 # Rapide | Sur | Exploration | AutoRefactor


### PR DESCRIPTION
## Summary
- remove Unicode BOM markers from benchmark and scaffold modules
- remove BOM from settings configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8dc32abe88320aec34fdc3ad5e654