### PR TITLE
ci: add mypy, bandit, and semgrep

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,17 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black ruff pytest
+          pip install black ruff pytest mypy bandit semgrep
       - name: Lint
         run: ruff check .
       - name: Format check
         run: black --check .
+      - name: Type check
+        run: mypy .
+      - name: Bandit
+        run: bandit -q -r .
+      - name: Semgrep
+        run: semgrep --quiet --error --config config/semgrep.yml .
       - name: Tests
         run: pytest -q
 


### PR DESCRIPTION
## Summary
- install mypy, bandit, and semgrep in CI
- run mypy, bandit, and semgrep during CI checks

## Testing
- `mypy .` *(fails: Source file found twice under different module names)*
- `bandit -q -r .` *(fails: command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8dc3486fc8320b4b13a2f04556dfb