### PR TITLE
Clean up test imports

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,10 +1,4 @@
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
-
 from app.llm.client import Client
-
 
 def test_client_fallback_echo() -> None:
     client = Client()

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,11 +1,6 @@
-import pathlib
-import sys
-
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
-
-from app.core.planner import Planner
 import pytest
 
+from app.core.planner import Planner
 
 def test_briefing_includes_sections() -> None:
     plan = Planner().briefing(

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,11 +1,8 @@
 import sys
-from pathlib import Path
 
 import pytest
 
-sys.path.append(str(Path(__file__).resolve().parents[1]))
 from app.core import sandbox
-
 
 @pytest.mark.skipif(sys.platform == "win32", reason="non-Windows only")
 def test_run_unix_executes_command():


### PR DESCRIPTION
## Summary
- Remove manual `sys.path` mangling from tests
- Configure pytest to include project root for imports

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba9ec40ebc83209412d73634455984