### PR TITLE
Gracefully handle embedding service outages

### DIFF
--- a/app/tools/embeddings.py
+++ b/app/tools/embeddings.py
@@ -1,3 +1,10 @@
+"""Utilities for working with embeddings.
+
+If the embedding backend cannot be reached, the helper below returns an empty
+vector (``np.array([], dtype=np.float32)``) for each requested text. This
+effectively disables vector search.
+"""
+
 import http.client
 import json
 
@@ -19,8 +26,8 @@ def embed_ollama(texts, model: str = "nomic-embed-text"):
             raise RuntimeError(f"Embedding request failed: {resp.status}")
         data = json.loads(resp.read())
         return [np.array(v, dtype=np.float32) for v in data["embeddings"]]
-    except Exception as e:  # pragma: no cover - network
-        raise RuntimeError(f"Embedding request failed: {e}")
+    except Exception:  # pragma: no cover - network
+        return [np.array([], dtype=np.float32) for _ in texts]
     finally:
         try:
             conn.close()

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,0 +1,13 @@
+import numpy as np  # type: ignore
+
+from app.tools.embeddings import embed_ollama
+
+
+def test_embed_ollama_connection_error(monkeypatch):
+    def bad_conn(*args, **kwargs):
+        raise OSError("fail")
+
+    monkeypatch.setattr("http.client.HTTPConnection", bad_conn)
+    vecs = embed_ollama(["hello"])
+    assert len(vecs) == 1
+    assert vecs[0].size == 0

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -36,7 +36,7 @@ def test_search_embedding_error(tmp_path, monkeypatch):
     mem.add("note", "bonjour")
 
     def bad_embed(texts):
-        raise RuntimeError("fail")
+        return [np.array([], dtype=np.float32)]
 
     monkeypatch.setattr("app.core.memory.embed_ollama", bad_embed)
     assert mem.search("bonjour") == []


### PR DESCRIPTION
## Summary
- Return empty vectors when the Ollama embedding service is unreachable, disabling vector search instead of raising runtime errors
- Document the fallback behavior in the embeddings helper
- Add tests for embedding fallback and adjust memory search test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ba9ecac6908320bb3e802c9f34a4fa