### PR TITLE
feat: add Windows sandbox using job objects

### DIFF
--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -18,6 +18,10 @@ def test_run_unix_executes_command():
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="Windows only")
-def test_run_windows_notimplemented():
-    with pytest.raises(NotImplementedError):
-        sandbox.run(["python", "-c", "print('hi')"])
+def test_run_windows_executes_command():
+    result = sandbox.run(["python", "-c", "print('hi')"])
+    assert result["code"] == 0
+    assert result["out"].strip() == "hi"
+    assert result["timeout"] is False
+    assert result["cpu_exceeded"] is False
+    assert result["memory_exceeded"] is False


### PR DESCRIPTION
## Summary
- support Windows in sandbox using Job Objects for CPU and memory limits
- add Windows-specific test path for sandbox run

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba9ed620cc83208af00b29763e3623