### PR TITLE
Handle missing embeddings gracefully

### DIFF
--- a/app/tools/embeddings.py
+++ b/app/tools/embeddings.py
@@ -1,8 +1,8 @@
 """Utilities for working with embeddings.
 
-If the embedding backend cannot be reached, the helper below returns an empty
-vector (``np.array([], dtype=np.float32)``) for each requested text. This
-effectively disables vector search.
+If the embedding backend cannot be reached, the helper below returns a zero
+vector (``np.zeros(1, dtype=np.float32)``) for each requested text. This
+disables vector search but allows the application to continue running.
 """
 
 import http.client
@@ -27,7 +27,7 @@ def embed_ollama(texts, model: str = "nomic-embed-text"):
         data = json.loads(resp.read())
         return [np.array(v, dtype=np.float32) for v in data["embeddings"]]
     except Exception:  # pragma: no cover - network
-        return [np.array([], dtype=np.float32) for _ in texts]
+        return [np.zeros(1, dtype=np.float32) for _ in texts]
     finally:
         try:
             conn.close()

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -56,3 +56,7 @@ class _Linalg:
 
 
 linalg = _Linalg()
+
+
+def zeros(shape: int, dtype: str | None = None) -> ndarray:  # noqa: ARG001
+    return ndarray([0.0] * int(shape))

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -10,4 +10,5 @@ def test_embed_ollama_connection_error(monkeypatch):
     monkeypatch.setattr("http.client.HTTPConnection", bad_conn)
     vecs = embed_ollama(["hello"])
     assert len(vecs) == 1
-    assert vecs[0].size == 0
+    assert vecs[0].shape == (1,)
+    assert vecs[0][0] == 0.0


### PR DESCRIPTION
## Summary
- Return a zero vector when embedding backend is unreachable
- Document that missing embeddings disable vector search without stopping the app
- Add numpy.zeros stub and adjust tests

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*
- `python3 -m pip install pytest -q` *(fails: No module named pip)*

------
https://chatgpt.com/codex/tasks/task_e_68baa25eb9b08320a3e246eb587b159e