### PR TITLE
Use runpy to load dataset modules in tests

### DIFF
--- a/datasets/python/fib/tests/test_fib.py
+++ b/datasets/python/fib/tests/test_fib.py
@@ -1,8 +1,9 @@
 import pathlib
-import sys
+import runpy
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
-from fib import fib
+fib = runpy.run_path(
+    pathlib.Path(__file__).resolve().parents[1] / "src" / "fib.py"
+)["fib"]
 
 
 def test_values():

--- a/datasets/python/fizzbuzz/tests/test_fizzbuzz.py
+++ b/datasets/python/fizzbuzz/tests/test_fizzbuzz.py
@@ -1,8 +1,9 @@
 import pathlib
-import sys
+import runpy
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
-from fizzbuzz import fizzbuzz
+fizzbuzz = runpy.run_path(
+    pathlib.Path(__file__).resolve().parents[1] / "src" / "fizzbuzz.py"
+)["fizzbuzz"]
 
 
 def test_samples():

--- a/datasets/python/is_prime/tests/test_is_prime.py
+++ b/datasets/python/is_prime/tests/test_is_prime.py
@@ -1,8 +1,9 @@
 import pathlib
-import sys
+import runpy
 
-sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
-from is_prime import is_prime
+is_prime = runpy.run_path(
+    pathlib.Path(__file__).resolve().parents[1] / "src" / "is_prime.py"
+)["is_prime"]
 
 
 def test_small():


### PR DESCRIPTION
## Summary
- remove `sys.path` manipulation from dataset tests
- ensure pytest discovers `app.*` via existing root `pytest.ini`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68baa25f88fc8320a3ffbb6702b1b26e