### PR TITLE
Improve numpy stub and dataset tests

### DIFF
--- a/app/core/sandbox.py
+++ b/app/core/sandbox.py
@@ -74,9 +74,8 @@ def run(
             violation = win32job.QueryInformationJobObject(
                 job, win32job.JobObjectLimitViolationInformation
             )
-            vflags = (
-                violation.get("LimitFlags", 0)
-                | violation.get("ViolationLimitFlags", 0)
+            vflags = violation.get("LimitFlags", 0) | violation.get(
+                "ViolationLimitFlags", 0
             )
             if vflags & win32job.JOB_OBJECT_LIMIT_PROCESS_TIME:
                 result["cpu_exceeded"] = True

--- a/datasets/python/fib/tests/test_fib.py
+++ b/datasets/python/fib/tests/test_fib.py
@@ -2,7 +2,7 @@ import pathlib
 import runpy
 
 fib = runpy.run_path(
-    pathlib.Path(__file__).resolve().parents[1] / "src" / "fib.py"
+    str(pathlib.Path(__file__).resolve().parents[1] / "src" / "fib.py")
 )["fib"]
 
 

--- a/datasets/python/fizzbuzz/tests/test_fizzbuzz.py
+++ b/datasets/python/fizzbuzz/tests/test_fizzbuzz.py
@@ -2,7 +2,7 @@ import pathlib
 import runpy
 
 fizzbuzz = runpy.run_path(
-    pathlib.Path(__file__).resolve().parents[1] / "src" / "fizzbuzz.py"
+    str(pathlib.Path(__file__).resolve().parents[1] / "src" / "fizzbuzz.py")
 )["fizzbuzz"]
 
 

--- a/datasets/python/is_prime/tests/test_is_prime.py
+++ b/datasets/python/is_prime/tests/test_is_prime.py
@@ -2,7 +2,7 @@ import pathlib
 import runpy
 
 is_prime = runpy.run_path(
-    pathlib.Path(__file__).resolve().parents[1] / "src" / "is_prime.py"
+    str(pathlib.Path(__file__).resolve().parents[1] / "src" / "is_prime.py")
 )["is_prime"]
 
 

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -33,6 +33,13 @@ class ndarray:
     def size(self) -> int:  # pragma: no cover - trivial
         return len(self._values)
 
+    @property
+    def shape(self) -> tuple[int, ...]:  # pragma: no cover - trivial
+        return (len(self._values),)
+
+    def __getitem__(self, idx: int) -> float:  # pragma: no cover - convenience
+        return self._values[idx]
+
     def __iter__(self):  # pragma: no cover - convenience
         return iter(self._values)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
 from app.llm.client import Client
 
+
 def test_client_fallback_echo() -> None:
     client = Client()
     assert client.generate("salut") == "Echo: salut"

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,5 +1,3 @@
-import numpy as np  # type: ignore
-
 from app.tools.embeddings import embed_ollama
 
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2,6 +2,7 @@ import pytest
 
 from app.core.planner import Planner
 
+
 def test_briefing_includes_sections() -> None:
     plan = Planner().briefing(
         "Créer un outil",

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -4,6 +4,7 @@ import pytest
 
 from app.core import sandbox
 
+
 @pytest.mark.skipif(sys.platform == "win32", reason="non-Windows only")
 def test_run_unix_executes_command():
     result = sandbox.run(["python", "-c", "print('hi')"])


### PR DESCRIPTION
## Summary
- add shape and indexing support to lightweight numpy stub
- ensure dataset tests convert Paths to str for runpy
- clean up unused import and format code

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `bandit -q -r .` *(fails: command not found)*
- `pip install bandit` *(fails: could not find version)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(fails: command not found)*
- `pip install semgrep` *(fails: could not find version)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb2863ed1483208960fdd50046944a