### PR TITLE
Add __len__ to ndarray stub and update tests

### DIFF
--- a/app/core/memory.py
+++ b/app/core/memory.py
@@ -57,7 +57,7 @@ class Memory:
         scored = []
         for _id, kind, text, vec in rows:
             v = np.frombuffer(vec, dtype=np.float32)
-            if v.size != q.size or v.size == 0:
+            if len(v) != len(q) or len(v) == 0:
                 continue
             s = float(q @ v / ((np.linalg.norm(q) * np.linalg.norm(v)) + 1e-9))
             scored.append((s, _id, kind, text))

--- a/numpy/__init__.py
+++ b/numpy/__init__.py
@@ -43,6 +43,9 @@ class ndarray:
     def __iter__(self):  # pragma: no cover - convenience
         return iter(self._values)
 
+    def __len__(self) -> int:
+        return len(self._values)
+
     def tolist(self) -> List[float]:  # pragma: no cover - convenience
         return list(self._values)
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -8,5 +8,6 @@ def test_embed_ollama_connection_error(monkeypatch):
     monkeypatch.setattr("http.client.HTTPConnection", bad_conn)
     vecs = embed_ollama(["hello"])
     assert len(vecs) == 1
+    assert len(vecs[0]) == 1
     assert vecs[0].shape == (1,)
     assert vecs[0][0] == 0.0

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -18,7 +18,9 @@ def test_add_and_search(tmp_path, monkeypatch):
         row = con.execute("SELECT kind,text,vec FROM items").fetchone()
     assert row[0] == "note"
     assert row[1] == "salut"
-    assert np.frombuffer(row[2], dtype=np.float32).tolist() == [1.0]
+    vec = np.frombuffer(row[2], dtype=np.float32)
+    assert vec.tolist() == [1.0]
+    assert len(vec) == 1
 
     results = mem.search("salut")
     assert len(results) == 1


### PR DESCRIPTION
## Summary
- implement `__len__` for ndarray stub
- use `len` in memory search logic
- test `len(ndarray)` in embeddings and memory tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb6e98df4c8320ad917a0310e10071