### PR TITLE
Use SHA-256 for benchmark hash

### DIFF
--- a/app/core/benchmark.py
+++ b/app/core/benchmark.py
@@ -3,5 +3,5 @@ class Bench:
         # Stub bench: renvoie un score pseudo aléatoire stable par nom
         import hashlib
 
-        h = int(hashlib.sha1(name.encode()).hexdigest(), 16)
+        h = int(hashlib.sha256(name.encode()).hexdigest(), 16)
         return (h % 1000) / 1000.0


### PR DESCRIPTION
## Summary
- replace SHA-1 with SHA-256 in `Bench.run_variant`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb6ecbf2c48320961c0932ae4cb262