### PR TITLE
Add Bandit configuration to ignore virtual environments

### DIFF
--- a/bandit.yml
+++ b/bandit.yml
@@ -1,0 +1,5 @@
+exclude:
+  - .venv
+  - build
+  - dist
+  - '*.egg-info'


### PR DESCRIPTION
## Summary
- add `bandit.yml` to skip `.venv` and common build directories

## Testing
- `pytest -q`
- `bandit -r .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6eccf9288320bfb01e6bb41c5390