### PR TITLE
Handle subprocess errors in autograder

### DIFF
--- a/app/core/autograder.py
+++ b/app/core/autograder.py
@@ -8,13 +8,18 @@ DATASETS = pathlib.Path("datasets/python")
 
 def _run_pytest(task_dir: pathlib.Path, timeout: int = 60) -> dict:
     t0 = time.time()
-    p = subprocess.run(
-        ["pytest", "-q"],
-        cwd=str(task_dir),
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
+    try:
+        p = subprocess.run(
+            ["pytest", "-q"],
+            cwd=str(task_dir),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError:
+        return {"ok": False, "error": "pytest not found"}
+    except subprocess.TimeoutExpired:
+        return {"ok": False, "error": f"pytest timed out after {timeout} seconds"}
     ok = p.returncode == 0
     return {
         "ok": ok,
@@ -33,7 +38,7 @@ def grade_task(name: str) -> dict:
     if not task.exists():
         return {"ok": False, "error": f"task {name} not found"}
     rep = _run_pytest(task)
-    rep["score"] = 1.0 if rep["ok"] else 0.0
+    rep["score"] = 1.0 if rep.get("ok") else 0.0
     rep["task"] = name
     return rep
 


### PR DESCRIPTION
## Summary
- Catch `FileNotFoundError` and `TimeoutExpired` in `_run_pytest` to return explicit error messages instead of raising
- Ensure `grade_task` forwards the `ok` flag safely when computing scores

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb708a7a6c8320980003598dccac70