### PR TITLE
feat: configurable ollama client

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -4,18 +4,30 @@ from __future__ import annotations
 
 import http.client
 import json
+import logging
+from pathlib import Path
+from urllib.parse import urlparse
+
+import tomllib
 
 
-def generate_ollama(prompt: str) -> str:
-    """Send *prompt* to a locally running Ollama server.
+def generate_ollama(prompt: str, *, host: str, model: str) -> str:
+    """Send *prompt* to an Ollama server.
 
-    The request is performed against ``http://127.0.0.1:11434/api/generate``
-    using a JSON payload. The response value is returned as a stripped string.
+    Args:
+        prompt: Text prompt to send for generation.
+        host: Hostname (and optional port) of the Ollama server.
+        model: Model identifier used for the request.
+
+    The response value is returned as a stripped string.
     """
 
-    conn = http.client.HTTPConnection("127.0.0.1", 11434, timeout=30)
+    parsed = urlparse(host if "://" in host else f"http://{host}")
+    conn = http.client.HTTPConnection(
+        parsed.hostname or "127.0.0.1", parsed.port or 11434, timeout=30
+    )
     try:  # pragma: no cover - network path
-        payload = json.dumps({"model": "llama3.2:3b", "prompt": prompt})
+        payload = json.dumps({"model": model, "prompt": prompt})
         conn.request(
             "POST",
             "/api/generate",
@@ -40,12 +52,32 @@ class Client:
     A locally running Ollama server is preferred. If it cannot be reached a
     deterministic echo response is returned so the rest of the application can
     continue to function in offline mode.
+
+    Args:
+        model: Model identifier passed to the Ollama server. If omitted, the
+            value is read from ``config/settings.toml``.
+        host: Hostname (and optional port) of the Ollama server. If omitted,
+            the value is read from ``config/settings.toml``.
     """
+
+    def __init__(self, model: str | None = None, host: str | None = None) -> None:
+        if model is None or host is None:
+            try:
+                cfg_path = Path(__file__).resolve().parents[2] / "config" / "settings.toml"
+                with cfg_path.open("rb") as fh:
+                    cfg = tomllib.load(fh).get("llm", {})
+            except Exception:
+                cfg = {}
+        else:
+            cfg = {}
+        self.model = model or cfg.get("model", "llama3.2:3b")
+        self.host = host or cfg.get("host", "127.0.0.1:11434")
 
     def generate(self, prompt: str) -> str:
         """Return a response for *prompt*."""
 
         try:  # pragma: no cover - network path
-            return generate_ollama(prompt)
+            return generate_ollama(prompt, host=self.host, model=self.model)
         except Exception:
+            logging.exception("Failed to generate response")
             return f"Echo: {prompt}"

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -5,6 +5,7 @@ mode = "Sur"                 # Rapide | Sur | Exploration | AutoRefactor
 
 [llm]
 backend = "ollama"           # ollama | llamacpp
+host = "127.0.0.1:11434"     # Hostname and port of the Ollama server
 model = "llama3.2:3b"
 ctx = 8192
 temperature = 0.6


### PR DESCRIPTION
## Summary
- load model and host settings for Ollama client
- forward configuration to generation function and log errors
- document new configuration options

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb708bbda8832099e69eb300a5c214