### PR TITLE
Improve embed_ollama typing and docs

### DIFF
--- a/app/tools/embeddings.py
+++ b/app/tools/embeddings.py
@@ -11,7 +11,24 @@ import json
 import numpy as np
 
 
-def embed_ollama(texts, model: str = "nomic-embed-text"):
+def embed_ollama(texts: list[str], model: str = "nomic-embed-text") -> list[np.ndarray]:
+    """Generate embeddings for the given texts via a local Ollama server.
+
+    Parameters
+    ----------
+    texts:
+        List of strings to embed.
+    model:
+        Name of the embedding model served by Ollama. Defaults to
+        ``"nomic-embed-text"``.
+
+    Returns
+    -------
+    list[np.ndarray]
+        A list of embedding vectors corresponding to ``texts``. Each vector is
+        a ``numpy.ndarray`` of ``float32``. If the Ollama backend cannot be
+        reached, a list of zero vectors of shape ``(1,)`` is returned instead.
+    """
     conn = None
     try:
         conn = http.client.HTTPConnection("127.0.0.1", 11434, timeout=30)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6,7 +6,7 @@ from app.core.memory import Memory
 
 
 def test_add_and_search(tmp_path, monkeypatch):
-    def fake_embed(texts):
+    def fake_embed(texts, model="nomic-embed-text"):
         return [np.array([1.0])]
 
     monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
@@ -29,7 +29,7 @@ def test_add_and_search(tmp_path, monkeypatch):
 
 
 def test_search_embedding_error(tmp_path, monkeypatch):
-    def good_embed(texts):
+    def good_embed(texts, model="nomic-embed-text"):
         return [np.array([1.0])]
 
     monkeypatch.setattr("app.core.memory.embed_ollama", good_embed)
@@ -37,7 +37,7 @@ def test_search_embedding_error(tmp_path, monkeypatch):
     mem = Memory(db_path)
     mem.add("note", "bonjour")
 
-    def bad_embed(texts):
+    def bad_embed(texts, model="nomic-embed-text"):
         return [np.array([], dtype=np.float32)]
 
     monkeypatch.setattr("app.core.memory.embed_ollama", bad_embed)


### PR DESCRIPTION
## Summary
- Add type hints and detailed docstring to `embed_ollama`
- Adjust memory tests to mirror new embedding signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb708d0f3083209890648111ae402b