### PR TITLE
feat: separate user and ai chat memory entries

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -73,9 +73,11 @@ class Engine:
 
     def chat(self, prompt: str) -> str:
         """Generate a response to *prompt* using the LLM client."""
-        self.mem.add("chat", prompt)
+        # Store the user prompt and the assistant answer using distinct
+        # memory kinds so analytics can differentiate between them.
+        self.mem.add("chat_user", prompt)
         answer = self.client.generate(prompt)
-        self.mem.add("chat", answer)
+        self.mem.add("chat_ai", answer)
         return answer
 
     def run_briefing(self, objective: str = "Projet démo") -> str:

--- a/tests/test_engine_chat.py
+++ b/tests/test_engine_chat.py
@@ -1,0 +1,29 @@
+import sqlite3
+import numpy as np  # type: ignore
+
+from app.core.memory import Memory
+from app.core.engine import Engine
+
+
+def test_chat_saves_distinct_kinds(tmp_path, monkeypatch):
+    # Avoid heavy embedding and network calls
+    def fake_embed(texts, model="nomic-embed-text"):
+        return [np.array([1.0])]
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+
+    class DummyClient:
+        def generate(self, prompt: str) -> str:
+            return "pong"
+
+    eng = Engine.__new__(Engine)
+    eng.mem = Memory(tmp_path / "mem.db")
+    eng.client = DummyClient()
+
+    answer = eng.chat("ping")
+    assert answer == "pong"
+
+    with sqlite3.connect(tmp_path / "mem.db") as con:
+        rows = con.execute("SELECT kind,text FROM items ORDER BY id").fetchall()
+
+    assert rows == [("chat_user", "ping"), ("chat_ai", "pong")]


### PR DESCRIPTION
## Summary
- track user prompts and AI answers in memory using distinct kinds (`chat_user` and `chat_ai`)
- add regression test ensuring chat history stores both kinds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7230de348320bc5d079d11aa7f89