### PR TITLE
Add __main__ entry point to scaffolded CLI

### DIFF
--- a/app/tools/scaffold.py
+++ b/app/tools/scaffold.py
@@ -19,6 +19,9 @@ def create_python_cli(name: str, base: Path):
             args = p.parse_args()
             if args.ping:
                 print("pong")
+
+        if __name__ == "__main__":
+            main()
     """
         ),
         encoding="utf-8",
@@ -47,16 +50,15 @@ def create_python_cli(name: str, base: Path):
     (proj / "tests/test_cli.py").write_text(
         textwrap.dedent(
             f"""\
-        import sys, pathlib, importlib
+        import sys, pathlib, runpy
 
         sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 
         def test_ping(capsys):
-            cli = importlib.import_module("{name}.cli")
             argv = sys.argv
             sys.argv = ["{name}", "--ping"]
             try:
-                cli.main()
+                runpy.run_module("{name}.cli", run_name="__main__")
             finally:
                 sys.argv = argv
             assert capsys.readouterr().out.strip() == "pong"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+import runpy
+import sys
+from pathlib import Path
+
+from app.tools.scaffold import create_python_cli
+
+
+def test_create_python_cli(tmp_path, capsys):
+    proj_dir = Path(create_python_cli("foo", tmp_path))
+    sys.path.insert(0, str(proj_dir))
+    argv = sys.argv
+    sys.argv = ["foo", "--ping"]
+    try:
+        runpy.run_module("foo.cli", run_name="__main__")
+    finally:
+        sys.argv = argv
+        sys.path.pop(0)
+    assert capsys.readouterr().out.strip() == "pong"


### PR DESCRIPTION
## Summary
- ensure scaffolded CLI modules can be run directly by adding an `if __name__ == "__main__"` block
- update scaffolded CLI tests to execute via runpy
- add regression test exercising the scaffolded CLI entry point

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb72359e488320a86f966449ad7a2d