### PR TITLE
Ensure engine chat tests import numpy and sqlite3

### DIFF
--- a/tests/test_engine_chat.py
+++ b/tests/test_engine_chat.py
@@ -1,5 +1,5 @@
+import numpy as np
 import sqlite3
-import numpy as np  # type: ignore
 
 from app.core.memory import Memory
 from app.core.engine import Engine


### PR DESCRIPTION
## Summary
- Reorder test imports so numpy and sqlite3 are explicitly imported first

## Testing
- `pytest tests/test_engine_chat.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7d34c2b48320af97720094c67dd6