### PR TITLE
Add configurable fallback phrase and log errors in LLM client

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,3 +4,8 @@ from app.llm.client import Client
 def test_client_fallback_echo() -> None:
     client = Client()
     assert client.generate("salut") == "Echo: salut"
+
+
+def test_client_custom_fallback() -> None:
+    client = Client(fallback_phrase="Offline")
+    assert client.generate("hi") == "Offline: hi"


### PR DESCRIPTION
## Summary
- capture generation errors and include message in log
- make fallback phrase configurable instead of fixed "Echo"
- test custom fallback phrase behaviour

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb7eebec14832097c0b8c8a2b8392b