### PR TITLE
feat: protect project scaffold from overwrite

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@ import runpy  # ensure CLI module runs without NameError
 import sys
 from pathlib import Path
 
+import pytest
+
 from app.tools.scaffold import create_python_cli
 
 
@@ -16,3 +18,12 @@ def test_create_python_cli(tmp_path, capsys):
         sys.argv = argv
         sys.path.pop(0)
     assert capsys.readouterr().out.strip() == "pong"
+
+
+def test_create_python_cli_refuses_overwrite(tmp_path):
+    proj_dir = tmp_path / "app" / "projects" / "foo"
+    proj_dir.mkdir(parents=True)
+    (proj_dir / "existing.txt").write_text("content", encoding="utf-8")
+
+    with pytest.raises(FileExistsError):
+        create_python_cli("foo", tmp_path)


### PR DESCRIPTION
## Summary
- ask for confirmation before overwriting existing scaffolded project
- add tests to ensure scaffolder refuses to overwrite

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7eeccecc8320b060786e5c87d614