### PR TITLE
Use absolute dataset path in autograder

### DIFF
--- a/app/core/autograder.py
+++ b/app/core/autograder.py
@@ -3,7 +3,7 @@ import subprocess
 import time
 
 
-DATASETS = pathlib.Path("datasets/python")
+DATASETS = pathlib.Path(__file__).resolve().parents[2] / "datasets" / "python"
 
 
 def _run_pytest(task_dir: pathlib.Path, timeout: int = 60) -> dict:


### PR DESCRIPTION
## Summary
- Make autograder dataset path absolute so it works regardless of CWD

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb80642e408320a28e2c232d2ec7d2