### PR TITLE
Log maintenance failures

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import json
+import logging
 from threading import Thread
 import tomllib
 
@@ -107,11 +108,11 @@ class Engine:
         try:
             self.run_quality_gate()
         except Exception:  # pragma: no cover - best effort
-            pass
+            logging.exception("run_quality_gate failed")
         try:
             self.auto_improve()
         except Exception:  # pragma: no cover - best effort
-            pass
+            logging.exception("auto_improve failed")
 
     def run_quality_gate(self) -> str:
         """Run static checks and tests, storing the result in memory."""


### PR DESCRIPTION
## Summary
- add `logging` import in engine to support error logging
- log exceptions in `perform_maintenance` instead of silently ignoring them

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb80658af88320b8f972fd54393bbb