### PR TITLE
Handle missing commands in evaluator

### DIFF
--- a/app/core/evaluator.py
+++ b/app/core/evaluator.py
@@ -31,5 +31,7 @@ class QualityGate:
                 "out": p.stdout[-4000:],
                 "err": p.stderr[-4000:],
             }
+        except FileNotFoundError as e:
+            return {"ok": False, "err": f"{args[0]} introuvable: {e}", "out": ""}
         except Exception as e:  # pragma: no cover - defensive
             return {"ok": False, "err": str(e), "out": ""}


### PR DESCRIPTION
## Summary
- handle missing commands in `QualityGate._cmd` by returning a clear error message for `FileNotFoundError`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb8066b4f48320a7760cd9bf540a3c