### PR TITLE
chore: remove BOM from prompt markdown files

### DIFF
--- a/app/llm/prompts/clarify.md
+++ b/app/llm/prompts/clarify.md
@@ -1,2 +1,2 @@
-﻿- Définir objectif, I/O, plateformes, contraintes, licence, livrables, critère succès.
+- Définir objectif, I/O, plateformes, contraintes, licence, livrables, critère succès.
 - Tant que ces points ne sont pas définis, bloquer l'implémentation.

--- a/app/llm/prompts/reviewer.md
+++ b/app/llm/prompts/reviewer.md
@@ -1,1 +1,1 @@
-﻿- Checklist: lisibilité, complexité, performances, sécurité, erreurs, logs, tests, docs.
+- Checklist: lisibilité, complexité, performances, sécurité, erreurs, logs, tests, docs.

--- a/app/llm/prompts/security.md
+++ b/app/llm/prompts/security.md
@@ -1,1 +1,1 @@
-﻿- Interdire secrets en clair. Bandit+Semgrep obligatoires. Écriture confinée au workspace.
+- Interdire secrets en clair. Bandit+Semgrep obligatoires. Écriture confinée au workspace.


### PR DESCRIPTION
## Summary
- remove byte-order marks from clarify, reviewer, and security prompt templates

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb81f881d48320a84bc9ce05d8c8c1