### PR TITLE
feat: allow configuring embedding host

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -25,6 +25,7 @@ ab_candidates = 2
 [memory]
 embed_backend = "ollama"
 embed_model = "nomic-embed-text"
+embed_host = "127.0.0.1:11434"
 top_k = 8
 db_path = "memory/mem.db"
 

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -6,8 +6,38 @@ def test_embed_ollama_connection_error(monkeypatch):
         raise OSError("fail")
 
     monkeypatch.setattr("http.client.HTTPConnection", bad_conn)
-    vecs = embed_ollama(["hello"])
+    vecs = embed_ollama(["hello"], host="1.2.3.4:5678")
     assert len(vecs) == 1
     assert len(vecs[0]) == 1
     assert vecs[0].shape == (1,)
     assert vecs[0][0] == 0.0
+
+
+def test_embed_ollama_host_argument(monkeypatch):
+    called = {}
+
+    def bad_conn(host, port, *args, **kwargs):
+        called["host"] = host
+        called["port"] = port
+        raise OSError("fail")
+
+    monkeypatch.setattr("http.client.HTTPConnection", bad_conn)
+    embed_ollama(["hi"], host="example.com:1234")
+    assert called == {"host": "example.com", "port": 1234}
+
+
+def test_embed_ollama_host_from_config(monkeypatch):
+    def fake_load(fh):
+        return {"memory": {"embed_host": "confighost:4242"}}
+
+    called = {}
+
+    def bad_conn(host, port, *args, **kwargs):
+        called["host"] = host
+        called["port"] = port
+        raise OSError("fail")
+
+    monkeypatch.setattr("app.tools.embeddings.tomllib.load", fake_load)
+    monkeypatch.setattr("http.client.HTTPConnection", bad_conn)
+    embed_ollama(["hi"])
+    assert called == {"host": "confighost", "port": 4242}


### PR DESCRIPTION
## Summary
- make `embed_ollama` accept host/port and read defaults from settings
- wire host settings through HTTPConnection
- test embedding host configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb81fdbcf48320866795aa732a4368