### PR TITLE
Use centralized configuration loader

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import json
 import logging
 from threading import Thread
-import tomllib
+
+from config import load_config
 
 from app.core import autograder as AG
 from app.core.benchmark import Bench
@@ -22,12 +23,7 @@ class Engine:
     def __init__(self, perform_maintenance: bool = False) -> None:
         self.base = Path(__file__).resolve().parents[2]
 
-        try:
-            cfg_path = self.base / "config" / "settings.toml"
-            with cfg_path.open("rb") as fh:
-                cfg = tomllib.load(fh).get("memory", {})
-        except Exception:
-            cfg = {}
+        cfg = load_config().get("memory", {})
 
         db_path = cfg.get("db_path", "memory/mem.db")
         path = Path(db_path)

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 import http.client
 import json
 import logging
-from pathlib import Path
 from urllib.parse import urlparse
 
-import tomllib
+from config import load_config
 
 
 def generate_ollama(prompt: str, *, host: str, model: str) -> str:
@@ -69,12 +68,7 @@ class Client:
         *,
         fallback_phrase: str = "Echo",
     ) -> None:
-        try:
-            cfg_path = Path(__file__).resolve().parents[2] / "config" / "settings.toml"
-            with cfg_path.open("rb") as fh:
-                cfg = tomllib.load(fh).get("llm", {})
-        except Exception:
-            cfg = {}
+        cfg = load_config().get("llm", {})
 
         if model is not None:
             cfg["model"] = model

--- a/app/tools/embeddings.py
+++ b/app/tools/embeddings.py
@@ -7,11 +7,11 @@ disables vector search but allows the application to continue running.
 
 import http.client
 import json
-from pathlib import Path
 from urllib.parse import urlparse
 
 import numpy as np
-import tomllib
+
+from config import load_config
 
 
 def embed_ollama(
@@ -40,12 +40,7 @@ def embed_ollama(
         reached, a list of zero vectors of shape ``(1,)`` is returned instead.
     """
 
-    try:
-        cfg_path = Path(__file__).resolve().parents[2] / "config" / "settings.toml"
-        with cfg_path.open("rb") as fh:
-            cfg = tomllib.load(fh).get("memory", {})
-    except Exception:
-        cfg = {}
+    cfg = load_config().get("memory", {})
 
     if model is not None:
         cfg["embed_model"] = model

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+import tomllib
+
+
+@lru_cache(maxsize=1)
+def load_config() -> dict:
+    """Load configuration from ``settings.toml``.
+
+    Returns
+    -------
+    dict
+        Parsed configuration dictionary. If the file cannot be read an empty
+        dictionary is returned.
+    """
+    cfg_path = Path(__file__).resolve().parent / "settings.toml"
+    try:
+        with cfg_path.open("rb") as fh:
+            return tomllib.load(fh)
+    except Exception:
+        return {}

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -38,3 +38,13 @@ focus_languages = ["python","node","cpp","powershell"]
 prefer_ab_testing = true
 reward_weights = { tests = 0.5, perf = 0.2, quality = 0.2, security = 0.1 }
 stagnation_patience = 2
+
+[data]
+path = "data"
+
+[training]
+epochs = 10
+batch_size = 32
+
+[model]
+name = "default"

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -27,7 +27,7 @@ def test_embed_ollama_host_argument(monkeypatch):
 
 
 def test_embed_ollama_host_from_config(monkeypatch):
-    def fake_load(fh):
+    def fake_config():
         return {"memory": {"embed_host": "confighost:4242"}}
 
     called = {}
@@ -37,7 +37,7 @@ def test_embed_ollama_host_from_config(monkeypatch):
         called["port"] = port
         raise OSError("fail")
 
-    monkeypatch.setattr("app.tools.embeddings.tomllib.load", fake_load)
+    monkeypatch.setattr("app.tools.embeddings.load_config", fake_config)
     monkeypatch.setattr("http.client.HTTPConnection", bad_conn)
     embed_ollama(["hi"])
     assert called == {"host": "confighost", "port": 4242}


### PR DESCRIPTION
## Summary
- add `config.load_config` helper for reading `settings.toml`
- define new `[data]`, `[training]` and `[model]` sections in configuration
- update engine, LLM client and embeddings utilities to use `load_config`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb868118448320ba3057fc9095854f