### PR TITLE
test: add pipeline and config tests

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import tomllib
+
+
+def load_config(section: str | None = None) -> dict[str, Any]:
+    """Load configuration from ``config/settings.toml``.
+
+    Args:
+        section: Optional top-level section name. When provided only that
+            section is returned. If the section does not exist an empty
+            dictionary is returned. When omitted the whole configuration is
+            returned.
+    """
+    cfg_path = Path(__file__).resolve().parents[1] / "config" / "settings.toml"
+    with cfg_path.open("rb") as fh:
+        data = tomllib.load(fh)
+    if section is None:
+        return data
+    return data.get(section, {})

--- a/app/core/pipeline.py
+++ b/app/core/pipeline.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, List
+
+
+def load_raw_data(path: str | Path) -> list[str]:
+    """Read *path* and return non-empty stripped lines."""
+    p = Path(path)
+    text = p.read_text(encoding="utf-8").splitlines()
+    return [line.strip() for line in text if line.strip()]
+
+
+def transform_data(lines: Iterable[str]) -> list[int]:
+    """Convert an iterable of text lines into integers."""
+    result: List[int] = []
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        result.append(int(line))
+    return result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,11 @@
+from app.config import load_config
+
+
+def test_load_existing_section():
+    cfg = load_config("llm")
+    assert cfg["model"] == "llama3.2:3b"
+    assert cfg["backend"] == "ollama"
+
+
+def test_load_missing_section():
+    assert load_config("does_not_exist") == {}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,14 @@
+from app.core.pipeline import load_raw_data, transform_data
+
+
+def test_load_raw_data(tmp_path):
+    file = tmp_path / "numbers.txt"
+    file.write_text("1\n2\n\n3\n", encoding="utf-8")
+    assert load_raw_data(file) == ["1", "2", "3"]
+
+
+def test_transform_data(tmp_path):
+    file = tmp_path / "numbers.txt"
+    file.write_text("1\n2\n3\n", encoding="utf-8")
+    raw = load_raw_data(file)
+    assert transform_data(raw) == [1, 2, 3]


### PR DESCRIPTION
## Summary
- add simple data pipeline functions and tests
- add config loader with section support and tests

## Testing
- `ruff check .`
- `black --check .` *(fails: app/tools/scaffold.py would be reformatted)*
- `mypy .`
- `bandit -q -r .` *(fails: command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8682c4a88320b5b0612f9b036291