### PR TITLE
docs: add ethics and traceability guidelines

### DIFF
--- a/ETHICS.md
+++ b/ETHICS.md
@@ -1,0 +1,18 @@
+# Principes éthiques
+
+Watcher vise à offrir un atelier local d'IA respectant la confidentialité des données et la transparence des opérations.
+
+## Principes
+- **Transparence** : les actions sont journalisées et les décisions importantes conservées pour audit.
+- **Souveraineté des données** : aucun envoi réseau n'est effectué; les informations restent sur l'environnement local.
+- **Responsabilité** : l'utilisateur conserve le contrôle et doit valider les résultats produits.
+
+## Limites
+- Les modèles sous-jacents peuvent générer des réponses erronées ou biaisées.
+- Les journaux et la mémoire peuvent contenir des données sensibles; leur gestion incombe à l'utilisateur.
+- Le système ne réalise pas de modération de contenu avancée.
+
+## Traçabilité
+- Journalisation via le module `logging` standard de Python.
+- Stockage persistant des décisions dans une base SQLite gérée par `app/core/memory.py`.
+

--- a/README.md
+++ b/README.md
@@ -51,3 +51,11 @@ pytest -q
 Sandbox d'exécution confinée, tests et linters obligatoires avant adoption de code.
 Semgrep utilise un fichier de règles local (`config/semgrep.yml`), aucun accès réseau requis.
 
+## Éthique et traçabilité
+
+Les actions du système sont journalisées via le module standard `logging`. Les erreurs et décisions importantes sont ainsi consignées pour audit ou débogage.
+
+Les contenus générés peuvent être conservés dans une base SQLite par le composant de mémoire (`app/core/memory.py`). Cette base stocke textes et métadonnées afin d'offrir un historique local des opérations.
+
+Pour un aperçu détaillé des principes éthiques et des limites d'utilisation, consultez [ETHICS.md](ETHICS.md).
+


### PR DESCRIPTION
## Summary
- document logging and memory mechanisms for traceability
- add ETHICS.md outlining ethical principles and system limits

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat app/tools/scaffold.py)*
- `mypy .`
- `bandit -q -r .` *(missing: bandit not installed)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(missing: semgrep not installed)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8685754c832081f2437a78db3c38