### PR TITLE
feat: validate prompts before generating

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -13,7 +13,7 @@ from app.core.evaluator import QualityGate
 from app.core.memory import Memory
 from app.core.planner import Planner
 from app.core.learner import Learner
-from app.llm.client import Client
+from app.llm.client import Client, validate_prompt
 from app.tools.scaffold import create_python_cli
 from app.data import pipeline
 
@@ -78,6 +78,7 @@ class Engine:
 
     def chat(self, prompt: str) -> str:
         """Generate a response to *prompt* using the LLM client."""
+        prompt = validate_prompt(prompt)
         # Store the user prompt and the assistant answer using distinct
         # memory kinds so analytics can differentiate between them.
         self.mem.add("chat_user", prompt)

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -10,6 +10,18 @@ from urllib.parse import urlparse
 from config import load_config
 
 
+def validate_prompt(prompt: str) -> str:
+    """Return a sanitized version of *prompt*.
+
+    Leading and trailing whitespace is stripped and an empty prompt raises a
+    ``ValueError``.
+    """
+    prompt = prompt.strip()
+    if not prompt:
+        raise ValueError("prompt must not be empty")
+    return prompt
+
+
 def generate_ollama(prompt: str, *, host: str, model: str) -> str:
     """Send *prompt* to an Ollama server.
 


### PR DESCRIPTION
## Summary
- sanitize prompts before generation
- validate prompts in Engine.chat before storing and sending to LLM

## Testing
- `ruff check .`
- `black --check .`
- `mypy .` *(fails: Library stubs not installed for "yaml")*
- `bandit -q -r .` *(command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb89666004832090689ad3c5fb8752