### PR TITLE
Improve prompt validation typing

### DIFF
--- a/app/core/validation.py
+++ b/app/core/validation.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+
+def validate_prompt(prompt: Any) -> str:
+    """Validate that the given prompt is a non-empty string.
+
+    Parameters
+    ----------
+    prompt: Any
+        The user provided prompt to validate.
+
+    Returns
+    -------
+    str
+        The original prompt if it is valid.
+
+    Raises
+    ------
+    TypeError
+        If *prompt* is not an instance of :class:`str`.
+    ValueError
+        If the prompt is empty or consists solely of whitespace.
+    """
+    if not isinstance(prompt, str):
+        raise TypeError("Prompt must be a string")
+    if not prompt.strip():
+        raise ValueError("Prompt cannot be empty")
+    return prompt

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,17 @@
+import pytest
+
+from app.core.validation import validate_prompt
+
+
+def test_validate_prompt_valid() -> None:
+    assert validate_prompt("Hello") == "Hello"
+
+
+def test_validate_prompt_empty() -> None:
+    with pytest.raises(ValueError):
+        validate_prompt("")
+
+
+def test_validate_prompt_type() -> None:
+    with pytest.raises(TypeError):
+        validate_prompt(123)


### PR DESCRIPTION
## Summary
- add `validate_prompt` helper that validates any input
- expand tests for prompt validation

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb89682f948320a4f3901c5d13de55