### PR TITLE
feat(engine): augment chat with memory context

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -81,6 +81,14 @@ class Engine:
         # Store the user prompt and the assistant answer using distinct
         # memory kinds so analytics can differentiate between them.
         self.mem.add("chat_user", prompt)
+
+        # Retrieve texts most similar to the prompt from memory.
+        excerpts = [text for _score, _id, _kind, text in self.mem.search(prompt)]
+
+        # Combine the original prompt with retrieved excerpts before sending to the LLM.
+        if excerpts:
+            prompt = "\n\n".join([prompt, "\n".join(excerpts)])
+
         answer = self.client.generate(prompt)
         self.mem.add("chat_ai", answer)
         return answer


### PR DESCRIPTION
## Summary
- include relevant memory excerpts when generating chat responses
- test chat includes retrieved context in LLM prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb893481488320b4e1ad7132b0dfeb