### PR TITLE
Add response critic and retry logic to chat engine

### DIFF
--- a/app/core/critic.py
+++ b/app/core/critic.py
@@ -1,0 +1,16 @@
+"""Simple critic module evaluating LLM responses."""
+
+from __future__ import annotations
+
+
+def review(prompt: str, answer: str) -> float:
+    """Return a naive quality score for *answer* given *prompt*.
+
+    The current implementation is intentionally lightweight: it merely checks
+    that the answer is non-empty and returns a float in the ``[0, 1]`` range.
+    A real implementation could hook into an LLM-based evaluator or any other
+    heuristic.  This function is easily monkeypatched in tests to emulate
+    various critic behaviours.
+    """
+
+    return 1.0 if answer.strip() else 0.0

--- a/tests/test_critic.py
+++ b/tests/test_critic.py
@@ -1,0 +1,61 @@
+import numpy as np
+
+from app.core.engine import Engine
+from app.core.memory import Memory
+
+
+def test_chat_retries_on_low_score(tmp_path, monkeypatch):
+    """Engine.chat should retry generation when critic gives low score."""
+
+    # Avoid heavy embedding calls
+    monkeypatch.setattr("app.core.memory.embed_ollama", lambda texts, model="": [np.array([1.0])])
+
+    # Track generate calls and provide different answers per attempt
+    calls = {"count": 0}
+
+    class DummyClient:
+        def generate(self, prompt: str) -> str:
+            calls["count"] += 1
+            return "bad" if calls["count"] == 1 else "good"
+
+    # Critic returns low then high score
+    def fake_review(prompt, answer):
+        return 0.0 if answer == "bad" else 1.0
+
+    monkeypatch.setattr("app.core.critic.review", fake_review)
+
+    eng = Engine.__new__(Engine)
+    eng.mem = Memory(tmp_path / "mem.db")
+    eng.client = DummyClient()
+
+    ans = eng.chat("ping", threshold=0.5)
+
+    assert ans == "good"
+    assert calls["count"] == 2
+
+
+def test_chat_accepts_high_score(tmp_path, monkeypatch):
+    """When critic approves, only one generation should occur."""
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", lambda texts, model="": [np.array([1.0])])
+
+    calls = {"count": 0}
+
+    class DummyClient:
+        def generate(self, prompt: str) -> str:
+            calls["count"] += 1
+            return "fine"
+
+    def fake_review(prompt, answer):
+        return 1.0
+
+    monkeypatch.setattr("app.core.critic.review", fake_review)
+
+    eng = Engine.__new__(Engine)
+    eng.mem = Memory(tmp_path / "mem.db")
+    eng.client = DummyClient()
+
+    ans = eng.chat("ping")
+
+    assert ans == "fine"
+    assert calls["count"] == 1


### PR DESCRIPTION
## Summary
- add `critic.review` to score LLM answers
- retry chat generation if critic score below threshold
- cover critic flow with tests

## Testing
- `pytest tests/test_critic.py -q`
- `pytest tests/test_engine_chat.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb893605fc8320aab6c4f31c42469e