### PR TITLE
Add feedback rating and integrate into auto improvement

### DIFF
--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -52,6 +52,12 @@ class WatcherApp(ttk.Frame):
         self.inp.pack(side="left", fill="both", expand=True)
         self.send_btn = ttk.Button(bottom, text="Envoyer", command=self._send)
         self.send_btn.pack(side="left", padx=8)
+        ttk.Label(bottom, text="Note").pack(side="left")
+        self.rate_var = tk.IntVar(value=0)
+        tk.Spinbox(bottom, from_=0, to=5, textvariable=self.rate_var, width=3).pack(
+            side="left", padx=4
+        )
+        ttk.Button(bottom, text="Noter", command=self._rate).pack(side="left")
         self.status = ttk.Label(
             self,
             text="Mode: Sur | Backend: ollama | Modèle: llama3.2:3b",
@@ -133,6 +139,12 @@ class WatcherApp(ttk.Frame):
     def _improve(self) -> None:
         self._run_async(self.engine.auto_improve, "Improve")
 
+    def _rate(self) -> None:
+        score = self.rate_var.get()
+        msg = self.engine.add_feedback(score)
+        self.out.insert("end", f"\n[Feedback] {msg}\n")
+        self.out.see("end")
+
 
 if __name__ == "__main__":
     if not os.environ.get("DISPLAY"):
@@ -155,6 +167,14 @@ if __name__ == "__main__":
                     q = input("[You] ").strip()
                     if q.lower() in {"exit", "quit"}:
                         break
+                    if q.lower().startswith("rate "):
+                        try:
+                            score = float(q.split()[1])
+                        except (IndexError, ValueError):
+                            print("[Watcher] usage: rate <score>")
+                            continue
+                        print(f"[Watcher] {eng.add_feedback(score)}")
+                        continue
                     if not q:
                         continue
                     ans = eng.chat(q)


### PR DESCRIPTION
## Summary
- store user-rated Q/A pairs in a new feedback table
- allow rating responses from the UI or CLI
- feed accumulated feedback into auto_improve before benchmarking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8936c3188320ba97443368eafa77