### PR TITLE
Add plugin registry and discovery

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -1,9 +1,11 @@
 """Core orchestration engine for the Watcher project."""
 
 from pathlib import Path
+import importlib
 import json
 import logging
 from threading import Thread
+import tomllib
 
 from config import load_config
 
@@ -16,6 +18,7 @@ from app.core.learner import Learner
 from app.llm.client import Client
 from app.tools.scaffold import create_python_cli
 from app.data import pipeline
+from app.tools.plugins import Plugin
 
 
 class Engine:
@@ -37,6 +40,8 @@ class Engine:
         self.learner = Learner(self.bench, self.base / "data")
         self.planner = Planner()
         self.client = Client()
+        self.plugins: list[Plugin] = []
+        self._load_plugins()
         self.start_msg = self._bootstrap()
         if perform_maintenance:
             Thread(target=self.perform_maintenance, daemon=True).start()
@@ -139,3 +144,42 @@ class Engine:
         b = comp["B"]
         keep = comp["best"]["name"]
         return f"train_ok={rep.get('ok', False)} A={a:.3f} B={b:.3f} keep={keep}"
+
+    # ------------------------------------------------------------------
+    # Plugin related helpers
+
+    def _load_plugins(self) -> None:
+        """Load plugins defined in ``plugins.toml``.
+
+        Each entry in the file should look like::
+
+            [[plugins]]
+            path = "package.module:ClassName"
+
+        Loading errors are logged but otherwise ignored.
+        """
+
+        cfg = self.base / "plugins.toml"
+        if not cfg.exists():
+            return
+        try:
+            data = tomllib.loads(cfg.read_text(encoding="utf-8"))
+        except Exception:  # pragma: no cover - best effort
+            logging.exception("Invalid plugins.toml")
+            return
+        for item in data.get("plugins", []):
+            path = item.get("path")
+            if not path:
+                continue
+            module_name, _, class_name = path.partition(":")
+            try:
+                module = importlib.import_module(module_name)
+                cls = getattr(module, class_name)
+                plugin: Plugin = cls()
+                self.plugins.append(plugin)
+            except Exception:  # pragma: no cover - best effort
+                logging.exception("Failed to load plugin %s", path)
+
+    def run_plugins(self) -> list[str]:
+        """Execute all loaded plugins and return their outputs."""
+        return [p.run() for p in self.plugins]

--- a/app/tools/plugins/__init__.py
+++ b/app/tools/plugins/__init__.py
@@ -1,0 +1,12 @@
+"""Plugin protocol and discovery helpers."""
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class Plugin(Protocol):
+    """Simple plugin interface."""
+
+    def run(self) -> str:  # pragma: no cover - interface definition
+        """Execute the plugin and return a human readable message."""
+        ...

--- a/app/tools/plugins/hello.py
+++ b/app/tools/plugins/hello.py
@@ -1,0 +1,7 @@
+"""Demonstration Hello plugin."""
+
+class HelloPlugin:
+    """Plugin de démonstration qui retourne un message de salutation."""
+
+    def run(self) -> str:
+        return "Hello from plugin"

--- a/plugins.toml
+++ b/plugins.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+path = "app.tools.plugins.hello:HelloPlugin"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,8 @@
+from app.core.engine import Engine
+from app.tools.plugins.hello import HelloPlugin
+
+
+def test_hello_plugin_loaded_and_runs():
+    engine = Engine()
+    assert any(isinstance(p, HelloPlugin) for p in engine.plugins)
+    assert "Hello from plugin" in engine.run_plugins()


### PR DESCRIPTION
## Summary
- define a simple `Plugin` protocol for tools
- add plugin registry and TOML based discovery to Engine
- provide HelloPlugin example and unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8937bcc883209b627f0cea7c0328