### PR TITLE
feat: learn from rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ dvc pull
 - `datasets/` : jeux d'entraînement Python (`fib`, `fizzbuzz`, `is_prime`).
 - `config/` : paramètres et règles de sécurité (`semgrep`).
 
+## Auto-amélioration
+
+Le module `Learner` met à jour une politique très simple qui décide quel
+"prompt" utiliser lors des expériences. Après chaque cycle de formation,
+`auto_improve` exécute un A/B test, calcule une récompense à partir du
+`QualityGate` ou d'un éventuel retour utilisateur puis appelle
+`update_policy(reward, context)` pour privilégier les variantes les plus
+performantes.
+
 ## Sécurité
 
 Sandbox d'exécution confinée, tests et linters obligatoires avant adoption de code.

--- a/app/core/learner.py
+++ b/app/core/learner.py
@@ -1,4 +1,10 @@
-"""Persistent benchmark-based learner for simple self-improvement."""
+"""Persistent learner with a tiny reinforcement policy.
+
+This module persists benchmark results and maintains a very small policy used
+to pick between prompt variants.  After every training iteration the learner
+receives a reward signal allowing it to favour prompts that historically led
+to higher quality outputs.
+"""
 
 from __future__ import annotations
 
@@ -14,6 +20,7 @@ class Learner:
     def __init__(self, bench: Bench, data_dir: Path) -> None:
         self.bench = bench
         self.file = data_dir / "best_variant.json"
+        self.policy_file = data_dir / "policy.json"
         self.file.parent.mkdir(parents=True, exist_ok=True)
 
     def compare(self, a: str, b: str) -> dict:
@@ -27,6 +34,39 @@ class Learner:
             self._save_best(best)
         return {"A": score_a, "B": score_b, "best": best}
 
+    def update_policy(self, reward: float, context: dict | None = None) -> str:
+        """Update the internal policy using a simple reinforcement rule.
+
+        Args:
+            reward: Feedback signal in ``[−inf, +inf]``.  Positive values
+                encourage the variant used in ``context``.
+            context: Optional metadata such as ``{"prompt": "A"}`` indicating
+                which variant produced the reward.
+
+        Returns:
+            The name of the currently preferred prompt variant.
+        """
+
+        policy = self._load_policy()
+        ctx = context or {}
+        variant = (
+            ctx.get("prompt") or ctx.get("variant") or policy.get("current_prompt", "A")
+        )
+
+        stats = policy.setdefault("stats", {})
+        stat = stats.setdefault(variant, {"reward": 0.0, "count": 0})
+        stat["reward"] += float(reward)
+        stat["count"] += 1
+
+        # Choose variant with highest average reward
+        best = max(
+            stats.items(),
+            key=lambda kv: kv[1]["reward"] / max(1, kv[1]["count"]),
+        )[0]
+        policy["current_prompt"] = best
+        self._save_policy(policy)
+        return best
+
     def _load_best(self) -> dict | None:
         if self.file.exists():
             try:
@@ -37,3 +77,14 @@ class Learner:
 
     def _save_best(self, best: dict) -> None:
         self.file.write_text(json.dumps(best), encoding="utf-8")
+
+    def _load_policy(self) -> dict:
+        if self.policy_file.exists():
+            try:
+                return json.loads(self.policy_file.read_text(encoding="utf-8"))
+            except Exception:  # pragma: no cover - defensive
+                pass
+        return {"current_prompt": "A", "stats": {}}
+
+    def _save_policy(self, policy: dict) -> None:
+        self.policy_file.write_text(json.dumps(policy), encoding="utf-8")

--- a/tests/test_learner_rl.py
+++ b/tests/test_learner_rl.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import json
+
+from app.core.learner import Learner
+from app.core.benchmark import Bench
+
+
+def test_policy_updates_with_reward(tmp_path: Path) -> None:
+    bench = Bench()
+    learner = Learner(bench, tmp_path)
+
+    # Give low rewards to prompt A
+    for _ in range(3):
+        learner.update_policy(0.1, {"prompt": "A"})
+
+    # Give higher rewards to prompt B
+    for _ in range(3):
+        learner.update_policy(1.0, {"prompt": "B"})
+
+    policy = json.loads((tmp_path / "policy.json").read_text())
+    assert policy["current_prompt"] == "B"


### PR DESCRIPTION
## Summary
- add reinforcement-style `update_policy` to learner with persistence
- compute quality-based reward in `auto_improve` and update policy
- document auto-improvement workflow and test policy adaptation

## Testing
- `ruff check app/core/learner.py app/core/engine.py tests/test_learner_rl.py`
- `black --check app/core/learner.py app/core/engine.py tests/test_learner_rl.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb89389ba483209e7a6143bb6282fc