### PR TITLE
Improve dataset validation error handling

### DIFF
--- a/app/data/validation.py
+++ b/app/data/validation.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Utilities for validating dataset structure."""
+
+from pathlib import Path
+
+
+def validate_dataset(path: str | Path) -> Path:
+    """Validate that *path* points to a dataset directory.
+
+    A valid dataset directory must contain ``src`` and ``tests`` directories
+    as well as a ``meta.json`` file. The function returns the resolved path to
+    the dataset when validation succeeds.
+
+    Parameters
+    ----------
+    path:
+        The path to the dataset directory.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the dataset path, ``src`` or ``tests`` directories, or ``meta.json``
+        file does not exist. The raised error message includes the offending
+        path.
+    NotADirectoryError
+        If *path* exists but is not a directory.
+    """
+
+    dataset_path = Path(path)
+    if not dataset_path.exists():
+        raise FileNotFoundError(f"Dataset path does not exist: {dataset_path}")
+    if not dataset_path.is_dir():
+        raise NotADirectoryError(f"Dataset path is not a directory: {dataset_path}")
+
+    src_dir = dataset_path / "src"
+    if not src_dir.is_dir():
+        raise FileNotFoundError(f"Missing src directory: {src_dir}")
+
+    tests_dir = dataset_path / "tests"
+    if not tests_dir.is_dir():
+        raise FileNotFoundError(f"Missing tests directory: {tests_dir}")
+
+    meta_file = dataset_path / "meta.json"
+    if not meta_file.is_file():
+        raise FileNotFoundError(f"Missing meta.json file: {meta_file}")
+
+    return dataset_path.resolve()

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.core.validation import validate_prompt
+from app.data.validation import validate_dataset
 
 
 def test_validate_prompt_valid() -> None:
@@ -15,3 +16,59 @@ def test_validate_prompt_empty() -> None:
 def test_validate_prompt_type() -> None:
     with pytest.raises(TypeError):
         validate_prompt(123)
+
+
+# ---------------------------------------------------------------------------
+# Dataset validation tests
+# ---------------------------------------------------------------------------
+
+def _make_dataset(
+    tmp_path,
+    *,
+    include_src: bool = True,
+    include_tests: bool = True,
+    include_meta: bool = True,
+):
+    ds = tmp_path / "task"
+    ds.mkdir()
+    if include_src:
+        (ds / "src").mkdir()
+    if include_tests:
+        (ds / "tests").mkdir()
+    if include_meta:
+        (ds / "meta.json").write_text("{}", encoding="utf-8")
+    return ds
+
+
+def test_validate_dataset_missing_path(tmp_path) -> None:
+    missing = tmp_path / "missing"
+    with pytest.raises(FileNotFoundError):
+        validate_dataset(missing)
+
+
+def test_validate_dataset_not_directory(tmp_path) -> None:
+    file_path = tmp_path / "file"
+    file_path.write_text("hi", encoding="utf-8")
+    with pytest.raises(NotADirectoryError):
+        validate_dataset(file_path)
+
+
+def test_validate_dataset_missing_src(tmp_path) -> None:
+    ds = _make_dataset(tmp_path, include_src=False)
+    with pytest.raises(FileNotFoundError) as exc:
+        validate_dataset(ds)
+    assert str(ds / "src") in str(exc.value)
+
+
+def test_validate_dataset_missing_tests(tmp_path) -> None:
+    ds = _make_dataset(tmp_path, include_tests=False)
+    with pytest.raises(FileNotFoundError) as exc:
+        validate_dataset(ds)
+    assert str(ds / "tests") in str(exc.value)
+
+
+def test_validate_dataset_missing_meta(tmp_path) -> None:
+    ds = _make_dataset(tmp_path, include_meta=False)
+    with pytest.raises(FileNotFoundError) as exc:
+        validate_dataset(ds)
+    assert str(ds / "meta.json") in str(exc.value)


### PR DESCRIPTION
## Summary
- add dataset validator that raises specific errors for missing folders and metadata
- cover dataset validation with tests for FileNotFoundError and NotADirectoryError

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8c45d9348320a61d6434d08f6cf6