### PR TITLE
Validate meta.json schema and add tests

### DIFF
--- a/app/data/validation.py
+++ b/app/data/validation.py
@@ -1,0 +1,49 @@
+"""Utilities for validating dataset metadata."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import json
+from typing import Any
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+META_FILE = BASE_DIR / "meta.json"
+
+REQUIRED_KEYS = {"name", "version"}
+
+
+def validate_meta(path: Path | str | None = None) -> dict[str, Any]:
+    """Load and validate a ``meta.json`` file.
+
+    Parameters
+    ----------
+    path: Path | str | None, optional
+        Path to the ``meta.json`` file. Defaults to ``BASE_DIR / 'meta.json'``.
+
+    Returns
+    -------
+    dict
+        Parsed JSON content.
+
+    Raises
+    ------
+    FileNotFoundError
+        If the file does not exist.
+    ValueError
+        If the file contains invalid JSON or is missing required keys.
+    """
+    p = Path(path) if path else META_FILE
+    if not p.exists():
+        raise FileNotFoundError(f"meta.json not found at {p}")
+    try:
+        with p.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except json.JSONDecodeError as exc:
+        raise ValueError("meta.json contains invalid JSON") from exc
+
+    missing = REQUIRED_KEYS.difference(data)
+    if missing:
+        raise ValueError(
+            f"meta.json missing required keys: {', '.join(sorted(missing))}"
+        )
+    return data

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,7 @@
 import pytest
 
 from app.core.validation import validate_prompt
+from app.data.validation import validate_meta
 
 
 def test_validate_prompt_valid() -> None:
@@ -15,3 +16,10 @@ def test_validate_prompt_empty() -> None:
 def test_validate_prompt_type() -> None:
     with pytest.raises(TypeError):
         validate_prompt(123)
+
+
+def test_validate_meta_invalid_json(tmp_path) -> None:
+    meta = tmp_path / "meta.json"
+    meta.write_text("{", encoding="utf-8")
+    with pytest.raises(ValueError):
+        validate_meta(meta)


### PR DESCRIPTION
## Summary
- add `validate_meta` helper to check for meta.json existence and required keys
- test `validate_meta` error path with invalid JSON

## Testing
- `pytest tests/test_validation.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb8c475d8c83208a3add7fa081bca3