### PR TITLE
Add dataset path validation and tests

### DIFF
--- a/app/core/validation.py
+++ b/app/core/validation.py
@@ -1,4 +1,5 @@
 from typing import Any
+from pathlib import Path
 
 
 def validate_prompt(prompt: Any) -> str:
@@ -26,3 +27,35 @@ def validate_prompt(prompt: Any) -> str:
     if not prompt.strip():
         raise ValueError("Prompt cannot be empty")
     return prompt
+
+
+def validate_dataset(path: Any) -> Path:
+    """Validate that *path* points to an existing directory.
+
+    Parameters
+    ----------
+    path:
+        Path-like object pointing to the dataset directory to validate.
+
+    Returns
+    -------
+    pathlib.Path
+        The resolved dataset path if it is valid.
+
+    Raises
+    ------
+    TypeError
+        If *path* is not a string or :class:`~pathlib.Path` instance.
+    FileNotFoundError
+        If the provided path does not exist.
+    NotADirectoryError
+        If the path exists but is not a directory.
+    """
+    if not isinstance(path, (str, Path)):
+        raise TypeError("Dataset path must be a string or Path")
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Dataset path does not exist: {p}")
+    if not p.is_dir():
+        raise NotADirectoryError(f"Dataset path is not a directory: {p}")
+    return p

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.core.validation import validate_prompt
+from app.core.validation import validate_prompt, validate_dataset
 
 
 def test_validate_prompt_valid() -> None:
@@ -15,3 +15,9 @@ def test_validate_prompt_empty() -> None:
 def test_validate_prompt_type() -> None:
     with pytest.raises(TypeError):
         validate_prompt(123)
+
+
+def test_validate_dataset_missing(tmp_path) -> None:
+    missing = tmp_path / "does-not-exist"
+    with pytest.raises(FileNotFoundError):
+        validate_dataset(missing)


### PR DESCRIPTION
## Summary
- add `validate_dataset` helper ensuring dataset path exists and is a directory
- cover missing dataset path with new unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8c480d208320aad2a4cd1eeb7ec7