### PR TITLE
Add heuristic critic scoring with adjustable weights

### DIFF
--- a/app/core/critic.py
+++ b/app/core/critic.py
@@ -1,0 +1,76 @@
+"""Simple heuristic critic module.
+
+This module provides a lightweight text evaluation strategy used by the
+Watcher project.  The implementation intentionally avoids external network
+calls so that the test-suite can run in an isolated environment.  The design
+however mirrors how an LLM based critic could be structured by accepting
+weights for different quality criteria and producing a granular score.
+
+The critic exposes a :class:`Critic` class whose :meth:`evaluate` method
+returns both individual sub‑scores and the combined weighted score.  A caller
+can tweak the ``threshold`` and ``weights`` to reflect different quality
+requirements.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class Critic:
+    """Evaluate text quality using simple heuristics.
+
+    Parameters
+    ----------
+    weights:
+        Mapping of criterion name to weighting factor.  The available criteria
+        are ``"length"`` and ``"politeness"``.  Additional criteria can be added
+        later without affecting the public API.
+    threshold:
+        Minimum overall score required for ``passed`` to be ``True``.
+    """
+
+    weights: dict[str, float] = field(
+        default_factory=lambda: {"length": 0.5, "politeness": 0.5}
+    )
+    threshold: float = 0.75
+
+    def evaluate(self, text: str) -> dict[str, float | dict[str, float] | bool]:
+        """Return a granular evaluation of ``text``.
+
+        The evaluation is intentionally simple:
+
+        * ``length`` – proportion of the first 100 words that are populated.
+        * ``politeness`` – ``1.0`` when the text contains polite keywords such
+          as "please" or "thank you", otherwise ``0.0``.
+
+        Returns
+        -------
+        dict
+            A dictionary with ``score`` (weighted total), ``scores`` containing
+            individual criterion scores and ``passed`` which indicates whether
+            the score meets the configured threshold.
+        """
+
+        words = text.split()
+        scores = {
+            "length": min(len(words) / 100.0, 1.0),
+            "politeness": (
+                1.0
+                if any(keyword in text.lower() for keyword in ("please", "thank you"))
+                else 0.0
+            ),
+        }
+
+        total_weight = sum(self.weights.values()) or 1.0
+        weighted_total = (
+            sum(scores.get(k, 0.0) * self.weights.get(k, 0.0) for k in scores)
+            / total_weight
+        )
+
+        return {
+            "score": weighted_total,
+            "scores": scores,
+            "passed": weighted_total >= self.threshold,
+        }

--- a/tests/test_critic.py
+++ b/tests/test_critic.py
@@ -1,0 +1,28 @@
+import math
+
+from app.core.critic import Critic
+
+
+def test_high_score_passes():
+    critic = Critic(threshold=0.8)
+    text = "please " + "word " * 100 + "thank you"
+    result = critic.evaluate(text)
+    assert math.isclose(result["score"], 1.0, abs_tol=1e-6)
+    assert result["passed"] is True
+
+
+def test_weighting_affects_score():
+    critic = Critic(weights={"length": 0.1, "politeness": 0.9})
+    text = "please hello"
+    result = critic.evaluate(text)
+    # length is 0.02, politeness 1.0 -> score ~0.902
+    assert result["score"] > 0.9
+    assert result["scores"]["politeness"] == 1.0
+
+
+def test_threshold_triggers_failure():
+    critic = Critic(threshold=0.7)
+    text = "word " * 10
+    result = critic.evaluate(text)
+    assert result["score"] < critic.threshold
+    assert result["passed"] is False


### PR DESCRIPTION
## Summary
- implement heuristic-based `Critic` that scores text on length and politeness
- allow weight and threshold configuration for pass/fail logic
- add tests covering high score, weighting effects, and threshold failure scenarios

## Testing
- `ruff check app/core/critic.py tests/test_critic.py`
- `black --check app/core/critic.py tests/test_critic.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8c63fc348320bf52a065d376347e