### PR TITLE
feat: factor quality gate and feedback into reward

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ semgrep --quiet --error --config config/semgrep.yml .
 pytest -q
 ```
 
+## Auto-amélioration
+
+Lors de la routine `auto_improve`, Watcher calcule une récompense
+composite utilisée pour ajuster sa stratégie d'apprentissage :
+
+- 70 % provient du taux de réussite du QualityGate (linters, tests, etc.).
+- 30 % provient de la note moyenne des retours utilisateurs (échelle 0‑5
+  normalisée sur 0‑1).
+
+Cette récompense est transmise à `Learner.update_policy` pour influencer
+les décisions futures.
+
 ## Données
 
 Les jeux de données localisés dans `datasets/raw` et `datasets/processed` sont

--- a/app/core/learner.py
+++ b/app/core/learner.py
@@ -14,6 +14,7 @@ class Learner:
     def __init__(self, bench: Bench, data_dir: Path) -> None:
         self.bench = bench
         self.file = data_dir / "best_variant.json"
+        self.policy_file = data_dir / "policy.json"
         self.file.parent.mkdir(parents=True, exist_ok=True)
 
     def compare(self, a: str, b: str) -> dict:
@@ -26,6 +27,16 @@ class Learner:
             best = {"name": name, "score": score}
             self._save_best(best)
         return {"A": score_a, "B": score_b, "best": best}
+
+    def update_policy(self, reward: float) -> None:
+        """Update the learning policy based on a reward signal.
+
+        The current policy is a simple log of the latest reward value,
+        persisted to ``policy.json`` for potential future use.
+        """
+        self.policy_file.write_text(
+            json.dumps({"last_reward": reward}), encoding="utf-8"
+        )
 
     def _load_best(self) -> dict | None:
         if self.file.exists():


### PR DESCRIPTION
## Summary
- compute composite reward from QualityGate checks and user feedback in `auto_improve`
- allow `Learner` to accept reward via `update_policy`
- document new reward logic in README

## Testing
- `ruff check .`
- `black --check .` *(fails: would reformat app/tools/plugins/__init__.py, app/tools/plugins/hello.py, app/core/memory.py)*
- `mypy .` *(fails: Library stubs not installed for "yaml")*
- `bandit -q -r .` *(fails: command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb8c713f8c83208e4f84b5a7d2e426