### PR TITLE
refactor: reuse quality gate results

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -127,12 +127,13 @@ class Engine:
 
     def perform_maintenance(self) -> None:
         """Run quality gate and auto-improvement routines."""
+        qg_res: str | None = None
         try:
-            self.run_quality_gate()
+            qg_res = self.run_quality_gate()
         except Exception:  # pragma: no cover - best effort
             logging.exception("run_quality_gate failed")
         try:
-            self.auto_improve()
+            self.auto_improve(qg_res)
         except Exception:  # pragma: no cover - best effort
             logging.exception("auto_improve failed")
 
@@ -153,8 +154,18 @@ class Engine:
             return "data preparation failed"
         return str(path)
 
-    def auto_improve(self) -> str:
-        """Train on datasets and perform a simple A/B benchmark."""
+    def auto_improve(self, qg_res: str | None = None) -> str:
+        """Train on datasets and perform a simple A/B benchmark.
+
+        If *qg_res* is ``None`` the quality gate is executed to obtain a
+        fresh result.  When a recent result is already available it can be
+        passed in to avoid running the expensive checks twice.
+        """
+        if qg_res is None:
+            # Only execute the quality gate if a recent result wasn't
+            # supplied.  ``run_quality_gate`` already persists the result
+            # in memory so there is no need to keep the return value here.
+            self.run_quality_gate()
         fb = self.mem.all_feedback()
         if fb:
             raw_dir = self.base / "datasets" / "raw"

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,0 +1,50 @@
+import numpy as np
+
+from app.core.engine import Engine
+from app.core.memory import Memory
+
+
+def _setup_engine(tmp_path, monkeypatch, calls):
+    """Create a light-weight Engine instance for testing."""
+
+    # Avoid heavy embedding work when Memory.add is called
+    monkeypatch.setattr(
+        "app.core.memory.embed_ollama",
+        lambda texts, model="nomic-embed-text": [np.array([1.0])],
+    )
+
+    eng = Engine.__new__(Engine)
+    eng.mem = Memory(tmp_path / "mem.db")
+    eng.base = tmp_path
+    eng.prepare_data = lambda: "data"
+
+    class DummyQG:
+        def run_all(self):
+            calls.append("run_all")
+            return {"ok": True, "results": {}}
+
+    class DummyLearner:
+        def compare(self, a, b):
+            return {"A": 0.0, "B": 0.0, "best": {"name": "A"}}
+
+    eng.qg = DummyQG()
+    eng.learner = DummyLearner()
+
+    monkeypatch.setattr("app.core.autograder.grade_all", lambda: {"ok": True})
+
+    return eng
+
+
+def test_perform_maintenance_reuses_quality_gate(tmp_path, monkeypatch):
+    calls: list[str] = []
+    eng = _setup_engine(tmp_path, monkeypatch, calls)
+    eng.perform_maintenance()
+    assert calls == ["run_all"]
+
+
+def test_auto_improve_runs_quality_when_missing(tmp_path, monkeypatch):
+    calls: list[str] = []
+    eng = _setup_engine(tmp_path, monkeypatch, calls)
+    eng.auto_improve()
+    assert calls == ["run_all"]
+


### PR DESCRIPTION
## Summary
- pass quality gate results from `perform_maintenance` into `auto_improve`
- allow `auto_improve` to skip running expensive checks when recent results are supplied
- add regression tests for maintenance workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8c72bccc8320ba5a0865d2929474