### PR TITLE
Fix memory search threshold and add regression test

### DIFF
--- a/app/core/memory.py
+++ b/app/core/memory.py
@@ -106,6 +106,6 @@ class Memory:
             for _id, kind, text, score in rows
             if score is not None and score > 0
         ]
-        if threshold > 0 and (not scored or scored[-1][0] < threshold):
+        if threshold > 0 and (not scored or scored[0][0] < threshold):
             raise ValueError(f"no results with score >= {threshold}")
         return scored

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -58,3 +58,22 @@ def test_search_respects_threshold(tmp_path, monkeypatch):
     mem.add("note", "salut")
     with pytest.raises(ValueError):
         mem.search("salut", threshold=0.5)
+
+
+def test_search_threshold_checks_top_score(tmp_path, monkeypatch):
+    def fake_embed(texts, model="nomic-embed-text"):
+        mapping = {
+            "good": np.array([1.0, 0.0]),
+            "bad": np.array([0.1, 1.0]),
+        }
+        return [mapping[text] for text in texts]
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+    mem = Memory(tmp_path / "mem.db")
+    mem.add("note", "good")
+    mem.add("note", "bad")
+
+    results = mem.search("good", top_k=2, threshold=0.5)
+    assert len(results) == 2
+    assert results[0][0] >= 0.5
+    assert results[1][0] < 0.5


### PR DESCRIPTION
## Summary
- Correct `Memory.search` to validate threshold against top score
- Add regression test ensuring search succeeds when best result exceeds threshold but later ones don't

## Testing
- `pytest tests/test_memory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8e894c50832093cac626d84be9ee