### PR TITLE
Add memory summarization to limit stored items

### DIFF
--- a/tests/test_memory_summary.py
+++ b/tests/test_memory_summary.py
@@ -1,0 +1,22 @@
+import sqlite3
+import numpy as np  # type: ignore
+
+from app.core.memory import Memory
+
+
+def test_summarize_limits_items(tmp_path, monkeypatch):
+    def fake_embed(texts, model="nomic-embed-text"):
+        return [np.array([1.0]) for _ in texts]
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+    db_path = tmp_path / "mem.db"
+    mem = Memory(db_path)
+    max_items = 5
+    for i in range(max_items + 3):
+        mem.add("note", f"msg {i}")
+        mem.summarize("note", max_items)
+        with sqlite3.connect(db_path) as con:
+            count = con.execute(
+                "SELECT COUNT(*) FROM items WHERE kind='note'"
+            ).fetchone()[0]
+        assert count <= max_items


### PR DESCRIPTION
## Summary
- add Memory.summarize to condense oldest records when exceeding a limit
- test that summarization keeps items table within max_items

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb9532e8688320a33b7ef58a684753