### PR TITLE
feat: log llm trace in memory

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -100,8 +100,9 @@ class Engine:
         if excerpts:
             llm_prompt = "\n\n".join([llm_prompt, "\n".join(excerpts)])
 
-        answer = self.client.generate(llm_prompt)
+        answer, trace = self.client.generate(llm_prompt)
         self.mem.add("chat_ai", answer)
+        self.mem.add("trace", trace)
         self.last_prompt = user_prompt
         self.last_answer = answer
         return answer

--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -91,11 +91,17 @@ class Client:
         self.host = cfg.get("host", "127.0.0.1:11434")
         self.fallback_phrase = fallback_phrase
 
-    def generate(self, prompt: str) -> str:
-        """Return a response for *prompt*."""
+    def generate(self, prompt: str) -> tuple[str, str]:
+        """Return a response and trace for *prompt*."""
 
+        trace: list[str] = []
         try:  # pragma: no cover - network path
-            return generate_ollama(prompt, host=self.host, model=self.model)
+            trace.append("ollama")
+            resp = generate_ollama(prompt, host=self.host, model=self.model)
+            trace.append("success")
+            return resp, " -> ".join(trace)
         except Exception as exc:
+            trace.append(f"error:{exc.__class__.__name__}")
+            trace.append("fallback")
             logging.exception("Failed to generate response: %s", exc)
-            return f"{self.fallback_phrase}: {prompt}"
+            return f"{self.fallback_phrase}: {prompt}", " -> ".join(trace)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,9 +3,13 @@ from app.llm.client import Client
 
 def test_client_fallback_echo() -> None:
     client = Client()
-    assert client.generate("salut") == "Echo: salut"
+    answer, trace = client.generate("salut")
+    assert answer == "Echo: salut"
+    assert "fallback" in trace
 
 
 def test_client_custom_fallback() -> None:
     client = Client(fallback_phrase="Offline")
-    assert client.generate("hi") == "Offline: hi"
+    answer, trace = client.generate("hi")
+    assert answer == "Offline: hi"
+    assert "fallback" in trace


### PR DESCRIPTION
## Summary
- extend LLM client to return generation trace
- persist trace entries during engine chat
- add regression tests for trace logging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb9534290483208e3aa48dc102d30f