### PR TITLE
feat: improve answers via critic suggestions

### DIFF
--- a/app/core/critic.py
+++ b/app/core/critic.py
@@ -74,3 +74,38 @@ class Critic:
             "scores": scores,
             "passed": weighted_total >= self.threshold,
         }
+
+
+def suggest(prompt: str, answer: str) -> str:
+    """Return a simple improvement plan for ``answer``.
+
+    The heuristic mirrors the :class:`Critic` scoring rules.  Two basic
+    suggestions are provided:
+
+    * Encourage adding more detail when the length score is low.
+    * Request a polite phrase when none is detected.
+
+    Parameters
+    ----------
+    prompt:
+        The original user prompt.  Currently unused but allows future
+        expansion to contextual suggestions.
+    answer:
+        The assistant response to critique.
+
+    Returns
+    -------
+    str
+        A human readable plan combining zero or more improvement steps.
+    """
+
+    critic = Critic()
+    result = critic.evaluate(answer)
+    suggestions: list[str] = []
+
+    if result["scores"].get("length", 0.0) < 0.5:
+        suggestions.append("Ajoutez des détails.")
+    if result["scores"].get("politeness", 0.0) < 1.0:
+        suggestions.append("Ajoutez une formule de politesse.")
+
+    return " ".join(suggestions)

--- a/tests/test_critic_suggestions.py
+++ b/tests/test_critic_suggestions.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from app.core.critic import suggest
+from app.core.engine import Engine
+from app.core.memory import Memory
+
+
+def test_suggest_returns_plan_for_short_impolite_answer():
+    plan = suggest("question", "ok")
+    assert "politesse" in plan.lower()
+    assert "détail" in plan.lower()
+
+
+def test_engine_applies_suggestions(tmp_path, monkeypatch):
+    # Avoid heavy embedding calls
+    def fake_embed(texts, model="nomic-embed-text"):
+        return [np.array([1.0])]
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+    monkeypatch.setattr(Memory, "search", lambda self, q, top_k=8: [])
+
+    class DummyClient:
+        def generate(self, prompt: str) -> str:
+            return "ok"
+
+    eng = Engine.__new__(Engine)
+    eng.mem = Memory(tmp_path / "mem.db")
+    eng.client = DummyClient()
+
+    answer = eng.chat("ping")
+    assert "Merci." in answer
+    assert "détails" in answer

--- a/tests/test_engine_chat.py
+++ b/tests/test_engine_chat.py
@@ -22,12 +22,16 @@ def test_chat_saves_distinct_kinds(tmp_path, monkeypatch):
     eng.client = DummyClient()
 
     answer = eng.chat("ping")
-    assert answer == "pong"
+    assert answer.startswith("pong")
+    assert "Merci." in answer
 
     with sqlite3.connect(tmp_path / "mem.db") as con:
         rows = con.execute("SELECT kind,text FROM items ORDER BY id").fetchall()
 
-    assert rows == [("chat_user", "ping"), ("chat_ai", "pong")]
+    assert rows[0] == ("chat_user", "ping")
+    assert rows[1][0] == "chat_ai"
+    assert "pong" in rows[1][1]
+    assert "Merci." in rows[1][1]
 
 
 def test_chat_includes_retrieved_terms(tmp_path, monkeypatch):
@@ -56,6 +60,7 @@ def test_chat_includes_retrieved_terms(tmp_path, monkeypatch):
 
     answer = eng.chat("ping")
 
-    assert answer == "pong"
+    assert answer.startswith("pong")
+    assert "Merci." in answer
     assert "alpha beta" in eng.client.prompt
     assert "ping" in eng.client.prompt


### PR DESCRIPTION
## Summary
- add heuristic `suggest` function returning improvement plans
- apply critic suggestions in `Engine.chat` responses
- test suggestions and updated answer handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb95350ef4832092514e95cc452013