### PR TITLE
feat: add contextual learner with gradient updates

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -157,12 +157,17 @@ class Engine:
             return "data preparation failed"
         return str(path)
 
-    def auto_improve(self, qg_res: str | None = None) -> str:
-        """Train on datasets and perform a simple A/B benchmark.
+    def auto_improve(
+        self,
+        qg_res: str | None = None,
+        state: list[float] | None = None,
+        reward: float | None = None,
+    ) -> str:
+        """Train on datasets, update policy and perform a simple A/B benchmark.
 
-        If *qg_res* is ``None`` the quality gate is executed to obtain a
-        fresh result.  When a recent result is already available it can be
-        passed in to avoid running the expensive checks twice.
+        If *qg_res* is ``None`` the quality gate is executed to obtain a fresh
+        result.  When a recent result is already available it can be passed in
+        to avoid running the expensive checks twice.
         """
         if qg_res is None:
             # Only execute the quality gate if a recent result wasn't
@@ -191,6 +196,10 @@ class Engine:
         self.prepare_data()
         rep = AG.grade_all()
         self.mem.add("train", json.dumps(rep))
+
+        if state is not None and reward is not None:
+            self.learner.step(state, reward)
+
         comp = self.learner.compare("A", "B")
         self.mem.add("decision", json.dumps(comp))
         a = comp["A"]

--- a/app/core/learner.py
+++ b/app/core/learner.py
@@ -9,12 +9,36 @@ from app.core.benchmark import Bench
 
 
 class Learner:
-    """Track benchmark results and remember the best variant."""
+    """Track benchmark results, remember best variant and learn from context."""
 
     def __init__(self, bench: Bench, data_dir: Path) -> None:
         self.bench = bench
         self.file = data_dir / "best_variant.json"
         self.file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Simple policy parameters and learning state for REINFORCE-style updates
+        self.params: list[float] = []
+        self.prev_state: list[float] | None = None
+        self.lr = 0.1
+
+    def step(self, state: list[float], reward: float) -> list[float]:
+        """Update policy parameters based on ``reward`` and previous state.
+
+        The update implements a minimal REINFORCE gradient: ``grad = reward *
+        prev_state``.  The *current* ``state`` is stored for the next
+        invocation.
+        """
+
+        if not self.params:
+            # Lazy initialisation matching state dimensionality
+            self.params = [0.0 for _ in state]
+
+        if self.prev_state is not None:
+            grad = [reward * s for s in self.prev_state]
+            self.params = [p + self.lr * g for p, g in zip(self.params, grad)]
+
+        self.prev_state = state
+        return self.params
 
     def compare(self, a: str, b: str) -> dict:
         """Benchmark two variants and persist the best result."""

--- a/tests/test_learner_context.py
+++ b/tests/test_learner_context.py
@@ -1,0 +1,48 @@
+import numpy as np
+
+from app.core.engine import Engine
+from app.core.memory import Memory
+from app.core.learner import Learner
+from app.core.benchmark import Bench
+
+
+class DummyBench(Bench):
+    def run_variant(self, name: str) -> float:  # type: ignore[override]
+        return 0.0
+
+
+def _setup_engine(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.memory.embed_ollama", lambda texts, model="nomic-embed-text": [np.array([1.0])]
+    )
+
+    eng = Engine.__new__(Engine)
+    eng.mem = Memory(tmp_path / "mem.db")
+    eng.base = tmp_path
+    eng.prepare_data = lambda: "data"
+
+    class DummyQG:
+        def run_all(self):
+            return {"ok": True, "results": {}}
+
+    eng.qg = DummyQG()
+
+    bench = DummyBench()
+    eng.learner = Learner(bench, tmp_path)
+
+    monkeypatch.setattr("app.core.autograder.grade_all", lambda: {"ok": True})
+
+    return eng
+
+
+def test_parameter_updates_over_iterations(tmp_path, monkeypatch):
+    eng = _setup_engine(tmp_path, monkeypatch)
+
+    eng.auto_improve(qg_res="{}", state=[1.0, 0.0], reward=1.0)
+    assert eng.learner.params == [0.0, 0.0]
+
+    eng.auto_improve(qg_res="{}", state=[0.0, 1.0], reward=-1.0)
+    assert eng.learner.params == [-0.1, 0.0]
+
+    eng.auto_improve(qg_res="{}", state=[1.0, 1.0], reward=2.0)
+    assert eng.learner.params == [-0.1, 0.2]


### PR DESCRIPTION
## Summary
- extend learner to store previous state and update parameters with REINFORCE-style gradient
- allow Engine.auto_improve to forward state and reward to the learner
- test parameter evolution across iterations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb9536370c8320980d82dfbbb96fb0