### PR TITLE
Support runtime plugin reloading

### DIFF
--- a/app/tools/plugins/__init__.py
+++ b/app/tools/plugins/__init__.py
@@ -1,7 +1,12 @@
 """Plugin protocol and discovery helpers."""
 from __future__ import annotations
 
+import importlib
+import logging
+from pathlib import Path
 from typing import Protocol
+
+import tomllib
 
 
 class Plugin(Protocol):
@@ -10,3 +15,46 @@ class Plugin(Protocol):
     def run(self) -> str:  # pragma: no cover - interface definition
         """Execute the plugin and return a human readable message."""
         ...
+
+
+def reload_plugins(base: Path | None = None) -> list[Plugin]:
+    """Load plugin instances defined in ``plugins.toml``.
+
+    Parameters
+    ----------
+    base:
+        Optional base directory containing the ``plugins.toml`` file.  When
+        ``None`` the project root is used.
+    """
+
+    if base is None:
+        base = Path(__file__).resolve().parents[2]
+
+    cfg = base / "plugins.toml"
+    plugins: list[Plugin] = []
+    if not cfg.exists():
+        return plugins
+
+    try:
+        data = tomllib.loads(cfg.read_text(encoding="utf-8"))
+    except Exception:  # pragma: no cover - best effort
+        logging.exception("Invalid plugins.toml")
+        return plugins
+
+    for item in data.get("plugins", []):
+        path = item.get("path")
+        if not path:
+            continue
+        module_name, _, class_name = path.partition(":")
+        try:
+            module = importlib.import_module(module_name)
+            cls = getattr(module, class_name)
+            plugin: Plugin = cls()
+            plugins.append(plugin)
+        except Exception:  # pragma: no cover - best effort
+            logging.exception("Failed to load plugin %s", path)
+
+    return plugins
+
+
+__all__ = ["Plugin", "reload_plugins"]

--- a/tests/dummy_plugin.py
+++ b/tests/dummy_plugin.py
@@ -1,0 +1,8 @@
+"""Dummy plugin used in tests."""
+
+class DummyPlugin:
+    """Simple plugin returning a marker message."""
+
+    def run(self) -> str:  # pragma: no cover - trivial
+        return "dummy plugin loaded"
+

--- a/tests/test_plugin_reload.py
+++ b/tests/test_plugin_reload.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+from app.core.engine import Engine
+from tests.dummy_plugin import DummyPlugin
+
+
+def test_reload_plugins():
+    cfg = Path("plugins.toml")
+    original = cfg.read_text(encoding="utf-8")
+    engine = Engine()
+    assert not any(isinstance(p, DummyPlugin) for p in engine.plugins)
+
+    cfg.write_text(
+        original
+        + "\n[[plugins]]\npath = \"tests.dummy_plugin:DummyPlugin\"\n",
+        encoding="utf-8",
+    )
+    try:
+        engine.reload_plugins()
+        assert any(isinstance(p, DummyPlugin) for p in engine.plugins)
+        outputs = engine.run_plugins()
+        assert "dummy plugin loaded" in outputs
+    finally:
+        cfg.write_text(original, encoding="utf-8")
+


### PR DESCRIPTION
## Summary
- add `reload_plugins` helper to load plugins from `plugins.toml`
- expose `Engine.reload_plugins()` for hot reloading
- test plugin reloading with a dummy plugin

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb953736048320afd9ffd0f442209f