### PR TITLE
feat: add extensible data pipeline

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -42,6 +42,11 @@ stagnation_patience = 2
 [data]
 path = "data"
 
+[data.steps]
+load = "app.data.pipeline.load_raw_data"
+clean = "app.data.pipeline.clean_data"
+transform = "app.data.pipeline.transform_data"
+
 [training]
 epochs = 10
 batch_size = 32

--- a/tests/test_pipeline_extensible.py
+++ b/tests/test_pipeline_extensible.py
@@ -1,0 +1,30 @@
+from app.data import pipeline as dp
+
+
+class AddA:
+    def __call__(self, data):
+        data.append("a")
+        return data
+
+
+class AddB:
+    def __call__(self, data):
+        data.append("b")
+        return data
+
+
+def fake_config(section=None):
+    if section == "data":
+        return {
+            "steps": {
+                "first": "tests.test_pipeline_extensible.AddA",
+                "second": "tests.test_pipeline_extensible.AddB",
+            }
+        }
+    return {}
+
+
+def test_pipeline_extensible(monkeypatch):
+    monkeypatch.setattr(dp, "load_config", fake_config)
+    result = dp.run_pipeline([])
+    assert result == ["a", "b"]


### PR DESCRIPTION
## Summary
- add `PipelineStep` protocol for configurable data pipeline
- allow pipeline steps declared in `config/settings.toml`
- test custom pipeline sequencing

## Testing
- `ruff check app/data/pipeline.py tests/test_pipeline_extensible.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb95386dbc8320906fe74d027adec4