### PR TITLE
feat: add JSON logging with request IDs

### DIFF
--- a/app/core/logging_setup.py
+++ b/app/core/logging_setup.py
@@ -3,11 +3,45 @@
 from pathlib import Path
 import logging
 import logging.config
+from datetime import datetime
+import json
+from contextvars import ContextVar
 
 try:
     import yaml
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     yaml = None
+
+
+request_id_ctx: ContextVar[str] = ContextVar("request_id", default="")
+
+
+class RequestIdFilter(logging.Filter):
+    """Logging filter to inject a request_id into log records."""
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple
+        record.request_id = request_id_ctx.get("")
+        return True
+
+
+class JSONFormatter(logging.Formatter):
+    """Format log records as JSON."""
+
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting
+        log_record = {
+            "timestamp": datetime.utcfromtimestamp(record.created).isoformat() + "Z",
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        if hasattr(record, "request_id") and record.request_id:
+            log_record["request_id"] = record.request_id
+        return json.dumps(log_record)
+
+
+def set_request_id(request_id: str) -> None:
+    """Set the request identifier for subsequent log records."""
+    request_id_ctx.set(request_id)
 
 
 def configure() -> None:
@@ -17,5 +51,30 @@ def configure() -> None:
         with config_path.open("r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
         logging.config.dictConfig(config)
-    else:  # pragma: no cover - fallback when PyYAML not installed
+    elif config_path.exists():  # pragma: no cover - used when PyYAML missing
+        config = {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {"json": {"()": "app.core.logging_setup.JSONFormatter"}},
+            "filters": {"request_id": {"()": "app.core.logging_setup.RequestIdFilter"}},
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "level": "INFO",
+                    "formatter": "json",
+                    "filters": ["request_id"],
+                    "stream": "ext://sys.stdout",
+                },
+                "file": {
+                    "class": "logging.FileHandler",
+                    "level": "INFO",
+                    "formatter": "json",
+                    "filters": ["request_id"],
+                    "filename": "watcher.log",
+                },
+            },
+            "root": {"level": "INFO", "handlers": ["console", "file"]},
+        }
+        logging.config.dictConfig(config)
+    else:  # pragma: no cover - config file missing
         logging.basicConfig(level=logging.INFO)

--- a/config/logging.yml
+++ b/config/logging.yml
@@ -2,19 +2,25 @@ version: 1
 disable_existing_loggers: False
 
 formatters:
-  standard:
-    format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  json:
+    (): app.core.logging_setup.JSONFormatter
+
+filters:
+  request_id:
+    (): app.core.logging_setup.RequestIdFilter
 
 handlers:
   console:
     class: logging.StreamHandler
     level: INFO
-    formatter: standard
+    formatter: json
+    filters: [request_id]
     stream: ext://sys.stdout
   file:
     class: logging.FileHandler
     level: INFO
-    formatter: standard
+    formatter: json
+    filters: [request_id]
     filename: watcher.log
 
 root:

--- a/tests/test_structured_logs.py
+++ b/tests/test_structured_logs.py
@@ -1,0 +1,22 @@
+import json
+import os
+import logging
+
+from app.core import logging_setup
+
+
+def test_logs_are_json(capfd):
+    logging_setup.set_request_id("req-123")
+    logging_setup.configure()
+    logger = logging.getLogger("test")
+    logger.info("hello world")
+    out, err = capfd.readouterr()
+    logging.shutdown()
+    # clean up generated log file
+    if os.path.exists("watcher.log"):
+        os.remove("watcher.log")
+    data = json.loads(out.strip())
+    assert data["message"] == "hello world"
+    assert data["level"] == "INFO"
+    assert data["request_id"] == "req-123"
+    assert data["name"] == "test"


### PR DESCRIPTION
## Summary
- output logs as JSON and attach request IDs
- add filter and formatter helpers in logging setup
- test that logs are structured JSON

## Testing
- `pytest tests/test_structured_logs.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb953a89d08320bec3c8798270e8cc