### PR TITLE
feat: enforce prompt sanitization

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -15,7 +15,8 @@ from app.core.evaluator import QualityGate
 from app.core.memory import Memory
 from app.core.planner import Planner
 from app.core.learner import Learner
-from app.llm.client import Client, validate_prompt
+from app.llm.client import Client
+from app.core.validation import validate_prompt
 from app.tools.scaffold import create_python_cli
 from app.data import pipeline
 from app.tools.plugins import Plugin

--- a/app/core/validation.py
+++ b/app/core/validation.py
@@ -1,28 +1,54 @@
+"""User input validation helpers."""
+
+from __future__ import annotations
+
+import re
 from typing import Any
 
 
+# Simple list of patterns considered dangerous.  The goal is not to be
+# exhaustive but to catch obviously malicious inputs such as attempts to run
+# shell commands or embed scripts.  The check is performed case-insensitively.
+_DANGEROUS_PATTERNS = [
+    r"rm\s+-rf\s+/",  # destructive file removal
+    r"<\s*script",  # HTML/JS injection
+    r"shutdown",  # system shutdown
+    r"reboot",  # system reboot
+    r"sudo",  # privileged command execution
+]
+
+
 def validate_prompt(prompt: Any) -> str:
-    """Validate that the given prompt is a non-empty string.
+    """Validate that *prompt* is a safe, non-empty string.
 
     Parameters
     ----------
-    prompt: Any
+    prompt:
         The user provided prompt to validate.
 
     Returns
     -------
     str
-        The original prompt if it is valid.
+        Sanitised prompt.
 
     Raises
     ------
     TypeError
         If *prompt* is not an instance of :class:`str`.
     ValueError
-        If the prompt is empty or consists solely of whitespace.
+        If the prompt is empty or contains dangerous content.
     """
+
     if not isinstance(prompt, str):
         raise TypeError("Prompt must be a string")
-    if not prompt.strip():
+
+    prompt = prompt.strip()
+    if not prompt:
         raise ValueError("Prompt cannot be empty")
+
+    lowered = prompt.lower()
+    for pat in _DANGEROUS_PATTERNS:
+        if re.search(pat, lowered):
+            raise ValueError("Prompt contains potentially dangerous content")
+
     return prompt

--- a/tests/test_prompt_sanitization.py
+++ b/tests/test_prompt_sanitization.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from app.core.validation import validate_prompt
+from app.core.engine import Engine
+from app.core.memory import Memory
+
+
+def test_validate_prompt_rejects_script() -> None:
+    with pytest.raises(ValueError):
+        validate_prompt("<script>alert('x')</script>")
+
+
+def test_engine_chat_rejects_command(tmp_path, monkeypatch) -> None:
+    def fake_embed(texts, model="nomic-embed-text"):
+        return [np.array([1.0])]
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+    monkeypatch.setattr(Memory, "search", lambda self, q, top_k=8: [])
+
+    class DummyClient:
+        def generate(self, prompt: str) -> str:
+            return "pong"
+
+    eng = Engine.__new__(Engine)
+    eng.mem = Memory(tmp_path / "mem.db")
+    eng.client = DummyClient()
+
+    with pytest.raises(ValueError):
+        eng.chat("rm -rf /")


### PR DESCRIPTION
## Summary
- detect and reject dangerous commands in `validate_prompt`
- validate chat inputs in engine using the new logic
- test rejection of script tags and destructive shell commands

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb953d4a848320bd118ab4048cb857