### PR TITLE
doc: clarifier politiques de confidentialité

### DIFF
--- a/ETHICS.md
+++ b/ETHICS.md
@@ -16,3 +16,8 @@ Watcher vise à offrir un atelier local d'IA respectant la confidentialité des 
 - Journalisation via le module `logging` standard de Python.
 - Stockage persistant des décisions dans une base SQLite gérée par `app/core/memory.py`.
 
+## Conservation et effacement des retours
+- Les retours et commentaires de l'utilisateur sont conservés sur l'environnement local.
+- L'utilisateur peut à tout moment exporter ou supprimer ces informations pour préserver la confidentialité.
+- Aucune transmission externe n'est réalisée lors de ces opérations.
+

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ dvc pull
 Sandbox d'exécution confinée, tests et linters obligatoires avant adoption de code.
 Semgrep utilise un fichier de règles local (`config/semgrep.yml`), aucun accès réseau requis.
 
+## Confidentialité
+
+Watcher fonctionne hors ligne par défaut et n'envoie aucune donnée vers l'extérieur.
+Les journaux comme les contenus mémorisés restent sur l'environnement local et peuvent être effacés par l'utilisateur.
+
 ## Éthique et traçabilité
 
 Les actions du système sont journalisées via le module standard `logging`. Les erreurs et décisions importantes sont ainsi consignées pour audit ou débogage.

--- a/tests/test_docs_ethics.py
+++ b/tests/test_docs_ethics.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_ethics_mentions_feedback_retention():
+    content = Path("ETHICS.md").read_text(encoding="utf-8")
+    assert "Conservation et effacement des retours" in content
+
+
+def test_readme_mentions_confidentiality():
+    content = Path("README.md").read_text(encoding="utf-8")
+    assert "## Confidentialité" in content


### PR DESCRIPTION
## Summary
- détaille la conservation et l'effacement des retours dans `ETHICS.md`
- résume les garanties de confidentialité dans `README.md`
- ajoute un test CI vérifiant la présence de ces sections

## Testing
- `ruff check .` *(fails: E402 in app/data/validation.py)*
- `black --check .` *(fails: 6 files would be reformatted)*
- `mypy .` *(interrupted: no output produced)*
- `bandit -q -r .` *(fails: command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb953eae288320882fa57766c15ff8