### PR TITLE
Add self-check for chat responses

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -15,6 +15,7 @@ from app.core.evaluator import QualityGate
 from app.core.memory import Memory
 from app.core.planner import Planner
 from app.core.learner import Learner
+from app.core import self_check
 from app.llm.client import Client, validate_prompt
 from app.tools.scaffold import create_python_cli
 from app.data import pipeline
@@ -45,6 +46,7 @@ class Engine:
         self.start_msg = self._bootstrap()
         self.last_prompt = ""
         self.last_answer = ""
+        self.last_check = ""
         if perform_maintenance:
             Thread(target=self.perform_maintenance, daemon=True).start()
 
@@ -104,6 +106,10 @@ class Engine:
         self.mem.add("chat_ai", answer)
         self.last_prompt = user_prompt
         self.last_answer = answer
+        report = self_check.analyze(user_prompt, answer)
+        self.last_check = report
+        if report:
+            self.mem.add("self_check", report)
         return answer
 
     def add_feedback(self, rating: float, kind: str = "chat") -> str:

--- a/app/core/self_check.py
+++ b/app/core/self_check.py
@@ -1,0 +1,40 @@
+"""Simple consistency checks for chat responses."""
+from __future__ import annotations
+
+import re
+from typing import List
+
+
+def analyze(prompt: str, answer: str) -> str:
+    """Return a human readable error report if obvious mistakes are detected.
+
+    For now only a very small set of heuristics is implemented.  When *prompt*
+    contains a basic arithmetic expression like ``"2 + 2"`` the result is
+    evaluated and compared to the first number found in *answer*.  A mismatch
+    yields an error report, otherwise an empty string is returned.
+    """
+
+    report: List[str] = []
+
+    # Detect and evaluate simple arithmetic expressions in the prompt
+    expr_match = re.search(r"(\d+\s*[+\-*/]\s*\d+)", prompt)
+    if expr_match:
+        expr = expr_match.group(1)
+        try:
+            expected = eval(expr)
+            nums = re.findall(r"-?\d+", answer)
+            if nums:
+                got = int(nums[0])
+                if got != expected:
+                    report.append(
+                        f"Erreur calcul: {expr} = {expected} (pas {got})"
+                    )
+            else:
+                report.append(
+                    "Réponse sans nombre pour calcul demandé"
+                )
+        except Exception:
+            # If evaluation fails the check is silently ignored
+            pass
+
+    return "\n".join(report)

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -1,0 +1,27 @@
+import numpy as np
+
+from app.core.engine import Engine
+from app.core.memory import Memory
+
+
+def test_self_check_reports_arithmetic_error(tmp_path, monkeypatch):
+    def fake_embed(texts, model="nomic-embed-text"):
+        return [np.array([1.0])]
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+    monkeypatch.setattr(Memory, "search", lambda self, q, top_k=8: [])
+
+    class DummyClient:
+        def generate(self, prompt: str) -> str:
+            return "5"  # wrong on purpose
+
+    eng = Engine.__new__(Engine)
+    eng.mem = Memory(tmp_path / "mem.db")
+    eng.client = DummyClient()
+    eng.last_check = ""
+
+    answer = eng.chat("Combien font 2 + 2 ?")
+
+    assert answer == "5"
+    assert eng.last_check
+    assert "4" in eng.last_check


### PR DESCRIPTION
## Summary
- add self_check module analysing prompt/answer pairs for simple arithmetic errors
- integrate self_check into Engine.chat and store error reports
- test that self_check reports a wrong arithmetic answer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb9540ca2c8320b8d44817e3b9318e