### PR TITLE
Extend politeness check to French

### DIFF
--- a/app/core/critic.py
+++ b/app/core/critic.py
@@ -54,12 +54,18 @@ class Critic:
         """
 
         words = text.split()
+        text_lower = text.lower()
+        polite_keywords = (
+            "please",
+            "thank you",
+            "merci",
+            "s'il vous plaît",
+            "s'il vous plait",
+        )
         scores = {
             "length": min(len(words) / 100.0, 1.0),
             "politeness": (
-                1.0
-                if any(keyword in text.lower() for keyword in ("please", "thank you"))
-                else 0.0
+                1.0 if any(keyword in text_lower for keyword in polite_keywords) else 0.0
             ),
         }
 

--- a/tests/test_critic_suggestions.py
+++ b/tests/test_critic_suggestions.py
@@ -1,0 +1,13 @@
+import pytest
+
+from app.core.critic import Critic
+
+
+@pytest.mark.parametrize(
+    "text",
+    ["Merci pour votre aide", "S'il vous plaît, pourriez-vous aider?"]
+)
+def test_french_politeness(text):
+    critic = Critic()
+    result = critic.evaluate(text)
+    assert result["scores"]["politeness"] == 1.0


### PR DESCRIPTION
## Summary
- recognize French polite phrases like "merci" and "s'il vous plaît" in Critic evaluation
- add tests exercising French politeness scoring

## Testing
- `pytest tests/test_critic.py tests/test_critic_suggestions.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb9d6c8d2c8320a2e384997ccf5fd6