### PR TITLE
Refactor critic suggestions and update engine

### DIFF
--- a/tests/test_critic.py
+++ b/tests/test_critic.py
@@ -26,3 +26,11 @@ def test_threshold_triggers_failure():
     result = critic.evaluate(text)
     assert result["score"] < critic.threshold
     assert result["passed"] is False
+
+
+def test_suggest_returns_identifiers():
+    critic = Critic()
+    suggestions = critic.suggest("hi")
+    assert "detail" in suggestions
+    assert "politeness" in suggestions
+    assert isinstance(suggestions, list)

--- a/tests/test_learner_context.py
+++ b/tests/test_learner_context.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from app.core.engine import Engine
 from app.core.memory import Memory
 from app.core.learner import Learner

--- a/tests/test_prompt_sanitization.py
+++ b/tests/test_prompt_sanitization.py
@@ -4,6 +4,7 @@ import pytest
 from app.core.validation import validate_prompt
 from app.core.engine import Engine
 from app.core.memory import Memory
+from app.core.critic import Critic
 
 
 def test_validate_prompt_rejects_script() -> None:
@@ -25,6 +26,7 @@ def test_engine_chat_rejects_command(tmp_path, monkeypatch) -> None:
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
     eng.client = DummyClient()
+    eng.critic = Critic()
 
     with pytest.raises(ValueError):
         eng.chat("rm -rf /")

--- a/tests/test_trace_logging.py
+++ b/tests/test_trace_logging.py
@@ -1,8 +1,10 @@
 import numpy as np
+import numpy as np
 import sqlite3
 
 from app.core.memory import Memory
 from app.core.engine import Engine
+from app.core.critic import Critic
 
 
 def test_trace_stored_in_memory(tmp_path, monkeypatch):
@@ -19,15 +21,17 @@ def test_trace_stored_in_memory(tmp_path, monkeypatch):
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
     eng.client = DummyClient()
+    eng.critic = Critic()
 
-    answer = eng.chat("ping")
+    prompt = "please " + "word " * 60 + "thank you"
+    answer = eng.chat(prompt)
     assert answer == "pong"
 
     with sqlite3.connect(tmp_path / "mem.db") as con:
         rows = con.execute("SELECT kind,text FROM items ORDER BY id").fetchall()
 
     assert rows == [
-        ("chat_user", "ping"),
+        ("chat_user", prompt),
         ("chat_ai", "pong"),
         ("trace", "trace-steps"),
     ]


### PR DESCRIPTION
## Summary
- Return structured identifiers from `Critic.suggest` instead of free text
- `Engine.chat` consults the critic and responds to suggestion identifiers
- Update tests to exercise the new structured suggestion format

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb9d6da9548320b47647d90d21719c