### PR TITLE
feat: chunk prompts before generation

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -57,6 +57,12 @@ def generate_ollama(prompt: str, *, host: str, model: str) -> str:
             pass
 
 
+def chunk_prompt(prompt: str, *, size: int = 1000) -> list[str]:
+    """Yield slices of *prompt* of at most *size* characters."""
+
+    return [prompt[i : i + size] for i in range(0, len(prompt), size)]
+
+
 class Client:
     """Generate text using an LLM backend.
 
@@ -92,14 +98,23 @@ class Client:
         self.fallback_phrase = fallback_phrase
 
     def generate(self, prompt: str) -> tuple[str, str]:
-        """Return a response and trace for *prompt*."""
+        """Return a response and trace for *prompt*.
+
+        The prompt is sent in fixed-size chunks so very large prompts can be
+        handled without overwhelming the backend. Successful responses from
+        each chunk are concatenated before being returned.
+        """
 
         trace: list[str] = []
         try:  # pragma: no cover - network path
-            trace.append("ollama")
-            resp = generate_ollama(prompt, host=self.host, model=self.model)
+            responses: list[str] = []
+            for idx, chunk in enumerate(chunk_prompt(prompt)):
+                trace.append(f"ollama:{idx}")
+                responses.append(
+                    generate_ollama(chunk, host=self.host, model=self.model)
+                )
             trace.append("success")
-            return resp, " -> ".join(trace)
+            return "".join(responses), " -> ".join(trace)
         except Exception as exc:
             trace.append(f"error:{exc.__class__.__name__}")
             trace.append("fallback")


### PR DESCRIPTION
## Summary
- add helper to chunk prompts before sending to LLM
- concatenate per-chunk responses and preserve trace data

## Testing
- `ruff check app/llm/client.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb9d74ca908320be63167b0a33d087