### PR TITLE
Add self-check test for correct arithmetic answers

### DIFF
--- a/app/core/self_check.py
+++ b/app/core/self_check.py
@@ -1,0 +1,44 @@
+"""Arithmetic self-check utilities."""
+
+from __future__ import annotations
+
+import re
+from typing import Callable
+
+from app.core.memory import Memory
+
+
+_OPERATORS: dict[str, Callable[[int, int], int]] = {
+    '+': lambda a, b: a + b,
+    '-': lambda a, b: a - b,
+    '*': lambda a, b: a * b,
+    '/': lambda a, b: a // b if b != 0 else 0,
+}
+
+
+def self_check(answer: str, mem: Memory | None = None) -> str | None:
+    """Validate simple arithmetic expressions inside *answer*.
+
+    The function looks for patterns of the form ``"A op B = C"`` where
+    ``op`` is one of ``+``, ``-``, ``*`` or ``/``. When the expression is
+    incorrect a human readable report is returned and optionally stored in
+    ``mem`` under the ``"report"`` kind. Correct expressions return ``None``
+    and do not touch memory.
+    """
+
+    match = re.search(r"(\d+)\s*([+\-*/])\s*(\d+)\s*=\s*(\d+)", answer)
+    if not match:
+        return None
+
+    a, op, b, res = match.groups()
+    a_i, b_i, res_i = int(a), int(b), int(res)
+    calc = _OPERATORS.get(op)
+    if calc is None:
+        return None
+    expected = calc(a_i, b_i)
+    if expected != res_i:
+        report = f"expected {expected} but got {res_i} for {a} {op} {b}"
+        if mem is not None:
+            mem.add("report", report)
+        return report
+    return None

--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -1,0 +1,21 @@
+import sqlite3
+
+import numpy as np
+
+from app.core.memory import Memory
+from app.core.self_check import self_check
+
+
+def test_correct_answer_produces_no_report(tmp_path, monkeypatch):
+    def fake_embed(texts, model="nomic-embed-text"):
+        return [np.array([1.0])]
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+    mem = Memory(tmp_path / "mem.db")
+
+    report = self_check("2 + 2 = 4", mem)
+    assert report is None
+
+    with sqlite3.connect(tmp_path / "mem.db") as con:
+        count = con.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+    assert count == 0


### PR DESCRIPTION
## Summary
- add arithmetic self-check helper that records a report only when expressions are incorrect
- test that a correct answer generates no report and leaves memory empty

## Testing
- `pytest tests/test_self_check.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb9d7907e48320be9dc4b932615681