### PR TITLE
test: add whitespace regression cases

### DIFF
--- a/tests/test_long_context.py
+++ b/tests/test_long_context.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from app.llm.client import Client
+from app.llm.client import Client, chunk_prompt
 
 
 @pytest.mark.parametrize("value", [0, -1])
@@ -11,4 +11,20 @@ def test_ctx_must_be_positive(value):
 
     with pytest.raises(ValueError):
         Client(ctx=value)
+
+
+def test_chunk_prompt_preserves_leading_space():
+    """Leading whitespace should not be stripped when chunking."""
+
+    prompt = " foo"
+    chunks = chunk_prompt(prompt, size=2)
+    assert chunks == [" f", "oo"]
+
+
+def test_chunk_prompt_preserves_trailing_space():
+    """Trailing whitespace should be kept in the final chunk."""
+
+    prompt = "foo "
+    chunks = chunk_prompt(prompt, size=2)
+    assert chunks == ["fo", "o "]
 


### PR DESCRIPTION
## Summary
- verify Client rejects non-positive ctx values
- ensure chunk_prompt retains leading and trailing whitespace

## Testing
- `pytest tests/test_long_context.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bba1ef76008320b5ee2275872c2174