### PR TITLE
Expand safe_eval numeric regex and add tests

### DIFF
--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -16,3 +16,11 @@ def test_safe_eval_prevents_code_execution(tmp_path, monkeypatch):
     # Attempt to execute arbitrary code via import should raise ValueError
     with pytest.raises(ValueError):
         safe_eval("__import__('os').system('echo unsafe')")
+
+
+def test_safe_eval_allows_signed_float():
+    assert safe_eval("+1.0") == 1.0
+
+
+def test_safe_eval_allows_scientific_notation():
+    assert safe_eval("1e-3") == 0.001


### PR DESCRIPTION
## Summary
- allow numeric regex to parse signed floats and scientific notation
- test safe_eval with +1.0 and 1e-3 inputs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bba178dd348320b686a2431ed2383e