### PR TITLE
test: add float tolerance cases to self check

### DIFF
--- a/tests/test_self_check.py
+++ b/tests/test_self_check.py
@@ -16,3 +16,28 @@ def test_safe_eval_prevents_code_execution(tmp_path, monkeypatch):
     # Attempt to execute arbitrary code via import should raise ValueError
     with pytest.raises(ValueError):
         safe_eval("__import__('os').system('echo unsafe')")
+
+
+@pytest.mark.parametrize(
+    "expr, expected",
+    [
+        ("0.1 + 0.2", 0.3),
+        ("1 / 3", 1 / 3),
+    ],
+)
+def test_safe_eval_handles_float_results(expr, expected):
+    """Ensure floating point math is evaluated with appropriate tolerance."""
+    assert abs(safe_eval(expr) - expected) < 1e-9
+
+
+@pytest.mark.parametrize(
+    "expr, wrong",
+    [
+        ("0.1 + 0.2", 0.3001),
+        ("1 / 3", 0.333),
+    ],
+)
+def test_safe_eval_detects_incorrect_float_results(expr, wrong):
+    """Incorrect answers should not match even within tight tolerance."""
+    result = safe_eval(expr)
+    assert abs(result - wrong) > 1e-5


### PR DESCRIPTION
## Summary
- add parametrized tests covering float addition and division in `safe_eval`
- verify both correct evaluations and detection of incorrect results using tolerances

## Testing
- `pytest tests/test_self_check.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bba17ee8d883209ded362028be0ced