### PR TITLE
Add reasoning chain for explicit memory

### DIFF
--- a/app/core/logging_setup.py
+++ b/app/core/logging_setup.py
@@ -8,7 +8,7 @@ import json
 from contextvars import ContextVar
 
 try:
-    import yaml
+    import yaml  # type: ignore[import-untyped]
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     yaml = None
 

--- a/app/core/memory.py
+++ b/app/core/memory.py
@@ -40,6 +40,16 @@ class Memory:
                 (kind, text, vec, time.time()),
             )
 
+    def last(self, kind: str) -> tuple[int, str] | None:
+        """Return the most recently added item for ``kind``."""
+
+        with sqlite3.connect(self.db_path) as con:
+            row = con.execute(
+                "SELECT id,text FROM items WHERE kind=? ORDER BY id DESC LIMIT 1",
+                (kind,),
+            ).fetchone()
+        return row if row is not None else None
+
     def summarize(self, kind: str, max_items: int) -> None:
         with sqlite3.connect(self.db_path) as con:
             c = con.cursor()
@@ -63,9 +73,7 @@ class Memory:
             )
         self.add(kind, summary)
 
-    def add_feedback(
-        self, kind: str, prompt: str, answer: str, rating: float
-    ) -> None:
+    def add_feedback(self, kind: str, prompt: str, answer: str, rating: float) -> None:
         """Persist a rated question/answer pair."""
         with sqlite3.connect(self.db_path) as con:
             c = con.cursor()

--- a/app/core/reasoning.py
+++ b/app/core/reasoning.py
@@ -1,0 +1,83 @@
+"""Utilities to record explicit reasoning steps.
+
+This module implements :class:`ReasoningChain`, a lightweight helper that
+collects reasoning steps during an interaction.  The chain can be persisted
+to :class:`~app.core.memory.Memory` for later inspection which
+provides a basic form of explicit reasoning and audit trail.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from app.core.memory import Memory
+
+
+@dataclass
+class ReasoningChain:
+    """Container storing a sequence of reasoning steps.
+
+    Examples
+    --------
+    >>> chain = ReasoningChain()
+    >>> chain.add("analyse input")
+    >>> chain.add("produce answer")
+    >>> chain.to_text()
+    'analyse input\nproduce answer'
+    """
+
+    steps: List[str] = field(default_factory=list)
+
+    def add(self, step: str) -> None:
+        """Append a new reasoning *step* to the chain."""
+
+        self.steps.append(step)
+
+    def clear(self) -> None:
+        """Remove all stored steps."""
+
+        self.steps.clear()
+
+    def to_text(self) -> str:
+        """Return the chain as a single string joined by newlines."""
+
+        return "\n".join(self.steps)
+
+    @classmethod
+    def from_text(cls, text: str) -> "ReasoningChain":
+        """Create a chain from ``text`` containing newline separated steps."""
+
+        steps = text.splitlines() if text else []
+        return cls(steps)
+
+    def save(self, mem: Memory, kind: str = "reasoning") -> None:
+        """Persist the reasoning chain to *mem* using ``Memory.add``.
+
+        Parameters
+        ----------
+        mem:
+            Memory instance where the chain should be stored.
+        kind:
+            ``kind`` value used when saving to memory.  Defaults to
+            ``"reasoning"``.
+        """
+
+        if self.steps:
+            mem.add(kind, self.to_text())
+
+    @classmethod
+    def from_memory(cls, mem: Memory, kind: str = "reasoning") -> "ReasoningChain":
+        """Load the most recent reasoning chain of *kind* from *mem*.
+
+        If no chain is stored, an empty :class:`ReasoningChain` is returned.
+        """
+
+        item = mem.last(kind)
+        if item is None:
+            return cls()
+        _id, text = item
+        return cls.from_text(text)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.steps)

--- a/app/data/validation.py
+++ b/app/data/validation.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """Utilities for validating dataset structure."""
+
+from __future__ import annotations
 
 from pathlib import Path
 

--- a/tests/dummy_plugin.py
+++ b/tests/dummy_plugin.py
@@ -1,8 +1,10 @@
 """Dummy plugin used in tests."""
 
+# mypy: ignore-errors
+
+
 class DummyPlugin:
     """Simple plugin returning a marker message."""
 
     def run(self) -> str:  # pragma: no cover - trivial
         return "dummy plugin loaded"
-

--- a/tests/test_reasoning_chain.py
+++ b/tests/test_reasoning_chain.py
@@ -1,0 +1,42 @@
+import sqlite3
+import numpy as np
+
+from app.core.memory import Memory
+from app.core.engine import Engine
+from app.core.critic import Critic
+from app.core.reasoning import ReasoningChain
+
+
+def test_chat_records_reasoning(tmp_path, monkeypatch):
+    """Engine.chat should append reasoning steps and persist them when provided."""
+
+    def fake_embed(texts, model="nomic-embed-text"):
+        return [np.array([1.0])]
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+    monkeypatch.setattr(Memory, "search", lambda self, q, top_k=8: [])
+    monkeypatch.setattr(Critic, "suggest", lambda self, prompt: [])
+
+    class DummyClient:
+        def generate(self, prompt: str) -> tuple[str, str]:
+            return "pong", "dummy-trace"
+
+    eng = Engine.__new__(Engine)
+    eng.mem = Memory(tmp_path / "mem.db")
+    eng.client = DummyClient()
+    eng.critic = Critic()
+
+    chain = ReasoningChain()
+    answer = eng.chat("ping", reasoning=chain)
+
+    assert answer == "pong"
+    assert chain.steps[0].startswith("prompt: ping")
+    assert chain.steps[-1].startswith("answer: pong")
+
+    with sqlite3.connect(tmp_path / "mem.db") as con:
+        rows = con.execute("SELECT kind,text FROM items ORDER BY id").fetchall()
+
+    assert ("reasoning", chain.to_text()) in rows
+
+    loaded = ReasoningChain.from_memory(eng.mem)
+    assert loaded.steps == chain.steps

--- a/tests/test_trace_logging.py
+++ b/tests/test_trace_logging.py
@@ -1,5 +1,4 @@
 import numpy as np
-import numpy as np
 import sqlite3
 
 from app.core.memory import Memory


### PR DESCRIPTION
## Summary
- track explicit reasoning steps with new `ReasoningChain`
- allow `Engine.chat` to log reasoning chains to memory
- load saved reasoning traces via `Memory.last` and `ReasoningChain.from_memory`
- ignore missing yaml type stubs and package tests to silence mypy

## Testing
- `ruff check .`
- `black --check app/core/reasoning.py app/core/engine.py app/core/memory.py app/data/validation.py app/core/logging_setup.py tests/test_reasoning_chain.py tests/test_trace_logging.py tests/dummy_plugin.py tests/__init__.py`
- `mypy .` *(fails: function of unknown type; union-attr; assignment; missing stubs)*
- `bandit -q -r .` *(command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc0f1314d48320b34ceaee06e6b47c