### PR TITLE
feat: add reproducibility utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ semgrep --quiet --error --config config/semgrep.yml .
 pytest -q
 ```
 
+## Reproductibilité
+
+Un utilitaire `set_seed` permet de fixer la graine aléatoire pour Python,
+NumPy et, si disponible, PyTorch. Le fichier de configuration `config/settings.toml`
+contient un paramètre `seed` dans la section `[training]` qui peut être adapté
+pour garantir des exécutions déterministes.
+
 ## Données
 
 Les jeux de données localisés dans `datasets/raw` et `datasets/processed` sont

--- a/app/core/reproducibility.py
+++ b/app/core/reproducibility.py
@@ -1,0 +1,40 @@
+"""Utilities for controlling randomness across the project."""
+
+from __future__ import annotations
+
+import os
+import random
+
+try:  # NumPy is optional
+    import numpy as np
+except Exception:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
+
+
+def set_seed(seed: int) -> None:
+    """Seed Python, NumPy and other libraries for reproducibility.
+
+    The function configures the :mod:`random` module, ``PYTHONHASHSEED``
+    environment variable and, when available, NumPy and PyTorch. It ignores
+    missing optional dependencies so that callers can always invoke it without
+    guarding import errors.
+
+    Parameters
+    ----------
+    seed:
+        The deterministic seed value used for all RNGs.
+    """
+
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    if np is not None and hasattr(np, "random") and hasattr(np.random, "seed"):
+        np.random.seed(seed)  # type: ignore[attr-defined]
+    try:  # pragma: no cover - PyTorch may not be installed
+        import torch  # type: ignore[import-not-found]
+
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        torch.backends.cudnn.deterministic = True
+        torch.backends.cudnn.benchmark = False
+    except Exception:  # pragma: no cover - optional dependency
+        pass

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -50,6 +50,7 @@ transform = "app.data.pipeline.transform_data"
 [training]
 epochs = 10
 batch_size = 32
+seed = 42
 
 [model]
 name = "default"

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import random
+
+from app.core.reproducibility import set_seed
+
+try:  # NumPy may be a lightweight stub without RNG support
+    import numpy as np
+
+    HAS_NUMPY_RNG = hasattr(np, "random") and hasattr(np.random, "rand")
+except Exception:  # pragma: no cover - optional dependency
+    np = None  # type: ignore[assignment]
+    HAS_NUMPY_RNG = False
+
+
+def test_set_seed_reproducible():
+    set_seed(123)
+    py_vals = [random.random() for _ in range(3)]
+    if HAS_NUMPY_RNG:
+        np_vals = np.random.rand(3)
+
+    set_seed(123)
+    assert py_vals == [random.random() for _ in range(3)]
+    if HAS_NUMPY_RNG:
+        assert np.allclose(np_vals, np.random.rand(3))


### PR DESCRIPTION
## Summary
- add `set_seed` helper seeding Python, NumPy and optionally PyTorch
- document and configure training seed via `settings.toml`
- test deterministic behavior of RNG seeding

## Testing
- `ruff check .`
- `black --check app/core/reproducibility.py tests/test_reproducibility.py`
- `mypy app/core/reproducibility.py tests/test_reproducibility.py`
- `bandit -q -r .` *(fails: command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc3f673b3c8320b607655658fa1b61