### PR TITLE
Add modular preprocessing and domain-specific scrapers

### DIFF
--- a/app/data/preprocess/__init__.py
+++ b/app/data/preprocess/__init__.py
@@ -1,0 +1,12 @@
+"""Preprocessing utilities for text data.
+
+This subpackage provides simple text cleaning and tokenization steps that can be
+composed into data pipelines. Each module exposes a callable implementing the
+:class:`~app.data.pipeline.PipelineStep` protocol so that they can be referenced
+from configuration files.
+"""
+
+from .cleaning import HtmlCleaner
+from .tokenizer import SimpleTokenizer
+
+__all__ = ["HtmlCleaner", "SimpleTokenizer"]

--- a/app/data/preprocess/cleaning.py
+++ b/app/data/preprocess/cleaning.py
@@ -1,0 +1,36 @@
+"""Text cleaning helpers.
+
+The :class:`HtmlCleaner` class removes basic HTML markup and normalises
+whitespace. It implements the :class:`~app.data.pipeline.PipelineStep`
+protocol, making it suitable for use in :func:`app.data.pipeline.run_pipeline`.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class HtmlCleaner:
+    """Strip HTML tags and collapse whitespace in text."""
+
+    def __call__(self, data: Any) -> str:
+        """Return *data* with HTML tags removed.
+
+        Parameters
+        ----------
+        data:
+            Text to clean. Non-string inputs are converted to ``str``.
+        """
+
+        text = str(data)
+        logger.debug("cleaning text of length %d", len(text))
+        # Remove HTML tags
+        text = re.sub(r"<[^>]+>", "", text)
+        # Collapse repeated whitespace
+        text = re.sub(r"\s+", " ", text).strip()
+        logger.debug("cleaned text -> %s", text)
+        return text

--- a/app/data/preprocess/tokenizer.py
+++ b/app/data/preprocess/tokenizer.py
@@ -1,0 +1,28 @@
+"""Tokenisation utilities."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, List
+
+logger = logging.getLogger(__name__)
+
+
+class SimpleTokenizer:
+    """Split text into lowercase word tokens."""
+
+    def __call__(self, data: Any) -> List[str]:
+        """Tokenise *data* and return a list of words.
+
+        Parameters
+        ----------
+        data:
+            Text to tokenise. Non-string inputs are converted to ``str``.
+        """
+
+        text = str(data)
+        logger.debug("tokenising text of length %d", len(text))
+        tokens = re.findall(r"\w+", text.lower())
+        logger.debug("generated %d tokens", len(tokens))
+        return tokens

--- a/app/data/scrapers/__init__.py
+++ b/app/data/scrapers/__init__.py
@@ -1,0 +1,11 @@
+"""Specialised scraping helpers.
+
+This package defines high level wrappers around :mod:`app.data.scraper` for
+collecting domain specific texts. The functions are intentionally lightweight so
+that they can be easily swapped or extended.
+"""
+
+from .french import fetch_french_corpus
+from .programming import fetch_programming_docs
+
+__all__ = ["fetch_french_corpus", "fetch_programming_docs"]

--- a/app/data/scrapers/french.py
+++ b/app/data/scrapers/french.py
@@ -1,0 +1,35 @@
+"""Helpers for scraping French text sources."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Dict, Iterable
+
+from ..scraper import scrape_all
+
+# Default small set of French pages under permissive licences. These are merely
+# examples and can be replaced or extended by configuration.
+DEFAULT_URLS = {
+    "https://www.gutenberg.org/cache/epub/2000/pg2000.html",  # Les Misérables
+}
+
+
+async def _async_fetch(urls: Iterable[str], cache_dir: Path) -> Dict[str, str]:
+    return await scrape_all(urls, cache_dir)
+
+
+def fetch_french_corpus(urls: Iterable[str] | None, cache_dir: Path) -> Dict[str, str]:
+    """Retrieve French texts from *urls*.
+
+    Parameters
+    ----------
+    urls:
+        Iterable of URLs to download. When ``None`` the :data:`DEFAULT_URLS`
+        collection is used.
+    cache_dir:
+        Directory where responses are cached.
+    """
+
+    urls = urls or DEFAULT_URLS
+    return asyncio.run(_async_fetch(urls, cache_dir))

--- a/app/data/scrapers/programming.py
+++ b/app/data/scrapers/programming.py
@@ -1,0 +1,35 @@
+"""Helpers for scraping programming documentation."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Dict, Iterable
+
+from ..scraper import scrape_all
+
+# Default documentation pages in English; chosen for permissive licences and
+# short size. These URLs are placeholders and can be adjusted.
+DEFAULT_URLS = {
+    "https://docs.python.org/3/",  # Python documentation index
+}
+
+
+async def _async_fetch(urls: Iterable[str], cache_dir: Path) -> Dict[str, str]:
+    return await scrape_all(urls, cache_dir)
+
+
+def fetch_programming_docs(urls: Iterable[str] | None, cache_dir: Path) -> Dict[str, str]:
+    """Download programming documentation pages.
+
+    Parameters
+    ----------
+    urls:
+        Iterable of URLs to download. When ``None`` the :data:`DEFAULT_URLS`
+        collection is used.
+    cache_dir:
+        Directory where responses are cached.
+    """
+
+    urls = urls or DEFAULT_URLS
+    return asyncio.run(_async_fetch(urls, cache_dir))

--- a/tests/test_domain_scrapers.py
+++ b/tests/test_domain_scrapers.py
@@ -1,0 +1,29 @@
+import app.data.scrapers.french as fr
+import app.data.scrapers.programming as prog
+
+
+def test_french_defaults(monkeypatch, tmp_path):
+    called = {}
+
+    async def fake(urls, cache_dir, *, concurrency=5):
+        called["urls"] = set(urls)
+        return {u: "ok" for u in urls}
+
+    monkeypatch.setattr(fr, "scrape_all", fake)
+    result = fr.fetch_french_corpus(None, tmp_path)
+    assert called["urls"] == fr.DEFAULT_URLS
+    assert result == {u: "ok" for u in fr.DEFAULT_URLS}
+
+
+def test_programming_custom_urls(monkeypatch, tmp_path):
+    urls = ["https://example.com"]
+    captured = {}
+
+    async def fake(urls, cache_dir, *, concurrency=5):
+        captured["urls"] = list(urls)
+        return {u: "ok" for u in urls}
+
+    monkeypatch.setattr(prog, "scrape_all", fake)
+    result = prog.fetch_programming_docs(urls, tmp_path)
+    assert captured["urls"] == urls
+    assert result == {u: "ok" for u in urls}

--- a/tests/test_preprocess_steps.py
+++ b/tests/test_preprocess_steps.py
@@ -1,0 +1,29 @@
+from app.data import pipeline as dp
+from app.data.preprocess import HtmlCleaner, SimpleTokenizer
+
+
+def fake_config(section=None):
+    if section == "data":
+        return {
+            "steps": {
+                "clean": "app.data.preprocess.cleaning.HtmlCleaner",
+                "tokenize": "app.data.preprocess.tokenizer.SimpleTokenizer",
+            }
+        }
+    return {}
+
+
+def test_cleaner_and_tokenizer(monkeypatch):
+    monkeypatch.setattr(dp, "load_config", fake_config)
+    text = "<p>Hello world!</p>"
+    result = dp.run_pipeline(text)
+    assert result == ["hello", "world"]
+
+
+def test_modules_callable():
+    cleaner = HtmlCleaner()
+    tokenizer = SimpleTokenizer()
+    cleaned = cleaner("<b>Salut\n monde</b>")
+    assert cleaned == "Salut monde"
+    tokens = tokenizer(cleaned)
+    assert tokens == ["salut", "monde"]


### PR DESCRIPTION
## Summary
- introduce text preprocessing helpers `HtmlCleaner` and `SimpleTokenizer` for pipeline-based data cleaning and tokenization
- add lightweight scrapers for French corpora and programming documentation with default URL sets
- cover new utilities with targeted tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc4bab0014832096d25a70c8bf5daf