### PR TITLE
feat: validate raw data files

### DIFF
--- a/app/core/pipeline.py
+++ b/app/core/pipeline.py
@@ -2,12 +2,29 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable, List
+import logging
 
 
 def load_raw_data(path: str | Path) -> list[str]:
-    """Read *path* and return non-empty stripped lines."""
+    """Read *path* and return non-empty stripped lines.
+
+    The function validates that *path* exists and points to a text file with a
+    ``.txt`` extension before attempting to read it. Clear log messages are
+    emitted when the file is missing or has an unexpected format.
+    """
+
     p = Path(path)
-    text = p.read_text(encoding="utf-8").splitlines()
+    if not p.exists():
+        logging.error("raw data file '%s' does not exist", p)
+        raise FileNotFoundError(p)
+    if not p.is_file() or p.suffix.lower() != ".txt":
+        logging.error("raw data file '%s' has unsupported format", p)
+        raise ValueError(f"unsupported file format: {p}")
+    try:
+        text = p.read_text(encoding="utf-8").splitlines()
+    except Exception as exc:  # pragma: no cover - defensive
+        logging.exception("failed to read raw data file '%s'", p)
+        raise exc
     return [line.strip() for line in text if line.strip()]
 
 

--- a/app/data/scrapers/programming.py
+++ b/app/data/scrapers/programming.py
@@ -19,7 +19,9 @@ async def _async_fetch(urls: Iterable[str], cache_dir: Path) -> Dict[str, str]:
     return await scrape_all(urls, cache_dir)
 
 
-def fetch_programming_docs(urls: Iterable[str] | None, cache_dir: Path) -> Dict[str, str]:
+def fetch_programming_docs(
+    urls: Iterable[str] | None, cache_dir: Path
+) -> Dict[str, str]:
     """Download programming documentation pages.
 
     Parameters

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.core.pipeline import load_raw_data, transform_data
 
 
@@ -5,6 +7,21 @@ def test_load_raw_data(tmp_path):
     file = tmp_path / "numbers.txt"
     file.write_text("1\n2\n\n3\n", encoding="utf-8")
     assert load_raw_data(file) == ["1", "2", "3"]
+
+
+def test_load_raw_data_missing_file(tmp_path, caplog):
+    missing = tmp_path / "absent.txt"
+    with pytest.raises(FileNotFoundError):
+        load_raw_data(missing)
+    assert "does not exist" in caplog.text
+
+
+def test_load_raw_data_invalid_format(tmp_path, caplog):
+    bad = tmp_path / "numbers.json"
+    bad.write_text("1\n2", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_raw_data(bad)
+    assert "unsupported format" in caplog.text
 
 
 def test_transform_data(tmp_path):


### PR DESCRIPTION
## Summary
- add existence and format validation to core pipeline `load_raw_data`
- cover error cases for missing or invalid files with new tests
- format programming scraper to satisfy project style

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `bandit -q -r .` *(fails: command not found; installation blocked)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(fails: command not found; installation blocked)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc4d6cc14083208a5573445751f7c4