### PR TITLE
feat: normalize data and validate raw files

### DIFF
--- a/app/data/pipeline.py
+++ b/app/data/pipeline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import json
 import logging
 import time
+import statistics
 from dataclasses import dataclass
 from importlib import import_module
 from typing import Any, Callable, Protocol, runtime_checkable
@@ -18,26 +19,81 @@ PROCESSED_DIR = BASE_DIR / "datasets" / "processed"
 
 
 def load_raw_data(path: Path | str | None = None) -> dict:
-    """Load raw data from ``datasets/raw``.
+    """Load and validate raw data from ``datasets/raw``.
 
-    Parameters
-    ----------
-    path:
-        Optional path to a JSON file. If not provided, ``RAW_DIR / 'data.json'``
-        is used.
-
-    Returns
-    -------
-    dict
-        The parsed JSON content. An empty dictionary is returned when the file
-        does not exist.
+    The function ensures the file exists and uses a ``.json`` extension before
+    reading it. Clear log messages are emitted for missing files, unsupported
+    formats and malformed JSON content.
     """
+
     p = Path(path) if path else RAW_DIR / "data.json"
+    if not p.exists():
+        logging.error("raw data file '%s' does not exist", p)
+        raise FileNotFoundError(p)
+    if p.suffix.lower() != ".json":
+        logging.error("raw data file '%s' has unsupported format", p)
+        raise ValueError(f"unsupported file format: {p}")
     try:
         with p.open("r", encoding="utf-8") as fh:
             return json.load(fh)
-    except FileNotFoundError:
-        return {}
+    except json.JSONDecodeError as exc:
+        logging.exception("raw data file '%s' contains invalid JSON", p)
+        raise exc
+
+
+def _remove_numeric_outliers(
+    values: list[float], threshold: float = 3.5
+) -> list[float]:
+    """Return *values* stripped of statistical outliers.
+
+    Uses the median absolute deviation (MAD) method with a configurable
+    *threshold*. Values whose modified z-score exceeds the threshold are
+    considered outliers and removed.
+    """
+
+    if len(values) < 2:
+        return values
+    median = statistics.median(values)
+    mad = statistics.median([abs(x - median) for x in values])
+    if mad == 0:
+        return values
+    result: list[float] = []
+    for x in values:
+        z = 0.6745 * (x - median) / mad
+        if abs(z) <= threshold:
+            result.append(x)
+    return result
+
+
+def normalize_data(data: dict) -> dict:
+    """Normalize *data* values and remove duplicates/outliers.
+
+    - Strings are stripped of surrounding whitespace.
+    - Lists are deduplicated while preserving order.
+    - Numerical lists additionally have statistical outliers removed.
+    """
+
+    normalized: dict = {}
+    for key, value in data.items():
+        if isinstance(value, str):
+            normalized[key] = value.strip()
+            continue
+        if isinstance(value, list):
+            seen: set[Any] = set()
+            deduped: list[Any] = []
+            for item in value:
+                item_norm = item.strip() if isinstance(item, str) else item
+                if item_norm not in seen:
+                    seen.add(item_norm)
+                    deduped.append(item_norm)
+            if deduped and all(isinstance(x, (int, float)) for x in deduped):
+                cleaned = _remove_numeric_outliers([float(x) for x in deduped])
+                normalized[key] = [int(x) if x.is_integer() else x for x in cleaned]
+            else:
+                normalized[key] = deduped
+            continue
+        normalized[key] = value
+    return normalized
 
 
 def clean_data(data: dict) -> dict:

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -44,6 +44,7 @@ path = "data"
 
 [data.steps]
 load = "app.data.pipeline.load_raw_data"
+normalize = "app.data.pipeline.normalize_data"
 clean = "app.data.pipeline.clean_data"
 transform = "app.data.pipeline.transform_data"
 

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -1,0 +1,34 @@
+import json
+import pytest
+from app.data.pipeline import load_raw_data, normalize_data
+
+
+def test_normalize_data_dedup_and_outliers():
+    data = {"nums": [1, 2, 2, 1000], "text": "  hi  ", "dup": ["a", "a", "b"]}
+    result = normalize_data(data)
+    assert result["text"] == "hi"
+    assert result["dup"] == ["a", "b"]
+    assert result["nums"] == [1, 2]
+
+
+def test_load_raw_data_missing_file(tmp_path, caplog):
+    missing = tmp_path / "data.json"
+    with pytest.raises(FileNotFoundError):
+        load_raw_data(missing)
+    assert "does not exist" in caplog.text
+
+
+def test_load_raw_data_invalid_format(tmp_path, caplog):
+    bad = tmp_path / "data.txt"
+    bad.write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_raw_data(bad)
+    assert "unsupported format" in caplog.text
+
+
+def test_load_raw_data_invalid_json(tmp_path, caplog):
+    bad = tmp_path / "data.json"
+    bad.write_text("{bad}", encoding="utf-8")
+    with pytest.raises(json.JSONDecodeError):
+        load_raw_data(bad)
+    assert "invalid JSON" in caplog.text


### PR DESCRIPTION
## Summary
- validate JSON raw data files with clear errors
- normalize and deduplicate data with numeric outlier removal
- cover normalization and loader errors in tests

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `bandit -q -r .` *(fails: command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc502c369083208e2e9b5fffac413a