### PR TITLE
chore: add makefile and ci integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install black ruff pytest mypy bandit semgrep dvc
-      - name: Lint
-        run: ruff check .
-      - name: Format check
-        run: black --check .
-      - name: Type check
-        run: mypy .
-      - name: Bandit
-        run: bandit -q -r .
-      - name: Semgrep
-        run: semgrep --quiet --error --config config/semgrep.yml .
       - name: Sync data
         run: dvc pull
         continue-on-error: true
-      - name: Tests
-        run: pytest -q
+      - name: Run checks
+        run: make check
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+.RECIPEPREFIX := >
+.PHONY: format lint type security test check
+
+format:
+> black .
+
+lint:
+> ruff check .
+> black --check .
+
+type:
+> mypy .
+
+security:
+> bandit -q -r .
+> semgrep --quiet --error --config config/semgrep.yml .
+
+test:
+> pytest -q
+
+check: lint type security test
+

--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ python -m app.ui.main
 Exécuter les vérifications locales avant de proposer du code :
 
 ```bash
+make check
+```
+
+Les commandes exécutées par `make check` sont :
+
+```bash
 ruff check .
 black --check .
 mypy .


### PR DESCRIPTION
## Summary
- add Makefile to consolidate linting, type checks, security scans, and tests
- streamline CI workflow to use the Makefile
- document unified `make check` command in README

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `bandit -q -r .` *(fails: command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc518dd9748320911598bbfc86dd4a