### PR TITLE
chore: ignore win32job import in mypy

### DIFF
--- a/app/core/sandbox.py
+++ b/app/core/sandbox.py
@@ -27,7 +27,7 @@ def run(
 
     if sys.platform == "win32":
         import subprocess
-        import win32job  # type: ignore[import-not-found]
+        import win32job
 
         result: dict[str, bool | int | str | None] = {
             "code": None,

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,3 +5,6 @@ ignore_errors = True
 
 [mypy-app.core.critic]
 ignore_errors = True
+
+[mypy-win32job]
+ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- configure mypy to ignore missing win32job stubs
- remove inline ignore from sandbox import

## Testing
- `mypy app`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc9da884b08320b009072b6f9af6bd