### PR TITLE
doc: clarify Windows sandbox handle usage

### DIFF
--- a/app/core/sandbox.py
+++ b/app/core/sandbox.py
@@ -28,6 +28,7 @@ def run(
     if sys.platform == "win32":
         import subprocess
         import win32job  # type: ignore[import-not-found]
+        from typing import Any, cast
 
         result: dict[str, bool | int | str | None] = {
             "code": None,
@@ -64,7 +65,11 @@ def run(
             text=True,
             creationflags=creation_flags,
         )
-        win32job.AssignProcessToJobObject(job, p._handle)
+        # Access the private ``_handle`` attribute to integrate with the
+        # Windows Job API. ``subprocess.Popen`` exposes this handle only via
+        # a non-public attribute; we cast to ``Any`` and silence the type
+        # checker to acknowledge this dependency on CPython internals.
+        win32job.AssignProcessToJobObject(job, cast(Any, p)._handle)  # type: ignore[attr-defined]
         try:
             out, err = p.communicate(timeout=timeout)
         except subprocess.TimeoutExpired:


### PR DESCRIPTION
## Summary
- document use of subprocess.Popen's private `_handle`
- cast to `Any` before assigning process handle to Windows job object

## Testing
- `pytest`
- `ruff check .`
- `mypy app`


------
https://chatgpt.com/codex/tasks/task_e_68bc9da9882c8320b5b635bbd8348c5f