### PR TITLE
Ignore win32job type stubs in mypy configuration

### DIFF
--- a/app/core/sandbox.py
+++ b/app/core/sandbox.py
@@ -36,7 +36,7 @@ def run(
 
     if sys.platform == "win32":
         import subprocess
-        import win32job  # type: ignore[import-not-found]
+        import win32job
         import win32con  # type: ignore[import-not-found]
         from win32api import CloseHandle, OpenProcess  # type: ignore[import-not-found]
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -6,5 +6,5 @@ ignore_errors = True
 [mypy-app.core.critic]
 ignore_errors = True
 
-[mypy-win32job]
+[mypy-win32job.*]
 ignore_missing_imports = True


### PR DESCRIPTION
## Summary
- ensure mypy ignores missing win32job stubs
- tidy sandbox by removing inline ignore

## Testing
- `pytest`
- `mypy app/core/sandbox.py`


------
https://chatgpt.com/codex/tasks/task_e_68bca31cabcc8320ba6cab0ce1713de6