### PR TITLE
Annotate private process handle for Windows sandbox

### DIFF
--- a/app/core/sandbox.py
+++ b/app/core/sandbox.py
@@ -65,10 +65,11 @@ def run(
             text=True,
             creationflags=creation_flags,
         )
-        # ``AssignProcessToJobObject`` attend un handle de processus. Python
-        # n'expose ce handle que via l'attribut privé ``_handle`` de
-        # ``subprocess.Popen``.
-        # Le ``cast`` évite les erreurs mypy liées à cet attribut privé.
+        # ``AssignProcessToJobObject`` attend un handle de processus.
+        # Python n'expose pas publiquement ce handle : l'attribut privé
+        # ``_handle`` de ``subprocess.Popen`` est la seule façon de l'obtenir.
+        # L'utiliser évite un appel séparé à ``OpenProcess``/``CloseHandle``, et
+        # le ``cast`` informe mypy de l'usage de cet attribut privé.
         win32job.AssignProcessToJobObject(
             job, cast(Any, p)._handle
         )  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- use subprocess.Popen private handle with `cast` for job object assignment on Windows
- document why accessing `_handle` is required for `AssignProcessToJobObject`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca31d797c8320baa27f0a076029d2