### PR TITLE
Allow configurable politeness keywords

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -55,3 +55,14 @@ seed = 42
 
 [model]
 name = "default"
+
+[critic]
+polite_keywords = [
+    "please",
+    "thank you",
+    "merci",
+    "s'il vous plaît",
+    "s'il vous plait",
+    "bonjour",
+    "salut",
+]

--- a/tests/test_critic.py
+++ b/tests/test_critic.py
@@ -34,3 +34,9 @@ def test_suggest_returns_identifiers():
     assert "detail" in suggestions
     assert "politeness" in suggestions
     assert isinstance(suggestions, list)
+
+
+def test_custom_keywords_override_default():
+    critic = Critic(polite_keywords=("hola",))
+    result = critic.evaluate("hola amigo")
+    assert result["scores"]["politeness"] == 1.0

--- a/tests/test_critic_suggestions.py
+++ b/tests/test_critic_suggestions.py
@@ -4,7 +4,13 @@ from app.core.critic import Critic
 
 
 @pytest.mark.parametrize(
-    "text", ["Merci pour votre aide", "S'il vous plaît, pourriez-vous aider?"]
+    "text",
+    [
+        "Merci pour votre aide",
+        "S'il vous plaît, pourriez-vous aider?",
+        "Bonjour, comment allez-vous?",
+        "Salut, comment ça va?",
+    ],
 )
 def test_french_politeness(text):
     critic = Critic()


### PR DESCRIPTION
## Summary
- make Critic polite keyword list configurable via `settings.toml`
- recognize common greetings like "bonjour" and "salut"
- extend tests for new keywords and custom overrides

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd974c2e6c8320b025a54f9701bfb3