### PR TITLE
Exclude non-code directories from Bandit scans

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ type:
 > mypy .
 
 security:
-> bandit -q -r .
+> bandit -q -r . -c bandit.yml
 > semgrep --quiet --error --config config/semgrep.yml .
 
 test:

--- a/README.md
+++ b/README.md
@@ -41,10 +41,14 @@ Les commandes exécutées par `make check` sont :
 ruff check .
 black --check .
 mypy .
-bandit -q -r .
+bandit -q -r . -c bandit.yml
 semgrep --quiet --error --config config/semgrep.yml .
 pytest -q
 ```
+
+La configuration `bandit.yml` exclut notamment les répertoires `.git`, `datasets`,
+`.venv`, `build`, `dist` et `*.egg-info` afin d'éviter l'analyse de contenus
+non pertinents.
 
 ## Reproductibilité
 

--- a/bandit.yml
+++ b/bandit.yml
@@ -1,4 +1,6 @@
 exclude:
+  - .git
+  - datasets
   - .venv
   - build
   - dist


### PR DESCRIPTION
## Summary
- ignore `.git` and `datasets` directories in Bandit config
- run Bandit with explicit config in Makefile
- document excluded directories in README

## Testing
- `make lint`
- `make type`
- `pytest -q`
- `make security` *(fails: bandit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd974e6b548320b91ac15d3d65c4bc