### PR TITLE
Use UTC-aware timestamps in logging

### DIFF
--- a/app/core/logging_setup.py
+++ b/app/core/logging_setup.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 import logging
 import logging.config
-from datetime import datetime
+import datetime
 import json
 from contextvars import ContextVar
 
@@ -29,7 +29,7 @@ class JSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting
         log_record = {
-            "timestamp": datetime.utcfromtimestamp(record.created).isoformat() + "Z",
+            "timestamp": datetime.datetime.fromtimestamp(record.created, tz=datetime.UTC).isoformat(),
             "level": record.levelname,
             "name": record.name,
             "message": record.getMessage(),


### PR DESCRIPTION
## Summary
- Use timezone-aware timestamps in JSON logging formatter to avoid manual 'Z' suffix
- Replace datetime utcfromtimestamp with datetime.fromtimestamp using UTC

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03f7362808320a9d4921ff8c06830