### PR TITLE
Use importlib resources for logging config

### DIFF
--- a/tests/test_structured_logs.py
+++ b/tests/test_structured_logs.py
@@ -5,18 +5,34 @@ import logging
 from app.core import logging_setup
 
 
-def test_logs_are_json(capfd):
+def _cleanup() -> None:
+    logging.shutdown()
+    logging.getLogger().handlers.clear()
+    if os.path.exists("watcher.log"):
+        os.remove("watcher.log")
+
+
+def test_logs_are_json(capfd, monkeypatch):
+    monkeypatch.delenv("LOGGING_CONFIG_PATH", raising=False)
     logging_setup.set_request_id("req-123")
     logging_setup.configure()
     logger = logging.getLogger("test")
     logger.info("hello world")
     out, err = capfd.readouterr()
-    logging.shutdown()
-    # clean up generated log file
-    if os.path.exists("watcher.log"):
-        os.remove("watcher.log")
+    _cleanup()
     data = json.loads(out.strip())
     assert data["message"] == "hello world"
     assert data["level"] == "INFO"
     assert data["request_id"] == "req-123"
     assert data["name"] == "test"
+
+
+def test_basic_logging_when_config_missing(capfd, monkeypatch):
+    monkeypatch.setenv("LOGGING_CONFIG_PATH", "missing.yml")
+    _cleanup()
+    logging_setup.configure()
+    logger = logging.getLogger("test")
+    logger.info("hello world")
+    out, err = capfd.readouterr()
+    _cleanup()
+    assert err.strip() == "INFO:test:hello world"


### PR DESCRIPTION
## Summary
- Load logging configuration via `importlib.resources` with optional `LOGGING_CONFIG_PATH` override
- Add tests ensuring logging falls back to basic config when YAML is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0963459848320834ba548284b3e65