### PR TITLE
feat: add SandboxResult dataclass for sandbox run

### DIFF
--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -9,19 +9,19 @@ from app.core import sandbox
 @pytest.mark.skipif(sys.platform.startswith("win"), reason="non-Windows only")
 def test_run_unix_executes_command():
     result = sandbox.run(["python", "-c", "print('hi')"])
-    assert result["code"] == 0
-    assert result["out"].strip() == "hi"
-    assert result["timeout"] is False
-    assert result["cpu_exceeded"] is False
-    assert result["memory_exceeded"] is False
+    assert result.code == 0
+    assert result.out.strip() == "hi"
+    assert result.timeout is False
+    assert result.cpu_exceeded is False
+    assert result.memory_exceeded is False
 
 
 # Skip Windows test when not running on Windows
 @pytest.mark.skipif(not sys.platform.startswith("win"), reason="Windows only")
 def test_run_windows_executes_command():
     result = sandbox.run(["python", "-c", "print('hi')"])
-    assert result["code"] == 0
-    assert result["out"].strip() == "hi"
-    assert result["timeout"] is False
-    assert result["cpu_exceeded"] is False
-    assert result["memory_exceeded"] is False
+    assert result.code == 0
+    assert result.out.strip() == "hi"
+    assert result.timeout is False
+    assert result.cpu_exceeded is False
+    assert result.memory_exceeded is False


### PR DESCRIPTION
## Summary
- add `SandboxResult` dataclass to encapsulate sandbox execution results
- adjust `sandbox.run` to return `SandboxResult`
- update sandbox tests for new result structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09636781883208507b76da4bc3894