### PR TITLE
Format logging_setup with black

### DIFF
--- a/app/core/logging_setup.py
+++ b/app/core/logging_setup.py
@@ -29,7 +29,9 @@ class JSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting
         log_record = {
-            "timestamp": datetime.datetime.fromtimestamp(record.created, tz=datetime.UTC).isoformat(),
+            "timestamp": datetime.datetime.fromtimestamp(
+                record.created, tz=datetime.UTC
+            ).isoformat(),
             "level": record.levelname,
             "name": record.name,
             "message": record.getMessage(),


### PR DESCRIPTION
## Summary
- Format logging_setup for consistent style

## Testing
- `black --check app/core/logging_setup.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0963742b8832081f19721b30fe74a