### PR TITLE
feat: make autograder dataset path configurable

### DIFF
--- a/app/core/autograder.py
+++ b/app/core/autograder.py
@@ -1,9 +1,30 @@
+import os
 import pathlib
 import subprocess
 import time
+from importlib import resources
 
 
-DATASETS = pathlib.Path(__file__).resolve().parents[2] / "datasets" / "python"
+def _datasets_path() -> pathlib.Path:
+    """Return the path to the datasets directory.
+
+    If the environment variable ``WATCHER_DATASETS`` is set, its value is used.
+    Otherwise we attempt to resolve the datasets location via
+    :mod:`importlib.resources`.  This makes the path configurable while still
+    supporting a sensible default.
+    """
+
+    env_path = os.environ.get("WATCHER_DATASETS")
+    if env_path:
+        return pathlib.Path(env_path)
+
+    try:
+        return pathlib.Path(resources.files("datasets") / "python")
+    except ModuleNotFoundError:
+        return pathlib.Path(__file__).resolve().parents[2] / "datasets" / "python"
+
+
+DATASETS = _datasets_path()
 
 
 def _run_pytest(task_dir: pathlib.Path, timeout: int = 60) -> dict:
@@ -29,12 +50,14 @@ def _run_pytest(task_dir: pathlib.Path, timeout: int = 60) -> dict:
     }
 
 
-def list_tasks() -> list[pathlib.Path]:
-    return [d for d in DATASETS.iterdir() if d.is_dir()]
+def list_tasks(path: pathlib.Path | None = None) -> list[pathlib.Path]:
+    base = path or _datasets_path()
+    return [d for d in base.iterdir() if d.is_dir()]
 
 
-def grade_task(name: str) -> dict:
-    task = DATASETS / name
+def grade_task(name: str, path: pathlib.Path | None = None) -> dict:
+    datasets = path or _datasets_path()
+    task = datasets / name
     if not task.exists():
         return {"ok": False, "error": f"task {name} not found"}
     rep = _run_pytest(task)

--- a/tests/test_autograder_paths.py
+++ b/tests/test_autograder_paths.py
@@ -1,0 +1,24 @@
+from app.core import autograder
+
+
+def test_list_tasks_default():
+    tasks = {p.name for p in autograder.list_tasks()}
+    assert {"fib", "fizzbuzz", "is_prime"}.issubset(tasks)
+
+
+def test_custom_dataset_path(monkeypatch, tmp_path):
+    custom = tmp_path / "custom"
+    # create tasks
+    for name in ["alpha", "beta"]:
+        tests_dir = custom / name / "tests"
+        tests_dir.mkdir(parents=True)
+        (tests_dir / f"test_{name}.py").write_text("def test_ok():\n    assert True\n")
+
+    monkeypatch.setenv("WATCHER_DATASETS", str(custom))
+
+    tasks = {p.name for p in autograder.list_tasks()}
+    assert tasks == {"alpha", "beta"}
+
+    result = autograder.grade_task("alpha")
+    assert result["ok"]
+


### PR DESCRIPTION
## Summary
- allow overriding autograder dataset path via `WATCHER_DATASETS` env variable
- resolve default dataset location with `importlib.resources`
- add tests covering default and custom dataset paths

## Testing
- `pytest`
- `pytest tests/test_autograder_paths.py`


------
https://chatgpt.com/codex/tasks/task_e_68c09637e6cc83209fe7728220e8c24a