### PR TITLE
chore: ignore environment and log artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,22 @@
+# Byte-compiled / cache
 __pycache__/
 *.pyc
+.pytest_cache/
+.mypy_cache/
+
+# Virtual environments
+.venv/
+
+# Environment variables
+*.env
+
+# Logs
+*.log
+
+# DVC
 .dvc/tmp/
 .dvc/cache/
+
+# Data
 data/
 memory/

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurit
    pip install black ruff pytest mypy bandit semgrep
    ```
 
-   Sur Windows, le script `installer.ps1` installe automatiquement toutes ces dépendances.
+    Sur Windows, le script `installer.ps1` installe automatiquement toutes ces dépendances.
+
+Les fichiers d'environnement (`*.env`), les journaux (`*.log`) et les environnements virtuels (`.venv/`) sont ignorés par Git afin d'éviter la mise en version de données sensibles ou temporaires.
 
 ## Utilisation
 

--- a/app/core/logging_setup.py
+++ b/app/core/logging_setup.py
@@ -29,7 +29,9 @@ class JSONFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting
         log_record = {
-            "timestamp": datetime.datetime.fromtimestamp(record.created, tz=datetime.UTC).isoformat(),
+            "timestamp": datetime.datetime.fromtimestamp(
+                record.created, tz=datetime.UTC
+            ).isoformat(),
             "level": record.levelname,
             "name": record.name,
             "message": record.getMessage(),


### PR DESCRIPTION
## Summary
- ignore virtual environments, environment files, logs, and caches
- document ignored artifacts in README
- format logging setup to satisfy style checks

## Testing
- `make check` *(fails: bandit: No such file or directory)*
- `pip install bandit semgrep` *(fails: Could not find a version that satisfies the requirement bandit)*

------
https://chatgpt.com/codex/tasks/task_e_68c09638b12c83209218e103b0f93c06