### PR TITLE
Use CommandResult for quality gate results

### DIFF
--- a/app/core/evaluator.py
+++ b/app/core/evaluator.py
@@ -1,9 +1,16 @@
 import subprocess
+from typing import TypedDict
+
+
+class CommandResult(TypedDict):
+    ok: bool
+    out: str
+    err: str
 
 
 class QualityGate:
-    def run_all(self) -> dict:
-        results = {
+    def run_all(self) -> dict[str, CommandResult]:
+        results: dict[str, CommandResult] = {
             "pytest": self._cmd(["pytest", "-q"]),
             "ruff": self._cmd(["ruff", "."]),
             "black": self._cmd(["black", "--check", "."]),
@@ -20,10 +27,9 @@ class QualityGate:
                 ]
             ),
         }
-        ok = all(r["ok"] for r in results.values())
-        return {"ok": ok, "results": results}
+        return results
 
-    def _cmd(self, args: list[str]) -> dict:
+    def _cmd(self, args: list[str]) -> CommandResult:
         try:
             p = subprocess.run(args, capture_output=True, text=True, timeout=60)
             return {

--- a/tests/test_learner_context.py
+++ b/tests/test_learner_context.py
@@ -25,7 +25,7 @@ def _setup_engine(tmp_path, monkeypatch):
 
     class DummyQG:
         def run_all(self):
-            return {"ok": True, "results": {}}
+            return {"pytest": {"ok": True, "out": "", "err": ""}}
 
     eng.qg = DummyQG()
 

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -21,7 +21,7 @@ def _setup_engine(tmp_path, monkeypatch, calls):
     class DummyQG:
         def run_all(self):
             calls.append("run_all")
-            return {"ok": True, "results": {}}
+            return {"pytest": {"ok": True, "out": "", "err": ""}}
 
     class DummyLearner:
         def compare(self, a, b):


### PR DESCRIPTION
## Summary
- add `CommandResult` TypedDict with `ok`, `out`, and `err`
- refactor quality gate to return `CommandResult` values
- adjust tests to work with new quality gate interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09639b9bc8320926a815fcc6b24f1