### PR TITLE
Ensure autograder uses importlib.resources path resolution

### DIFF
--- a/tests/test_autograder_paths.py
+++ b/tests/test_autograder_paths.py
@@ -1,3 +1,5 @@
+from contextlib import ExitStack
+
 from app.core import autograder
 
 
@@ -21,4 +23,43 @@ def test_custom_dataset_path(monkeypatch, tmp_path):
 
     result = autograder.grade_task("alpha")
     assert result["ok"]
+
+
+def test_datasets_path_env(monkeypatch, tmp_path):
+    custom = tmp_path / "ds"
+    monkeypatch.setenv("WATCHER_DATASETS", str(custom))
+
+    def fail_files(_):  # resources.files should not be called
+        raise AssertionError("files called")
+
+    monkeypatch.setattr(autograder.resources, "files", fail_files)
+
+    path = autograder._datasets_path()
+    assert path == custom
+
+
+def test_datasets_path_importlib(monkeypatch, tmp_path):
+    monkeypatch.delenv("WATCHER_DATASETS", raising=False)
+    called = {}
+
+    def fake_files(name: str):
+        assert name == "datasets"
+        return tmp_path
+
+    class DummyCtx:
+        def __enter__(self):
+            called["as_file"] = True
+            return tmp_path
+
+        def __exit__(self, *exc):
+            pass
+
+    monkeypatch.setattr(autograder.resources, "files", fake_files)
+    monkeypatch.setattr(autograder.resources, "as_file", lambda obj: DummyCtx())
+    monkeypatch.setattr(autograder, "_DATASETS", None)
+    monkeypatch.setattr(autograder, "_STACK", ExitStack())
+    (tmp_path / "python").mkdir()
+    path = autograder._datasets_path()
+    assert called.get("as_file")
+    assert path == tmp_path / "python"
 


### PR DESCRIPTION
## Summary
- resolve datasets directory using `importlib.resources.as_file` with a persistent context
- support `WATCHER_DATASETS` override when provided
- test autograder dataset path resolution with and without environment variable

## Testing
- `pytest tests/test_autograder_paths.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09ac8126483209bc91e323a7242c4