### PR TITLE
Handle specific TOML errors when loading config

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
+import logging
 import os
 import tomllib
 
@@ -20,12 +21,19 @@ REQUIRED_SECTIONS = {
 }
 
 
+logger = logging.getLogger(__name__)
+
+
 def _read_toml(path: Path) -> dict[str, Any]:
     try:
         with path.open("rb") as fh:
             return tomllib.load(fh)
-    except Exception:
+    except FileNotFoundError:
+        logger.error("Configuration file not found: %s", path)
         return {}
+    except tomllib.TOMLDecodeError as exc:
+        logger.error("Invalid TOML in %s: %s", path, exc)
+        raise
 
 
 def _deep_update(base: dict[str, Any], other: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_config_invalid_toml.py
+++ b/tests/test_config_invalid_toml.py
@@ -1,0 +1,14 @@
+import logging
+import tomllib
+import pytest
+
+from config import _read_toml
+
+
+def test_invalid_toml_logs_and_raises(tmp_path, caplog):
+    invalid = tmp_path / "bad.toml"
+    invalid.write_text("invalid = [")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(tomllib.TOMLDecodeError):
+            _read_toml(invalid)
+    assert "Invalid TOML" in caplog.text


### PR DESCRIPTION
## Summary
- avoid blanket exception in config loader
- log and return empty dict only when configuration file is missing
- add regression test for invalid TOML

## Testing
- `pytest tests/test_config_profiles.py tests/test_config.py tests/test_config_invalid_toml.py`

------
https://chatgpt.com/codex/tasks/task_e_68c0ab25de688320b2ed8d71e47af449