### PR TITLE
Ensure autograder stack closes at exit

### DIFF
--- a/app/core/autograder.py
+++ b/app/core/autograder.py
@@ -2,10 +2,12 @@ import os
 import pathlib
 import subprocess
 import time
+import atexit
 from contextlib import ExitStack
 from importlib import resources
 
 _STACK = ExitStack()
+atexit.register(_STACK.close)
 _DATASETS: pathlib.Path | None = None
 
 

--- a/tests/test_autograder_atexit.py
+++ b/tests/test_autograder_atexit.py
@@ -1,0 +1,29 @@
+import subprocess
+import sys
+import pathlib
+
+
+def test_exit_stack_closed(tmp_path):
+    marker = tmp_path / "marker.txt"
+    root = pathlib.Path(__file__).resolve().parents[1]
+    script = tmp_path / "script.py"
+    script.write_text(
+        f"""
+import sys, pathlib
+sys.path.insert(0, {str(root)!r})
+from app.core import autograder
+
+class DummyCtx:
+    def __init__(self, path):
+        self.path = pathlib.Path(path)
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        self.path.write_text("closed")
+
+autograder._STACK.enter_context(DummyCtx({str(marker)!r}))
+"""
+    )
+    subprocess.run([sys.executable, str(script)], check=True)
+    assert marker.read_text() == "closed"
+


### PR DESCRIPTION
## Summary
- Register autograder ExitStack with `atexit` to ensure cleanup on program termination
- Add regression test verifying the stack's close method is invoked when a script exits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0ab2680c4832091853b0882ea90f3