### PR TITLE
Enforce rating range in Engine.add_feedback

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -158,7 +158,28 @@ class Engine:
         return answer
 
     def add_feedback(self, rating: float, kind: str = "chat") -> str:
-        """Persist user feedback on the last exchange."""
+        """Persist user feedback on the last exchange.
+
+        Parameters
+        ----------
+        rating:
+            Score assigned by the user between ``0.0`` and ``1.0``.
+        kind:
+            Feedback category, defaults to ``"chat"``.
+
+        Returns
+        -------
+        str
+            Confirmation message or ``"no response to rate"`` when nothing was
+            rated.
+
+        Raises
+        ------
+        ValueError
+            If ``rating`` is outside the ``0.0``–``1.0`` interval.
+        """
+        if not 0.0 <= rating <= 1.0:
+            raise ValueError("rating must be between 0.0 and 1.0")
         if not self.last_prompt or not self.last_answer:
             return "no response to rate"
         self.mem.add_feedback(kind, self.last_prompt, self.last_answer, rating)

--- a/tests/test_engine_feedback.py
+++ b/tests/test_engine_feedback.py
@@ -1,0 +1,26 @@
+import pytest
+
+from app.core.engine import Engine
+from app.core.memory import Memory
+
+
+def _make_engine(tmp_path):
+    eng = Engine.__new__(Engine)
+    eng.mem = Memory(tmp_path / "mem.db")
+    eng.last_prompt = "question"
+    eng.last_answer = "answer"
+    return eng
+
+
+def test_add_feedback_accepts_valid_rating(tmp_path):
+    eng = _make_engine(tmp_path)
+    msg = eng.add_feedback(0.5)
+    assert msg == "feedback enregistré"
+    kind, prompt, answer, rating = eng.mem.all_feedback()[0]
+    assert (kind, prompt, answer, rating) == ("chat", "question", "answer", 0.5)
+
+
+def test_add_feedback_rejects_out_of_range_rating(tmp_path):
+    eng = _make_engine(tmp_path)
+    with pytest.raises(ValueError):
+        eng.add_feedback(1.5)


### PR DESCRIPTION
## Summary
- Validate `add_feedback` ratings fall within 0.0–1.0 and raise `ValueError` otherwise
- Document rating bounds for feedback persistence
- Test `add_feedback` with valid and out-of-range scores

## Testing
- `pytest tests/test_engine_feedback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0ab28a2f88320b9631bd06e53aaab