### PR TITLE
Add force overwrite option for CLI scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Sous Windows :
 python -m app.ui.main
 ```
 
+### Générer une CLI Python
+
+Un utilitaire `create_python_cli` (dans `app.tools.scaffold`) permet de
+générer un squelette de projet sous `app/projects/<nom>`. Passer
+`force=True` écrase les fichiers existants sans demande de confirmation.
+
 ## Tests & Qualité
 
 Exécuter les vérifications locales avant de proposer du code :

--- a/app/tools/scaffold.py
+++ b/app/tools/scaffold.py
@@ -19,11 +19,17 @@ def _confirm_overwrite(path: Path) -> bool:
     return resp.strip().lower() in {"y", "yes", "o", "oui"}
 
 
-def create_python_cli(name: str, base: Path):
+def create_python_cli(name: str, base: Path, force: bool = False) -> str:
+    """Create a minimal Python CLI project.
+
+    Existing files are overwritten when ``force`` is ``True``.
+    """
+
     proj = base / "app" / "projects" / name
     if proj.exists() and any(proj.iterdir()):
-        if not _confirm_overwrite(proj):
-            raise FileExistsError(f"Dossier {proj} non vide")
+        if not force:
+            if not _confirm_overwrite(proj):
+                raise FileExistsError(f"Dossier {proj} non vide")
 
     (proj / name).mkdir(parents=True, exist_ok=True)
     (proj / "tests").mkdir(parents=True, exist_ok=True)

--- a/tests/test_autograder_paths.py
+++ b/tests/test_autograder_paths.py
@@ -62,4 +62,3 @@ def test_datasets_path_importlib(monkeypatch, tmp_path):
     path = autograder._datasets_path()
     assert called.get("as_file")
     assert path == tmp_path / "python"
-

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,10 +20,27 @@ def test_create_python_cli(tmp_path, capsys):
     assert capsys.readouterr().out.strip() == "pong"
 
 
-def test_create_python_cli_refuses_overwrite(tmp_path):
+def test_create_python_cli_refuses_overwrite_without_force(tmp_path):
     proj_dir = tmp_path / "app" / "projects" / "foo"
     proj_dir.mkdir(parents=True)
     (proj_dir / "existing.txt").write_text("content", encoding="utf-8")
 
     with pytest.raises(FileExistsError):
         create_python_cli("foo", tmp_path)
+
+
+def test_create_python_cli_force_overwrite(tmp_path, capsys):
+    proj_dir = tmp_path / "app" / "projects" / "foo"
+    (proj_dir / "foo").mkdir(parents=True)
+    (proj_dir / "foo/cli.py").write_text("print('old')\n", encoding="utf-8")
+
+    proj_dir = Path(create_python_cli("foo", tmp_path, force=True))
+    sys.path.insert(0, str(proj_dir))
+    argv = sys.argv
+    sys.argv = ["foo", "--ping"]
+    try:
+        runpy.run_module("foo.cli", run_name="__main__")
+    finally:
+        sys.argv = argv
+        sys.path.pop(0)
+    assert capsys.readouterr().out.strip() == "pong"


### PR DESCRIPTION
## Summary
- allow `create_python_cli` to force overwriting existing projects
- document `force` flag and add tests for normal and forced modes

## Testing
- `make check` *(fails: bandit missing, install blocked)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c0ab2998f0832095e38154737d1695