### PR TITLE
Validate chunk size in LLM prompt chunking

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -59,7 +59,8 @@ def generate_ollama(prompt: str, *, host: str, model: str) -> str:
 
 def chunk_prompt(prompt: str, *, size: int = 1000) -> list[str]:
     """Yield slices of *prompt* of at most *size* characters."""
-
+    if size <= 0:
+        raise ValueError("size must be a positive integer")
     return [prompt[i : i + size] for i in range(0, len(prompt), size)]
 
 

--- a/tests/test_chunk_prompt.py
+++ b/tests/test_chunk_prompt.py
@@ -1,0 +1,9 @@
+import pytest
+
+from app.llm.client import chunk_prompt
+
+
+@pytest.mark.parametrize("size", [0, -1])
+def test_chunk_prompt_invalid_size(size: int) -> None:
+    with pytest.raises(ValueError, match="positive"):
+        chunk_prompt("hello", size=size)


### PR DESCRIPTION
## Summary
- enforce positive size parameter in `chunk_prompt` and raise a clear `ValueError`
- add unit tests verifying non-positive sizes are rejected

## Testing
- `pytest tests/test_client.py tests/test_chunk_prompt.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12b7b92788320b57a8b5e091eff08