### PR TITLE
Exclude Git metadata from Bandit scans

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -6,3 +6,11 @@
 2. Enter a prompt and press **Envoyer**.
 3. The button disables while the response is generated.
 4. The interface remains responsive and the button re-enables once the reply appears.
+
+## Static Analysis
+
+Run Bandit to scan the codebase while ignoring Git metadata:
+
+```
+bandit -q -r . -c bandit.yml
+```

--- a/bandit.yml
+++ b/bandit.yml
@@ -1,5 +1,5 @@
 exclude:
-  - .git
+  - .git          # ignore Git metadata
   - datasets
   - .venv
   - build


### PR DESCRIPTION
## Summary
- clarify Bandit config to skip the `.git` directory
- document Bandit usage in QA notes

## Testing
- `bandit -q -r . -c bandit.yml` *(fails: bandit: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c13ac38f98832098c520b84a07a669