### PR TITLE
Use importlib.resources.as_file for dataset paths

### DIFF
--- a/app/core/autograder.py
+++ b/app/core/autograder.py
@@ -27,7 +27,8 @@ def _datasets_path() -> pathlib.Path:
     global _DATASETS
     if _DATASETS is None:
         try:
-            root = _STACK.enter_context(resources.as_file(resources.files("datasets")))
+            ctx = resources.as_file(resources.files("datasets"))
+            root = _STACK.enter_context(ctx)
             candidate = root / "python"
             if candidate.exists():
                 _DATASETS = candidate

--- a/tests/test_autograder_paths.py
+++ b/tests/test_autograder_paths.py
@@ -62,3 +62,19 @@ def test_datasets_path_importlib(monkeypatch, tmp_path):
     path = autograder._datasets_path()
     assert called.get("as_file")
     assert path == tmp_path / "python"
+
+
+def test_datasets_path_resolution(monkeypatch, tmp_path):
+    """Ensure _datasets_path uses env var when set and defaults otherwise."""
+    custom = tmp_path / "custom"
+    monkeypatch.setenv("WATCHER_DATASETS", str(custom))
+    monkeypatch.setattr(autograder, "_DATASETS", None)
+    monkeypatch.setattr(autograder, "_STACK", ExitStack())
+    assert autograder._datasets_path() == custom
+
+    monkeypatch.delenv("WATCHER_DATASETS", raising=False)
+    monkeypatch.setattr(autograder, "_DATASETS", None)
+    monkeypatch.setattr(autograder, "_STACK", ExitStack())
+    path = autograder._datasets_path()
+    assert path.name == "python"
+    assert path.parent.name == "datasets"


### PR DESCRIPTION
## Summary
- ensure autograder resolves dataset package via `importlib.resources.as_file`
- test dataset path resolution with and without `WATCHER_DATASETS`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c13ac1f0cc8320a2c9282e387bbdd6