### PR TITLE
docs: explain log configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ Semgrep utilise un fichier de règles local (`config/semgrep.yml`), aucun accès
 Watcher fonctionne hors ligne par défaut et n'envoie aucune donnée vers l'extérieur.
 Les journaux comme les contenus mémorisés restent sur l'environnement local et peuvent être effacés par l'utilisateur.
 
+## Configuration des logs
+
+Watcher peut charger une configuration de journalisation personnalisée depuis un fichier YAML. Définissez la variable d'environnement `LOGGING_CONFIG_PATH` pour indiquer le chemin du fichier :
+
+```bash
+export LOGGING_CONFIG_PATH=/chemin/vers/logging.yml
+```
+
+Si cette variable est absente ou que le fichier fourni est introuvable, le fichier `config/logging.yml` inclus dans le projet est utilisé. En dernier recours, Watcher applique la configuration basique de Python (`logging.basicConfig`) avec le niveau `INFO`.
+
 ## Éthique et traçabilité
 
 Les actions du système sont journalisées via le module standard `logging`. Les erreurs et décisions importantes sont ainsi consignées pour audit ou débogage.

--- a/tests/test_autograder_atexit.py
+++ b/tests/test_autograder_atexit.py
@@ -26,4 +26,3 @@ autograder._STACK.enter_context(DummyCtx({str(marker)!r}))
     )
     subprocess.run([sys.executable, str(script)], check=True)
     assert marker.read_text() == "closed"
-


### PR DESCRIPTION
## Summary
- document `LOGGING_CONFIG_PATH` in a new "Configuration des logs" section
- format test_autograder_atexit for black

## Testing
- `make check` *(fails: bandit: No such file or directory)*
- `ruff check .`
- `black --check .`
- `mypy .`
- `bandit -q -r . -c bandit.yml` *(fails: command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c143d311788320ba0759501c274855