### PR TITLE
Add tests for Windows sandbox with and without pywin32

### DIFF
--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 
 import pytest
 
@@ -22,6 +23,101 @@ def test_run_windows_executes_command():
     result = sandbox.run(["python", "-c", "print('hi')"])
     assert result.code == 0
     assert result.out.strip() == "hi"
+    assert result.timeout is False
+    assert result.cpu_exceeded is False
+    assert result.memory_exceeded is False
+
+
+def test_run_windows_without_pywin32(monkeypatch, caplog):
+    """Simule Windows sans pywin32 et vérifie l'avertissement."""
+    import builtins
+
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    real_import = builtins.__import__
+
+    def _mock_import(name, *args, **kwargs):
+        if name in {"win32con", "win32job", "win32api"}:
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _mock_import)
+
+    with caplog.at_level(logging.WARNING):
+        result = sandbox.run(["python", "-c", "print('hi')"])
+
+    assert isinstance(result, sandbox.SandboxResult)
+    assert result.code == 0
+    assert result.out.strip() == "hi"
+    assert result.err == ""
+    assert result.timeout is False
+    assert result.cpu_exceeded is False
+    assert result.memory_exceeded is False
+    assert "pywin32 introuvable" in caplog.text
+
+
+def test_run_windows_with_pywin32(monkeypatch, caplog):
+    """Simule Windows avec pywin32 pour vérifier la voie normale."""
+    import types
+
+    monkeypatch.setattr(sys, "platform", "win32")
+
+    import subprocess
+    monkeypatch.setattr(subprocess, "CREATE_NEW_CONSOLE", 0, raising=False)
+
+    win32con = types.ModuleType("win32con")
+    win32con.PROCESS_ALL_ACCESS = 0x1
+
+    win32api = types.ModuleType("win32api")
+
+    def _close_handle(handle: int) -> None:  # pragma: no cover - stub
+        return None
+
+    def _open_process(flags: int, inherit: bool, pid: int) -> int:  # pragma: no cover - stub
+        return 1
+
+    win32api.CloseHandle = _close_handle
+    win32api.OpenProcess = _open_process
+
+    win32job = types.ModuleType("win32job")
+
+    def _create_job_object(arg1, arg2):  # pragma: no cover - stub
+        return 1
+
+    def _query_information_job_object(job, info_class):  # pragma: no cover - stub
+        if info_class == win32job.JobObjectExtendedLimitInformation:
+            return {"BasicLimitInformation": {"LimitFlags": 0}}
+        if info_class == win32job.JobObjectLimitViolationInformation:
+            return {"LimitFlags": 0, "ViolationLimitFlags": 0}
+        return {}
+
+    def _set_information_job_object(job, info_class, info):  # pragma: no cover - stub
+        return None
+
+    def _assign_process_to_job_object(job, handle):  # pragma: no cover - stub
+        return None
+
+    win32job.CreateJobObject = _create_job_object
+    win32job.QueryInformationJobObject = _query_information_job_object
+    win32job.SetInformationJobObject = _set_information_job_object
+    win32job.AssignProcessToJobObject = _assign_process_to_job_object
+    win32job.JobObjectExtendedLimitInformation = 1
+    win32job.JobObjectLimitViolationInformation = 2
+    win32job.JOB_OBJECT_LIMIT_PROCESS_TIME = 0x1
+    win32job.JOB_OBJECT_LIMIT_PROCESS_MEMORY = 0x2
+
+    monkeypatch.setitem(sys.modules, "win32con", win32con)
+    monkeypatch.setitem(sys.modules, "win32api", win32api)
+    monkeypatch.setitem(sys.modules, "win32job", win32job)
+
+    with caplog.at_level(logging.WARNING):
+        result = sandbox.run(["python", "-c", "print('hi')"])
+
+    assert "pywin32 introuvable" not in caplog.text
+    assert isinstance(result, sandbox.SandboxResult)
+    assert result.code == 0
+    assert result.out.strip() == "hi"
+    assert result.err == ""
     assert result.timeout is False
     assert result.cpu_exceeded is False
     assert result.memory_exceeded is False


### PR DESCRIPTION
## Summary
- add test simulating Windows without pywin32 that checks warning and result
- add test simulating Windows with pywin32 stubs to ensure normal execution

## Testing
- `pytest tests/test_sandbox.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c143d45ab08320890807f362796174