### PR TITLE
Log warning when embeddings backend unreachable

### DIFF
--- a/app/tools/embeddings.py
+++ b/app/tools/embeddings.py
@@ -7,11 +7,15 @@ disables vector search but allows the application to continue running.
 
 import http.client
 import json
+import logging
 from urllib.parse import urlparse
 
 from app.utils import np
 
 from config import load_config
+
+
+logger = logging.getLogger(__name__)
 
 
 def embed_ollama(
@@ -69,7 +73,8 @@ def embed_ollama(
             raise RuntimeError(f"Embedding request failed: {resp.status}")
         data = json.loads(resp.read())
         return [np.array(v, dtype=np.float32) for v in data["embeddings"]]
-    except Exception:  # pragma: no cover - network
+    except Exception as exc:  # pragma: no cover - network
+        logger.warning("Embedding backend unreachable: %s", exc)
         return [np.zeros(1, dtype=np.float32) for _ in texts]
     finally:
         if conn is not None:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -1,3 +1,5 @@
+import logging
+
 from app.tools.embeddings import embed_ollama
 
 
@@ -11,6 +13,16 @@ def test_embed_ollama_connection_error(monkeypatch):
     assert len(vecs[0]) == 1
     assert vecs[0].shape == (1,)
     assert vecs[0][0] == 0.0
+
+
+def test_embed_ollama_logs_warning(monkeypatch, caplog):
+    def bad_conn(*args, **kwargs):
+        raise OSError("fail")
+
+    monkeypatch.setattr("http.client.HTTPConnection", bad_conn)
+    with caplog.at_level(logging.WARNING):
+        embed_ollama(["hello"], host="1.2.3.4:5678")
+    assert "fail" in caplog.text
 
 
 def test_embed_ollama_host_argument(monkeypatch):


### PR DESCRIPTION
## Summary
- warn via module logger when embedding backend can't be reached
- add unit test to ensure warning is emitted

## Testing
- `pytest tests/test_embeddings.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d0e19b708320950a4d497eea7d44