### PR TITLE
Add name validation for scaffolded projects

### DIFF
--- a/app/tools/scaffold.py
+++ b/app/tools/scaffold.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import re
 import textwrap
 
 
@@ -19,11 +20,18 @@ def _confirm_overwrite(path: Path) -> bool:
     return resp.strip().lower() in {"y", "yes", "o", "oui"}
 
 
+_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
 def create_python_cli(name: str, base: Path, force: bool = False) -> str:
     """Create a minimal Python CLI project.
 
-    Existing files are overwritten when ``force`` is ``True``.
+    ``name`` must match ``^[A-Za-z_][A-Za-z0-9_]*$``. Existing files are
+    overwritten when ``force`` is ``True``.
     """
+
+    if not _NAME_RE.fullmatch(name):
+        raise ValueError(f"Invalid project name: {name!r}")
 
     proj = base / "app" / "projects" / name
     if proj.exists() and any(proj.iterdir()):

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,0 +1,17 @@
+import pytest
+from pathlib import Path
+
+from app.tools.scaffold import create_python_cli
+
+
+@pytest.mark.parametrize("name", ["foo", "Bar", "baz_123", "_underscore"])
+def test_create_python_cli_accepts_valid_names(tmp_path, name):
+    proj_dir = Path(create_python_cli(name, tmp_path))
+    assert proj_dir.name == name
+    assert proj_dir.exists()
+
+
+@pytest.mark.parametrize("name", ["123abc", "bad-name", "bad name", "name!", ""])
+def test_create_python_cli_rejects_invalid_names(tmp_path, name):
+    with pytest.raises(ValueError):
+        create_python_cli(name, tmp_path)


### PR DESCRIPTION
## Summary
- validate CLI scaffold names using a safe regex
- test valid and invalid project names for the scaffold helper

## Testing
- `pytest tests/test_scaffold.py tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_e_68c5d0e387dc832088ed9c2bab8bff8e