### PR TITLE
Raise error for missing base settings file

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -71,13 +71,14 @@ def load_config(profile: str | None = None) -> dict[str, Any]:
     -------
     dict
         Parsed and validated configuration dictionary. If the base file cannot
-        be read an empty dictionary is returned.
+        be read a ``FileNotFoundError`` is raised.
     """
 
     base_path = Path(__file__).resolve().parent
-    cfg = _read_toml(base_path / "settings.toml")
+    cfg_path = base_path / "settings.toml"
+    cfg = _read_toml(cfg_path)
     if not cfg:
-        return {}
+        raise FileNotFoundError(f"Configuration file not found: {cfg_path}")
 
     profile = profile or os.getenv("WATCHER_PROFILE")
     if profile:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,11 +1,17 @@
-from app.config import load_config
+import pytest
+
+from config import load_config
+import config as cfg_module
 
 
-def test_load_existing_section():
-    cfg = load_config("llm")
-    assert cfg["model"] == "llama3.2:3b"
-    assert cfg["backend"] == "ollama"
+def test_load_existing_config():
+    cfg = load_config()
+    assert cfg["llm"]["model"] == "llama3.2:3b"
+    assert cfg["llm"]["backend"] == "ollama"
 
 
-def test_load_missing_section():
-    assert load_config("does_not_exist") == {}
+def test_missing_base_file(monkeypatch):
+    monkeypatch.setattr(cfg_module, "_read_toml", lambda path: {})
+    load_config.cache_clear()
+    with pytest.raises(FileNotFoundError):
+        load_config()


### PR DESCRIPTION
## Summary
- raise `FileNotFoundError` when base configuration file is missing
- update config loader tests to expect the error when no base file exists

## Testing
- `pytest tests/test_config.py tests/test_config_profiles.py tests/test_config_invalid_toml.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5d0e2b4a483209ec5410eb91bf803