### PR TITLE
Add name validation to scaffold tool

### DIFF
--- a/app/tools/scaffold.py
+++ b/app/tools/scaffold.py
@@ -23,6 +23,30 @@ def _confirm_overwrite(path: Path) -> bool:
 _NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
+def validate_name(name: str) -> str:
+    """Validate project names.
+
+    Parameters
+    ----------
+    name:
+        Proposed project name.
+
+    Returns
+    -------
+    str
+        The validated name.
+
+    Raises
+    ------
+    ValueError
+        If ``name`` does not match ``_NAME_RE``.
+    """
+
+    if not _NAME_RE.fullmatch(name):
+        raise ValueError(f"Invalid project name: {name!r}")
+    return name
+
+
 def create_python_cli(name: str, base: Path, force: bool = False) -> str:
     """Create a minimal Python CLI project.
 
@@ -30,8 +54,7 @@ def create_python_cli(name: str, base: Path, force: bool = False) -> str:
     overwritten when ``force`` is ``True``.
     """
 
-    if not _NAME_RE.fullmatch(name):
-        raise ValueError(f"Invalid project name: {name!r}")
+    validate_name(name)
 
     proj = base / "app" / "projects" / name
     if proj.exists() and any(proj.iterdir()):

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,7 +1,18 @@
 import pytest
 from pathlib import Path
 
-from app.tools.scaffold import create_python_cli
+from app.tools.scaffold import create_python_cli, validate_name
+
+
+@pytest.mark.parametrize("name", ["foo", "Bar", "baz_123", "_underscore"])
+def test_validate_name_accepts_valid(name):
+    assert validate_name(name) == name
+
+
+@pytest.mark.parametrize("name", ["123abc", "bad-name", "bad name", "name!", ""])
+def test_validate_name_rejects_invalid(name):
+    with pytest.raises(ValueError):
+        validate_name(name)
 
 
 @pytest.mark.parametrize("name", ["foo", "Bar", "baz_123", "_underscore"])


### PR DESCRIPTION
## Summary
- ensure scaffolded project names match a safe pattern
- add tests for valid and invalid project names

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6926e73448320b8f7403880c64c5a