### PR TITLE
perf: batch feedback retrieval for data pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Ajouté
 - Documentation de la feuille de route et du journal de bord.
+- Chargement en batch des retours mémoire et benchmark associé.
 ## [2025-09-14]
 ### Added
 - feat(20250914-114451): auto entry (#PR)

--- a/docs/journal/2025-09-19.md
+++ b/docs/journal/2025-09-19.md
@@ -1,0 +1,4 @@
+### 2025-09-19
+- **Fait** : optimisation du module de mémoire avec `iter_feedback` pour un chargement en batch et ajout d'un benchmark de pipeline.
+- **Décisions / blocages** : aucun.
+- **Prochaines étapes** : étendre le chargement en batch à d'autres tables si besoin.


### PR DESCRIPTION
## Summary
- add `iter_feedback` generator to `Memory` for batched DB reads
- use batched iterator in `Engine.auto_improve` to reduce DB load
- benchmark batched vs naive feedback loading

## Testing
- `pytest tests/test_data_pipeline.py tests/test_memory.py tests/test_learner_context.py tests/test_maintenance.py`

------
https://chatgpt.com/codex/tasks/task_e_68c6e7af67288320a9f9f6e13b43f997