### PR TITLE
feat: support plugin discovery via entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ Un utilitaire `create_python_cli` (dans `app.tools.scaffold`) permet de
 générer un squelette de projet sous `app/projects/<nom>`. Passer
 `force=True` écrase les fichiers existants sans demande de confirmation.
 
+## Plugins
+
+Watcher peut être étendu par des plugins implémentant l'interface
+`Plugin` définie dans `app/tools/plugins`. Deux mécanismes de
+découverte sont supportés :
+
+- déclaration explicite dans le fichier `plugins.toml` ;
+- [entry points](https://packaging.python.org/en/latest/specifications/entry-points/)
+  Python via le groupe `watcher.plugins`.
+
+Un exemple minimal est fourni dans `app/tools/plugins/hello.py`.
+
 ## Tests & Qualité
 
 Exécuter les vérifications locales avant de proposer du code :

--- a/app/tools/plugins/__init__.py
+++ b/app/tools/plugins/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+from importlib.metadata import entry_points
 from pathlib import Path
 from typing import Protocol
 
@@ -11,11 +12,38 @@ import tomllib
 
 
 class Plugin(Protocol):
-    """Simple plugin interface."""
+    """Simple plugin interface used by all Watcher extensions."""
+
+    name: str
 
     def run(self) -> str:  # pragma: no cover - interface definition
         """Execute the plugin and return a human readable message."""
         ...
+
+
+def load_entry_point_plugins(group: str = "watcher.plugins") -> list[Plugin]:
+    """Return plugins discovered via :mod:`importlib.metadata` entry points."""
+
+    plugins: list[Plugin] = []
+    try:
+        try:
+            eps = entry_points(group=group)
+        except TypeError:  # pragma: no cover - fallback for older Python
+            eps = entry_points().get(group, [])  # type: ignore[assignment]
+    except Exception:  # pragma: no cover - best effort
+        logging.exception("Failed to query entry points")
+        return plugins
+
+    for ep in eps:
+        try:
+            cls = ep.load()
+            plugin: Plugin = cls()
+            plugins.append(plugin)
+        except Exception:  # pragma: no cover - best effort
+            logging.exception(
+                "Failed to load entry point %s", getattr(ep, "name", "<unknown>")
+            )
+    return plugins
 
 
 def reload_plugins(base: Path | None = None) -> list[Plugin]:
@@ -33,29 +61,27 @@ def reload_plugins(base: Path | None = None) -> list[Plugin]:
 
     cfg = base / "plugins.toml"
     plugins: list[Plugin] = []
-    if not cfg.exists():
-        return plugins
-
-    try:
-        data = tomllib.loads(cfg.read_text(encoding="utf-8"))
-    except Exception:  # pragma: no cover - best effort
-        logging.exception("Invalid plugins.toml")
-        return plugins
-
-    for item in data.get("plugins", []):
-        path = item.get("path")
-        if not path:
-            continue
-        module_name, _, class_name = path.partition(":")
+    if cfg.exists():
         try:
-            module = importlib.import_module(module_name)
-            cls = getattr(module, class_name)
-            plugin: Plugin = cls()
-            plugins.append(plugin)
+            data = tomllib.loads(cfg.read_text(encoding="utf-8"))
         except Exception:  # pragma: no cover - best effort
-            logging.exception("Failed to load plugin %s", path)
+            logging.exception("Invalid plugins.toml")
+        else:
+            for item in data.get("plugins", []):
+                path = item.get("path")
+                if not path:
+                    continue
+                module_name, _, class_name = path.partition(":")
+                try:
+                    module = importlib.import_module(module_name)
+                    cls = getattr(module, class_name)
+                    plugin: Plugin = cls()
+                    plugins.append(plugin)
+                except Exception:  # pragma: no cover - best effort
+                    logging.exception("Failed to load plugin %s", path)
 
+    plugins.extend(load_entry_point_plugins())
     return plugins
 
 
-__all__ = ["Plugin", "reload_plugins"]
+__all__ = ["Plugin", "reload_plugins", "load_entry_point_plugins"]

--- a/app/tools/plugins/hello.py
+++ b/app/tools/plugins/hello.py
@@ -4,5 +4,7 @@
 class HelloPlugin:
     """Plugin de démonstration qui retourne un message de salutation."""
 
+    name = "hello"
+
     def run(self) -> str:
         return "Hello from plugin"

--- a/tests/dummy_plugin.py
+++ b/tests/dummy_plugin.py
@@ -4,5 +4,7 @@
 class DummyPlugin:
     """Simple plugin returning a marker message."""
 
+    name = "dummy"
+
     def run(self) -> str:  # pragma: no cover - trivial
         return "dummy plugin loaded"

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,4 +1,7 @@
+from importlib.metadata import EntryPoint
+
 from app.core.engine import Engine
+from app.tools import plugins
 from app.tools.plugins.hello import HelloPlugin
 
 
@@ -6,3 +9,26 @@ def test_hello_plugin_loaded_and_runs():
     engine = Engine()
     assert any(isinstance(p, HelloPlugin) for p in engine.plugins)
     assert "Hello from plugin" in engine.run_plugins()
+
+
+def test_entry_point_plugin_loaded(monkeypatch):
+    ep = EntryPoint(
+        name="hello_ep",
+        value="app.tools.plugins.hello:HelloPlugin",
+        group="watcher.plugins",
+    )
+
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [ep])
+    result = plugins.load_entry_point_plugins()
+    assert any(isinstance(p, HelloPlugin) for p in result)
+
+
+def test_entry_point_plugin_failure(monkeypatch):
+    class BrokenEP:
+        name = "broken"
+
+        def load(self):  # pragma: no cover - used to simulate failure
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [BrokenEP()])
+    assert plugins.load_entry_point_plugins() == []


### PR DESCRIPTION
## Summary
- extend plugin interface with `name` attribute
- add discovery of `watcher.plugins` entry points
- document plugin system and test loading and failure cases

## Testing
- `pytest tests/test_plugins.py tests/test_plugin_reload.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6e7b0b7848320b93bf3c2b1bb9f86