### PR TITLE
feat: integrate structured logging

### DIFF
--- a/app/core/logging_setup.py
+++ b/app/core/logging_setup.py
@@ -1,3 +1,5 @@
+"""Utilities to configure structured JSON logging for the application."""
+
 from pathlib import Path
 import logging
 import logging.config

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,23 @@
+# Conventions de logging
+
+Le projet utilise un logging structuré au format JSON pour toutes les sorties.
+
+## Configuration
+
+Le module `app.core.logging_setup` centralise la configuration du logging.
+Il lit un fichier YAML `config/logging.yml` ou la variable d'environnement
+`LOGGING_CONFIG_PATH`. Les messages sont enrichis d'un identifiant de requête
+(`request_id`) lorsqu'il est défini via `logging_setup.set_request_id()`.
+
+Pour activer le logging, appelez `logging_setup.configure()` au démarrage de
+votre script puis obtenez un logger avec `logging.getLogger(__name__)`.
+
+## Niveaux
+
+- `logger.info` pour les évènements ordinaires.
+- `logger.warning` pour les situations anormales ou les dégradations de
+  service.
+- `logger.error` ou `logger.exception` pour les erreurs.
+
+Les messages sont sérialisés en JSON et sont visibles sur la sortie standard
+ainsi que dans le fichier `watcher.log`.

--- a/train.py
+++ b/train.py
@@ -8,7 +8,10 @@ and prints the learned parameters and mean squared error.
 from __future__ import annotations
 
 import csv
+import logging
 from pathlib import Path
+
+from app.core import logging_setup
 
 DATA_PATH = Path("datasets/simple_linear.csv")
 
@@ -43,9 +46,11 @@ def train(
 
 
 def main() -> None:
+    logging_setup.configure()
+    logger = logging.getLogger(__name__)
     xs, ys = load_data()
     w, b, mse = train(xs, ys)
-    print(f"w={w:.3f}, b={b:.3f}, mse={mse:.4f}")
+    logger.info("w=%0.3f, b=%0.3f, mse=%0.4f", w, b, mse)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use central logging_setup to configure structured JSON logging
- replace print statements with structured logs
- document logging conventions

## Testing
- `pytest tests/test_structured_logs.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e7b151b88320b3b36d5f81f08b5b