### PR TITLE
Add performance metrics tracking

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -3,6 +3,8 @@
 ## Performance
 - **Temps de réponse moyen** : viser < 500 ms par requête.
   - *Mesure* : journaliser l'heure d'entrée et de sortie pour chaque requête puis calculer la moyenne.
+- **Temps du moteur, de la base de données et des plugins** : suivre la durée d'exécution de ces composants critiques et compter le nombre d'appels.
+  - *Mesure* : utiliser les context managers `track_engine`, `track_db` et `track_plugin` dans `app/utils/metrics.py` pour enregistrer la durée et incrémenter les compteurs.
 
 ## Qualité
 - **Couverture des tests** : maintenir ≥ 85 % de code exécuté pendant les tests unitaires.

--- a/app/utils/metrics.py
+++ b/app/utils/metrics.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 import logging
+import time
 from typing import List
 
 
@@ -14,6 +16,12 @@ class PerformanceMetrics:
     response_times: List[float] = field(default_factory=list)
     evaluation_scores: List[float] = field(default_factory=list)
     error_logs: List[str] = field(default_factory=list)
+    engine_calls: int = 0
+    db_calls: int = 0
+    plugin_calls: int = 0
+    engine_response_times: List[float] = field(default_factory=list)
+    db_response_times: List[float] = field(default_factory=list)
+    plugin_response_times: List[float] = field(default_factory=list)
 
     def log_response_time(self, duration: float) -> None:
         """Record a new response time measurement."""
@@ -30,6 +38,45 @@ class PerformanceMetrics:
 
         self.error_logs.append(message)
         logging.getLogger(__name__).error(message)
+
+    @contextmanager
+    def track_engine(self) -> None:
+        """Measure and log the duration of an engine call."""
+
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            duration = time.perf_counter() - start
+            self.engine_calls += 1
+            self.engine_response_times.append(duration)
+            self.log_response_time(duration)
+
+    @contextmanager
+    def track_db(self) -> None:
+        """Measure and log the duration of a database call."""
+
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            duration = time.perf_counter() - start
+            self.db_calls += 1
+            self.db_response_times.append(duration)
+            self.log_response_time(duration)
+
+    @contextmanager
+    def track_plugin(self) -> None:
+        """Measure and log the duration of a plugin execution."""
+
+        start = time.perf_counter()
+        try:
+            yield
+        finally:
+            duration = time.perf_counter() - start
+            self.plugin_calls += 1
+            self.plugin_response_times.append(duration)
+            self.log_response_time(duration)
 
 
 # Shared instance used across the application.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,5 @@
+import time
+
 from app.utils.metrics import PerformanceMetrics
 
 
@@ -9,3 +11,21 @@ def test_metrics_logging() -> None:
     assert pm.response_times == [0.5]
     assert pm.evaluation_scores == [0.8]
     assert pm.error_logs == ["oops"]
+
+
+def test_component_counters_increment() -> None:
+    pm = PerformanceMetrics()
+
+    with pm.track_engine():
+        time.sleep(0.01)
+    with pm.track_db():
+        time.sleep(0.01)
+    with pm.track_plugin():
+        time.sleep(0.01)
+
+    assert pm.engine_calls == 1
+    assert pm.db_calls == 1
+    assert pm.plugin_calls == 1
+    assert len(pm.engine_response_times) == 1
+    assert len(pm.db_response_times) == 1
+    assert len(pm.plugin_response_times) == 1


### PR DESCRIPTION
## Summary
- track engine, database, and plugin execution times via context managers
- record call counts and response times in performance metrics
- document and test the new metrics collectors

## Testing
- `pytest tests/test_metrics.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6e7b20e408320a0ca0a6c626635fd