### PR TITLE
docs: document quality targets and config test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Ajouté
 - Documentation de la feuille de route et du journal de bord.
+- Politique de qualité : couverture ≥90 % et linters `ruff`/`black` obligatoires.
 ## [2025-09-14]
 ### Added
 - feat(20250914-114451): auto entry (#PR)

--- a/QA.md
+++ b/QA.md
@@ -14,3 +14,8 @@ Run Bandit to scan the codebase while ignoring Git metadata:
 ```
 bandit -q -r . -c bandit.yml
 ```
+
+## Quality Targets
+
+- Maintain at least **90%** test coverage.
+- Enforce `ruff` and `black` checks on every commit.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ générer un squelette de projet sous `app/projects/<nom>`. Passer
 
 ## Tests & Qualité
 
+Watcher applique une politique de qualité stricte : au moins **90 %** de couverture de tests et les linters `ruff` et `black` sont obligatoires avant toute contribution.
+
 Exécuter les vérifications locales avant de proposer du code :
 
 ```bash

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,5 +1,6 @@
-from app.utils import np
+from pathlib import Path
 
+from app.utils import np
 from app.core.engine import Engine
 from app.core.memory import Memory
 
@@ -47,3 +48,11 @@ def test_auto_improve_runs_quality_when_missing(tmp_path, monkeypatch):
     eng = _setup_engine(tmp_path, monkeypatch, calls)
     eng.auto_improve()
     assert calls == ["run_all"]
+
+
+def test_quality_config_present():
+    pyproject = Path("pyproject.toml")
+    assert pyproject.is_file()
+    content = pyproject.read_text()
+    assert "[tool.black]" in content
+    assert "[tool.ruff]" in content


### PR DESCRIPTION
## Summary
- document quality targets in QA and README
- verify pyproject has black/ruff config
- note quality policy in changelog

## Testing
- `make check` *(fails: bandit: No such file or directory)*
- `pip install bandit semgrep` *(fails: Could not find a version that satisfies the requirement bandit)*
- `pytest tests/test_maintenance.py::test_quality_config_present -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6e7b35670832084ab61482c62a125