### PR TITLE
docs: add cache chat responses entry to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## [Unreleased]
 
-### Ajouté
+### Added
 - Documentation de la feuille de route et du journal de bord.
 - Chargement en batch des retours mémoire et benchmark associé.
+- Cache chat responses.
+
 ## [2025-09-14]
 ### Added
 - feat(20250914-114451): auto entry (#PR)


### PR DESCRIPTION
## Summary
- document cache chat responses in changelog
- normalize heading language to "Added" under Unreleased

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6eab65e508320b50a10ce71f0ece7