### PR TITLE
test: parse pyproject using tomllib

### DIFF
--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -1,7 +1,14 @@
+from pathlib import Path
+
 from app.utils import np
 
 from app.core.engine import Engine
 from app.core.memory import Memory
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python <3.11
+    import tomli as tomllib
 
 
 def _setup_engine(tmp_path, monkeypatch, calls):
@@ -47,3 +54,11 @@ def test_auto_improve_runs_quality_when_missing(tmp_path, monkeypatch):
     eng = _setup_engine(tmp_path, monkeypatch, calls)
     eng.auto_improve()
     assert calls == ["run_all"]
+
+
+def test_pyproject_has_black_and_ruff():
+    pyproject = Path("pyproject.toml")
+    config = tomllib.loads(pyproject.read_text())
+    assert "tool" in config
+    assert "black" in config["tool"]
+    assert "ruff" in config["tool"]


### PR DESCRIPTION
## Summary
- ensure maintenance tests parse `pyproject.toml` using tomllib
- verify `black` and `ruff` sections exist under `[tool]`

## Testing
- `pytest tests/test_maintenance.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ec0718548320a038041a738c7963