### PR TITLE
Add dev dependency file and update CI and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install black ruff pytest mypy bandit semgrep dvc
+          pip install -r requirements.txt -r requirements-dev.txt
       - name: Sync data
         run: dvc pull
         continue-on-error: true

--- a/QA.md
+++ b/QA.md
@@ -9,8 +9,20 @@
 
 ## Static Analysis
 
+Install the development dependencies:
+
+```
+pip install -r requirements-dev.txt
+```
+
 Run Bandit to scan the codebase while ignoring Git metadata:
 
 ```
 bandit -q -r . -c bandit.yml
+```
+
+Run Semgrep using the local ruleset:
+
+```
+semgrep --quiet --error --config config/semgrep.yml .
 ```

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurit
 4. Installer les outils de développement :
 
    ```bash
-   pip install black ruff pytest mypy bandit semgrep
+   pip install -r requirements-dev.txt
    ```
 
-    Sur Windows, le script `installer.ps1` installe automatiquement toutes ces dépendances.
+   Sur Windows, le script `installer.ps1` installe automatiquement toutes ces dépendances.
 
 Les fichiers d'environnement (`*.env`), les journaux (`*.log`) et les environnements virtuels (`.venv/`) sont ignorés par Git afin d'éviter la mise en version de données sensibles ou temporaires.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,7 @@
+black
+ruff
+pytest
+mypy
+bandit
+semgrep
+dvc


### PR DESCRIPTION
## Summary
- add development requirements file listing black, ruff, pytest, mypy, bandit, semgrep and dvc
- update CI workflow to install both regular and dev requirements
- document new dev dependency installation instructions in README and QA notes

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement bandit)*
- `make check` *(fails: would reformat app/core/memory.py)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ec05d81c832098a081dc89936822