### PR TITLE
feat: centralize logging and test structured errors

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -2,7 +2,6 @@
 
 from pathlib import Path
 import json
-import logging
 import time
 from itertools import chain
 from threading import Thread
@@ -24,6 +23,7 @@ from app.data import pipeline
 from app.data.validation import validate_feedback_schema
 from app.tools import plugins
 from app.utils.metrics import metrics
+from app.core.logging_setup import get_logger
 
 
 class Engine:
@@ -219,11 +219,11 @@ class Engine:
         try:
             qg_res = self.run_quality_gate()
         except Exception:  # pragma: no cover - best effort
-            logging.exception("run_quality_gate failed")
+            logger.exception("run_quality_gate failed")
         try:
             self.auto_improve(qg_res)
         except Exception:  # pragma: no cover - best effort
-            logging.exception("auto_improve failed")
+            logger.exception("auto_improve failed")
 
     def run_quality_gate(self) -> str:
         """Run static checks and tests, storing the result in memory."""
@@ -239,11 +239,11 @@ class Engine:
             validate_feedback_schema(raw)
             cleaned = pipeline.clean_data(raw)
             path = pipeline.transform_data(cleaned)
-            logging.info(
+            logger.info(
                 "data prepared in %.3fs -> %s", time.perf_counter() - start, path
             )
         except Exception:  # pragma: no cover - best effort
-            logging.exception("data preparation failed")
+            logger.exception("data preparation failed")
             return "data preparation failed"
         return str(path)
 
@@ -318,3 +318,4 @@ class Engine:
     def run_plugins(self) -> list[str]:
         """Execute all loaded plugins and return their outputs."""
         return [p.run() for p in self.plugins]
+logger = get_logger(__name__)

--- a/app/core/memory.py
+++ b/app/core/memory.py
@@ -1,6 +1,5 @@
 import sqlite3
 import time
-import logging
 import math
 from pathlib import Path
 from typing import Iterator
@@ -8,6 +7,10 @@ from typing import Iterator
 from app.utils import np
 
 from app.tools.embeddings import embed_ollama
+from app.core.logging_setup import get_logger
+
+
+logger = get_logger(__name__)
 
 
 class Memory:
@@ -35,7 +38,7 @@ class Memory:
             vec_arr = self._embed(text)
             vec = vec_arr.astype("float32").tobytes()
         except Exception:
-            logging.exception("Failed to embed text for kind '%s'", kind)
+            logger.exception("Failed to embed text for kind '%s'", kind)
             vec = np.array([], dtype=np.float32).tobytes()
         with sqlite3.connect(self.db_path) as con:
             c = con.cursor()
@@ -150,7 +153,7 @@ class Memory:
         try:
             q = self._embed(query, use_cache=False).astype("float32")
         except Exception:
-            logging.exception("Failed to embed search query")
+            logger.exception("Failed to embed search query")
             return []
         q_bytes = q.tobytes()
         with sqlite3.connect(self.db_path) as con:

--- a/app/core/pipeline.py
+++ b/app/core/pipeline.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Iterable, List
-import logging
+
+from app.core.logging_setup import get_logger
+
+
+logger = get_logger(__name__)
 
 
 def load_raw_data(path: str | Path) -> list[str]:
@@ -15,15 +19,15 @@ def load_raw_data(path: str | Path) -> list[str]:
 
     p = Path(path)
     if not p.exists():
-        logging.error("raw data file '%s' does not exist", p)
+        logger.error("raw data file '%s' does not exist", p)
         raise FileNotFoundError(p)
     if not p.is_file() or p.suffix.lower() != ".txt":
-        logging.error("raw data file '%s' has unsupported format", p)
+        logger.error("raw data file '%s' has unsupported format", p)
         raise ValueError(f"unsupported file format: {p}")
     try:
         text = p.read_text(encoding="utf-8").splitlines()
     except Exception as exc:  # pragma: no cover - defensive
-        logging.exception("failed to read raw data file '%s'", p)
+        logger.exception("failed to read raw data file '%s'", p)
         raise exc
     return [line.strip() for line in text if line.strip()]
 

--- a/app/core/reproducibility.py
+++ b/app/core/reproducibility.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
-import logging
 import os
 import random
 
 from app.utils import np
+from app.core.logging_setup import get_logger
+
+
+logger = get_logger(__name__)
 
 
 def set_seed(seed: int) -> None:
@@ -37,4 +40,4 @@ def set_seed(seed: int) -> None:
     except ImportError:  # pragma: no cover - optional dependency
         pass
     except Exception as exc:  # pragma: no cover - optional dependency
-        logging.warning("Failed to seed PyTorch deterministically: %s", exc)
+        logger.warning("Failed to seed PyTorch deterministically: %s", exc)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -4,13 +4,16 @@ Le projet utilise un logging structuré au format JSON pour toutes les sorties.
 
 ## Configuration
 
-Le module `app.core.logging_setup` centralise la configuration du logging.
-Il lit un fichier YAML `config/logging.yml` ou la variable d'environnement
-`LOGGING_CONFIG_PATH`. Les messages sont enrichis d'un identifiant de requête
-(`request_id`) lorsqu'il est défini via `logging_setup.set_request_id()`.
+Le module `app.core.logging_setup` centralise la configuration du logging et
+fournit un logger unique nommé ``watcher``.  Il lit un fichier YAML
+`config/logging.yml` ou la variable d'environnement `LOGGING_CONFIG_PATH`. Les
+messages sont enrichis d'un identifiant de requête (`request_id`) lorsqu'il est
+défini via `logging_setup.set_request_id()`.
 
 Pour activer le logging, appelez `logging_setup.configure()` au démarrage de
-votre script puis obtenez un logger avec `logging.getLogger(__name__)`.
+votre script puis obtenez un logger via `logging_setup.get_logger(__name__)`.
+Tous les loggers enfants ainsi créés propagent leurs messages vers le logger
+central ``watcher``.
 
 ## Niveaux
 

--- a/tests/test_structured_logs.py
+++ b/tests/test_structured_logs.py
@@ -16,7 +16,7 @@ def test_logs_are_json(capfd, monkeypatch):
     monkeypatch.delenv("LOGGING_CONFIG_PATH", raising=False)
     logging_setup.set_request_id("req-123")
     logging_setup.configure()
-    logger = logging.getLogger("test")
+    logger = logging_setup.get_logger("test")
     logger.info("hello world")
     out, err = capfd.readouterr()
     _cleanup()
@@ -24,15 +24,31 @@ def test_logs_are_json(capfd, monkeypatch):
     assert data["message"] == "hello world"
     assert data["level"] == "INFO"
     assert data["request_id"] == "req-123"
-    assert data["name"] == "test"
+    assert data["name"] == "watcher.test"
 
 
 def test_basic_logging_when_config_missing(capfd, monkeypatch):
     monkeypatch.setenv("LOGGING_CONFIG_PATH", "missing.yml")
     _cleanup()
     logging_setup.configure()
-    logger = logging.getLogger("test")
+    logger = logging_setup.get_logger("test")
     logger.info("hello world")
     out, err = capfd.readouterr()
     _cleanup()
-    assert err.strip() == "INFO:test:hello world"
+    assert err.strip() == "INFO:watcher.test:hello world"
+
+
+def test_errors_are_logged(capfd, monkeypatch):
+    monkeypatch.delenv("LOGGING_CONFIG_PATH", raising=False)
+    _cleanup()
+    logging_setup.configure()
+    logger = logging_setup.get_logger("test")
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        logger.exception("failed")
+    out, err = capfd.readouterr()
+    _cleanup()
+    data = json.loads(out.strip())
+    assert data["level"] == "ERROR"
+    assert data["message"] == "failed"


### PR DESCRIPTION
## Summary
- provide central `watcher` logger and helper for child loggers
- replace ad-hoc logging calls in core modules with the shared logger
- document logging conventions and add error logging tests

## Testing
- `pytest tests/test_structured_logs.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6f92b06b88320ad3b5ff5acbbe96b