### PR TITLE
Handle invalid integer lines in transform_data

### DIFF
--- a/app/core/pipeline.py
+++ b/app/core/pipeline.py
@@ -39,5 +39,10 @@ def transform_data(lines: Iterable[str]) -> list[int]:
         line = line.strip()
         if not line:
             continue
-        result.append(int(line))
+        try:
+            value = int(line)
+        except ValueError:
+            logger.warning("invalid integer '%s'", line)
+            continue
+        result.append(value)
     return result

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -3,6 +3,7 @@ import time
 import pytest
 from app.core.memory import Memory
 from app.data.pipeline import load_raw_data, normalize_data
+from app.core.pipeline import transform_data
 
 
 def test_normalize_data_dedup_and_outliers():
@@ -73,3 +74,11 @@ def test_feedback_batch_loading_benchmark(tmp_path):
     batched = time.perf_counter() - start
 
     assert batched <= baseline
+
+
+def test_transform_data_invalid_line(caplog):
+    lines = ["1", "foo", "2"]
+    with caplog.at_level("WARNING"):
+        result = transform_data(lines)
+    assert result == [1, 2]
+    assert "invalid integer" in caplog.text


### PR DESCRIPTION
## Summary
- Log and skip invalid integers when converting text lines in `transform_data`
- Cover invalid line scenario in data pipeline tests

## Testing
- `pytest tests/test_data_pipeline.py::test_transform_data_invalid_line -q`
- `pytest tests/test_data_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c700c6f8e48320b7d5873e63fdd00c