### PR TITLE
fix: update entry point discovery for importlib

### DIFF
--- a/app/tools/plugins/__init__.py
+++ b/app/tools/plugins/__init__.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import importlib
 import logging
-from importlib.metadata import entry_points
+from importlib.metadata import EntryPoint, entry_points
 from pathlib import Path
-from typing import Protocol
+from typing import Iterable, Protocol
 
 import tomllib
 
@@ -39,9 +39,13 @@ def discover_entry_point_plugins(group: str = "watcher.plugins") -> list[Plugin]
     plugins: list[Plugin] = []
     try:
         try:
-            eps = entry_points(group=group)
+            eps: Iterable[EntryPoint] = entry_points(group=group)
         except TypeError:  # pragma: no cover - fallback for older Python
-            eps = entry_points().get(group, [])  # type: ignore[assignment]
+            eps = [
+                ep
+                for ep in entry_points()
+                if getattr(ep, "group", None) == group
+            ]
     except Exception:  # pragma: no cover - best effort
         logging.exception("Failed to query entry points")
         return plugins


### PR DESCRIPTION
## Summary
- avoid deprecated entry_points.get by iterating entry points when group lookup fails
- add explicit Iterable[EntryPoint] typing for mypy

## Testing
- `mypy app/tools/plugins/__init__.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7178bd6688320a5b2a1f656ad95e2