### PR TITLE
Validate plugins before loading

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -32,3 +32,18 @@ def test_entry_point_plugin_failure(monkeypatch):
 
     monkeypatch.setattr(plugins, "entry_points", lambda group=None: [BrokenEP()])
     assert plugins.discover_entry_point_plugins() == []
+
+
+def test_invalid_plugin_skipped(monkeypatch):
+    class BadPlugin:
+        def run(self):  # pragma: no cover - trivial
+            return "bad"
+
+    class BadEP:
+        name = "bad"
+
+        def load(self):
+            return BadPlugin
+
+    monkeypatch.setattr(plugins, "entry_points", lambda group=None: [BadEP()])
+    assert plugins.discover_entry_point_plugins() == []


### PR DESCRIPTION
## Summary
- Validate dynamically loaded plugins for required attributes
- Skip malformed plugins with a warning instead of failing
- Test malformed plugins are ignored during discovery

## Testing
- `pytest tests/test_plugins.py -q`
- `pytest tests/test_plugin_reload.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71d184c848320bcaee998f870abe4