### PR TITLE
Format code with Black

### DIFF
--- a/app/tools/plugins/__init__.py
+++ b/app/tools/plugins/__init__.py
@@ -47,11 +47,7 @@ def discover_entry_point_plugins(group: str = "watcher.plugins") -> list[Plugin]
         try:
             eps: Iterable[EntryPoint] = entry_points(group=group)
         except TypeError:  # pragma: no cover - fallback for older Python
-            eps = [
-                ep
-                for ep in entry_points()
-                if getattr(ep, "group", None) == group
-            ]
+            eps = [ep for ep in entry_points() if getattr(ep, "group", None) == group]
     except Exception:  # pragma: no cover - best effort
         logging.exception("Failed to query entry points")
         return plugins
@@ -63,9 +59,7 @@ def discover_entry_point_plugins(group: str = "watcher.plugins") -> list[Plugin]
             if _valid_plugin(plugin):
                 plugins.append(plugin)
             else:
-                logging.warning(
-                    "Invalid plugin %s", getattr(ep, "name", "<unknown>")
-                )
+                logging.warning("Invalid plugin %s", getattr(ep, "name", "<unknown>"))
         except Exception:  # pragma: no cover - best effort
             logging.exception(
                 "Failed to load entry point %s", getattr(ep, "name", "<unknown>")

--- a/app/utils/np.py
+++ b/app/utils/np.py
@@ -15,6 +15,7 @@ try:
     import numpy as np  # type: ignore
 except Exception:  # pragma: no cover - fallback
     import numpy_stub as np  # type: ignore
+
     logger.warning("numpy is not installed, using numpy_stub instead")
 
 __all__ = ["np"]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -84,7 +84,9 @@ def test_max_entries_limit() -> None:
     assert pm2.plugin_calls == 4
 
 
-def test_numpy_fallback_warning(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+def test_numpy_fallback_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     """Ensure a warning is logged when NumPy is unavailable."""
 
     # Remove any cached modules so import occurs afresh


### PR DESCRIPTION
## Summary
- Apply Black formatting to numpy fallback module and plugins init
- Reformat metrics tests for readability

## Testing
- `black --check app/utils/np.py app/tools/plugins/__init__.py tests/test_metrics.py`
- `pytest tests/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68c724b5a8408320b174f65e354b0387