### PR TITLE
Format test_engine_prepare_data with black

### DIFF
--- a/tests/test_engine_prepare_data.py
+++ b/tests/test_engine_prepare_data.py
@@ -16,13 +16,9 @@ def test_prepare_data_handles_list(monkeypatch, tmp_path):
     )
 
     cleaned: list[dict] = []
-    monkeypatch.setattr(
-        pipeline, "clean_data", lambda d: cleaned.append(d) or d
-    )
+    monkeypatch.setattr(pipeline, "clean_data", lambda d: cleaned.append(d) or d)
 
-    monkeypatch.setattr(
-        pipeline, "transform_data", lambda d: tmp_path / "out.json"
-    )
+    monkeypatch.setattr(pipeline, "transform_data", lambda d: tmp_path / "out.json")
 
     engine = Engine()
     result = engine.prepare_data()
@@ -30,4 +26,3 @@ def test_prepare_data_handles_list(monkeypatch, tmp_path):
     assert validated == raw
     assert cleaned == raw
     assert result.endswith("out.json")
-


### PR DESCRIPTION
## Summary
- format `test_engine_prepare_data.py` with `black`

## Testing
- `black --check tests/test_engine_prepare_data.py`
- `pytest tests/test_engine_prepare_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68c729203b30832087b28d8e90c163c2