### PR TITLE
Warn when profile config is missing

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -83,6 +83,10 @@ def load_config(profile: str | None = None) -> dict[str, Any]:
         try:
             profile_cfg = _read_toml(base_path / f"settings.{profile}.toml")
         except FileNotFoundError:
+            logger.warning(
+                "Profile configuration file not found: %s",
+                base_path / f"settings.{profile}.toml",
+            )
             profile_cfg = {}
         cfg = _deep_update(cfg, profile_cfg)
 

--- a/tests/test_config_profiles.py
+++ b/tests/test_config_profiles.py
@@ -1,3 +1,5 @@
+import logging
+
 from config import load_config
 
 
@@ -11,3 +13,13 @@ def test_prod_profile():
     cfg = load_config(profile="prod")
     assert cfg["ui"]["mode"] == "prod"
     assert cfg["ui"]["theme"] == "dark"
+
+
+def test_missing_profile_logs_warning(caplog):
+    load_config.cache_clear()
+    with caplog.at_level(logging.WARNING):
+        load_config(profile="missing")
+    assert any(
+        "Profile configuration file not found" in record.message
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Summary
- log a warning when profile-specific settings file is absent
- test that loading a missing profile emits a warning

## Testing
- `make check` *(fails: bandit: No such file or directory)*
- `pytest tests/test_config_profiles.py::test_missing_profile_logs_warning -q`


------
https://chatgpt.com/codex/tasks/task_e_68c72f153ca88320a3b70ad779bb57cb