### PR TITLE
Add configurable LRU cache for chat responses

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -28,6 +28,7 @@ embed_model = "nomic-embed-text"
 embed_host = "127.0.0.1:11434"
 top_k = 8
 db_path = "memory/mem.db"
+cache_size = 128
 
 [learn]
 target_score = 0.9


### PR DESCRIPTION
## Summary
- replace chat response dict cache with an OrderedDict-based LRU cache
- add `memory.cache_size` config to control LRU size
- test cache eviction behaviour

## Testing
- `pytest tests/test_engine_chat.py`

------
https://chatgpt.com/codex/tasks/task_e_68c737b235e083208176e5e6a22e5b16