### PR TITLE
Validate raw data paths

### DIFF
--- a/app/data/pipeline.py
+++ b/app/data/pipeline.py
@@ -27,8 +27,15 @@ def load_raw_data(path: Path | str | None = None) -> dict | list[dict]:
     extension before reading.  When *path* points to a directory all ``.json``
     files inside are loaded and returned as a list of dictionaries.
     """
-
-    p = Path(path) if path else RAW_DIR / "data.json"
+    p = Path(path) if path else Path("data.json")
+    if not p.is_absolute():
+        p = RAW_DIR / p
+    p = p.resolve()
+    try:
+        p.relative_to(RAW_DIR)
+    except ValueError:
+        logger.error("raw data file '%s' escapes RAW_DIR", p)
+        raise ValueError(f"path '{p}' escapes RAW_DIR")
     if not p.exists():
         logger.error("raw data file '%s' does not exist", p)
         raise FileNotFoundError(p)


### PR DESCRIPTION
## Summary
- Resolve raw data paths, ensure they stay within `datasets/raw`, and raise an error when they escape
- Extend data pipeline tests to cover path traversal and adjust existing tests to use the raw dataset directory

## Testing
- `pytest tests/test_data_pipeline.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c737b2bb0c8320b0ab0119c425aa6f