### PR TITLE
Handle plugin failures individually

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -341,8 +341,22 @@ class Engine:
         return f"{len(self.plugins)} plugins rechargés"
 
     def run_plugins(self) -> list[str]:
-        """Execute all loaded plugins and return their outputs."""
-        return [p.run() for p in self.plugins]
+        """Execute all loaded plugins and return their outputs.
+
+        Each plugin is executed in isolation so a failure in one does not
+        prevent others from running.  Errors are logged and the failing plugin
+        is skipped.
+        """
+
+        outputs: list[str] = []
+        for p in self.plugins:
+            try:
+                outputs.append(p.run())
+            except Exception:  # pragma: no cover - best effort logging
+                logger.exception(
+                    "Plugin %s failed", getattr(p, "name", p.__class__.__name__)
+                )
+        return outputs
 
 
 logger = get_logger(__name__)


### PR DESCRIPTION
## Summary
- protect plugin execution in `run_plugins` so one failure doesn't stop others
- test that a faulty plugin is logged while others continue

## Testing
- `pytest tests/test_plugins.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c737b34a188320b7d3e2c108cc12a1