### PR TITLE
feat: handle unhashable items in normalize_data

### DIFF
--- a/app/data/pipeline.py
+++ b/app/data/pipeline.py
@@ -98,12 +98,10 @@ def normalize_data(data: dict) -> dict:
             normalized[key] = value.strip()
             continue
         if isinstance(value, list):
-            seen: set[Any] = set()
             deduped: list[Any] = []
             for item in value:
                 item_norm = item.strip() if isinstance(item, str) else item
-                if item_norm not in seen:
-                    seen.add(item_norm)
+                if item_norm not in deduped:
                     deduped.append(item_norm)
             if deduped and all(isinstance(x, (int, float)) for x in deduped):
                 cleaned = _remove_numeric_outliers([float(x) for x in deduped])

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -15,6 +15,12 @@ def test_normalize_data_dedup_and_outliers():
     assert result["nums"] == [1, 2]
 
 
+def test_normalize_data_dedup_with_dicts():
+    data = {"items": [{"a": 1}, {"a": 1}, {"b": 2}]}
+    result = normalize_data(data)
+    assert result["items"] == [{"a": 1}, {"b": 2}]
+
+
 def test_load_raw_data_missing_file(caplog):
     missing = RAW_DIR / "missing.json"
     if missing.exists():


### PR DESCRIPTION
## Summary
- ensure `normalize_data` deduplicates lists with unhashable items by checking membership in the output list
- add a regression test for dictionary items in lists

## Testing
- `pytest tests/test_data_pipeline.py::test_normalize_data_dedup_and_outliers tests/test_data_pipeline.py::test_normalize_data_dedup_with_dicts -q`


------
https://chatgpt.com/codex/tasks/task_e_68c739849afc8320b3138433bf4cac7d