### PR TITLE
Move RAW_DIR mkdir below imports

### DIFF
--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -2,9 +2,15 @@ import json
 import time
 import pytest
 from app.core.memory import Memory
-from app.data.pipeline import RAW_DIR, load_raw_data, normalize_data, transform_data as save_data
-RAW_DIR.mkdir(parents=True, exist_ok=True)
+from app.data.pipeline import (
+    RAW_DIR,
+    load_raw_data,
+    normalize_data,
+    transform_data as save_data,
+)
 from app.core.pipeline import transform_data
+
+RAW_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def test_normalize_data_dedup_and_outliers():


### PR DESCRIPTION
## Summary
- ensure RAW_DIR is created after importing modules in `test_data_pipeline`

## Testing
- `ruff check tests/test_data_pipeline.py`
- `black --check tests/test_data_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68c73b1c6ab883209f3b43db1866ca35