### PR TITLE
Format test_engine_chat with black

### DIFF
--- a/tests/test_engine_chat.py
+++ b/tests/test_engine_chat.py
@@ -162,4 +162,3 @@ def test_chat_evicts_least_recent(tmp_path, monkeypatch):
     assert eng.client.calls.count(p2) == 1
     assert eng.client.calls.count(p3) == 1
     assert p3 not in eng._cache
-


### PR DESCRIPTION
## Summary
- Format `tests/test_engine_chat.py` using Black

## Testing
- `black --check tests/test_engine_chat.py`
- `pytest tests/test_engine_chat.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c73b1d516c832081e68e542145665f