### PR TITLE
Add security scanners to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,14 @@ jobs:
       - name: Sync data
         run: dvc pull
         continue-on-error: true
-      - name: Run checks
-        run: make check
+      - name: Run lint
+        run: make lint
+      - name: Run type check
+        run: make type
+      - name: Run security checks
+        run: |
+          bandit -q -r . -c bandit.yml
+          semgrep --quiet --error --config config/semgrep.yml .
+      - name: Run tests
+        run: make test
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-black
-ruff
-pytest
-mypy
 bandit
-semgrep
+black
 dvc
+mypy
+pytest
+ruff
+semgrep

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -2,9 +2,15 @@ import json
 import time
 import pytest
 from app.core.memory import Memory
-from app.data.pipeline import RAW_DIR, load_raw_data, normalize_data, transform_data as save_data
-RAW_DIR.mkdir(parents=True, exist_ok=True)
+from app.data.pipeline import (
+    RAW_DIR,
+    load_raw_data,
+    normalize_data,
+    transform_data as save_data,
+)
 from app.core.pipeline import transform_data
+
+RAW_DIR.mkdir(parents=True, exist_ok=True)
 
 
 def test_normalize_data_dedup_and_outliers():

--- a/tests/test_engine_chat.py
+++ b/tests/test_engine_chat.py
@@ -162,4 +162,3 @@ def test_chat_evicts_least_recent(tmp_path, monkeypatch):
     assert eng.client.calls.count(p2) == 1
     assert eng.client.calls.count(p3) == 1
     assert p3 not in eng._cache
-


### PR DESCRIPTION
## Summary
- order dev requirements and ensure Bandit/Semgrep are included
- run Bandit and Semgrep as dedicated security checks in CI
- fix test import order and formatting for lint

## Testing
- `make lint`
- `make type`
- `bandit -q -r . -c bandit.yml` *(fails: command not found)*
- `semgrep --quiet --error --config config/semgrep.yml .` *(fails: command not found)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c73b1df6008320aabaa3fceaf52af5