### PR TITLE
Validate non-empty dataset for training

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -1,0 +1,8 @@
+import pytest
+
+from train import train
+
+
+def test_train_raises_value_error_on_empty_dataset():
+    with pytest.raises(ValueError):
+        train([], [])

--- a/train.py
+++ b/train.py
@@ -32,9 +32,11 @@ def load_data() -> tuple[list[float], list[float]]:
 def train(
     xs: list[float], ys: list[float], lr: float = 0.01, epochs: int = 1000
 ) -> tuple[float, float, float]:
+    n = len(xs)
+    if n == 0:
+        raise ValueError("dataset must not be empty")
     w = 0.0
     b = 0.0
-    n = len(xs)
     for _ in range(epochs):
         y_pred = [w * x + b for x in xs]
         dw = (-2 / n) * sum((y - yp) * x for x, y, yp in zip(xs, ys, y_pred))


### PR DESCRIPTION
## Summary
- ensure `train` function raises `ValueError` when dataset is empty
- cover empty dataset scenario with dedicated unit test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c742b6dc188320a927a6c0de8338ef