### PR TITLE
Pin dev dependency versions for reproducible setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,13 @@ Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurit
 
 4. Installer les outils de développement :
 
-   ```bash
-   pip install -r requirements-dev.txt
-   ```
+    ```bash
+    pip install -r requirements-dev.txt
+    ```
 
-   Sur Windows, le script `installer.ps1` installe automatiquement toutes ces dépendances.
+    Ce fichier fixe des versions précises afin d'assurer une installation reproductible.
+
+    Sur Windows, le script `installer.ps1` installe automatiquement toutes ces dépendances.
 
 Les fichiers d'environnement (`*.env`), les journaux (`*.log`) et les environnements virtuels (`.venv/`) sont ignorés par Git afin d'éviter la mise en version de données sensibles ou temporaires.
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-bandit
-black
-dvc
-mypy
-pytest
-ruff
-semgrep
+bandit==1.7.5
+black==24.3.0
+dvc==3.49.0
+mypy==1.10.0
+pytest==8.2.0
+ruff==0.6.4
+semgrep==1.44.0


### PR DESCRIPTION
## Summary
- Pin exact versions in `requirements-dev.txt`
- Document that development tools use fixed versions in `README.md`

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c742b82cf08320badc368f1c442f2e