### PR TITLE
Define complete default configuration and restore scraper API

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -1,16 +1,63 @@
-﻿[scraper]
-rate_per_domain = 1.0
-concurrency = 6
-user_agent = \"WatcherBot/1.0 (+https://github.com/francis18georges-png/Watcher)\"
+[ui]
+mode = "Sur"
+theme = "dark"
+language = "fr"
+autosave = true
 
-[dataset]
-raw_dir = \"datasets/raw\"
-processed_dir = \"datasets/processed\"
+[llm]
+backend = "ollama"
+model = "llama3.2:3b"
+host = "127.0.0.1:11434"
+ctx = 4096
+fallback_phrase = "Echo"
 
-[embeddings]
-backend = \"local_faiss\"
+[dev]
+logging = "debug"
+trace_requests = false
+
+[planner]
+default_platform = "windows"
+default_license = "MIT"
+
+[memory]
+db_path = "memory/mem.db"
+cache_size = 128
+embed_model = "nomic-embed-text"
+embed_host = "127.0.0.1:11434"
+summary_max_tokens = 512
+
+[learn]
+optimizer = "adam"
+learning_rate = 0.1
+reward_clip = 1.0
+
+[intelligence]
+mode = "offline"
+curriculum = "default"
+
+[data]
+raw_dir = "datasets/raw"
+processed_dir = "datasets/processed"
+steps = {}
 
 [training]
 seed = 42
 batch_size = 16
 lr = 1e-4
+
+[model]
+name = "watcher"
+revision = "0.1"
+precision = "fp16"
+
+[scraper]
+rate_per_domain = 1.0
+concurrency = 6
+user_agent = "WatcherBot/1.0 (+https://github.com/francis18georges-png/Watcher)"
+
+[dataset]
+raw_dir = "datasets/raw"
+processed_dir = "datasets/processed"
+
+[embeddings]
+backend = "local_faiss"


### PR DESCRIPTION
## Summary
- replace the truncated base settings with a complete, BOM-free configuration
- define defaults for all required configuration sections plus existing scraper, dataset and embedding knobs
- keep dedicated dev/prod overrides so UI mode switches without losing shared options
- replace the experimental httpx scraper with a cached asyncio implementation that exposes the expected `scrape_all` API

## Testing
- pytest tests/test_config.py tests/test_config_profiles.py tests/test_app_config_env.py -q
- pytest tests/test_scraper.py tests/test_domain_scrapers.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ca7ca282c88320b6e718aaf3cecfa5