### PR TITLE
Normalize UI feedback scale to 0-1

### DIFF
--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -95,11 +95,17 @@ class WatcherApp(ttk.Frame):
         self.inp.pack(side="left", fill="both", expand=True)
         self.send_btn = ttk.Button(bottom, text="Envoyer", command=self._send)
         self.send_btn.pack(side="left", padx=8)
-        ttk.Label(bottom, text="Note").pack(side="left")
-        self.rate_var = tk.IntVar(value=0)
-        tk.Spinbox(bottom, from_=0, to=5, textvariable=self.rate_var, width=3).pack(
-            side="left", padx=4
+        ttk.Label(bottom, text="Note (0.0 – 1.0)").pack(side="left")
+        self.rate_var = tk.DoubleVar(value=0.0)
+        self.rate_input = tk.Spinbox(
+            bottom,
+            from_=0.0,
+            to=1.0,
+            increment=0.1,
+            textvariable=self.rate_var,
+            width=4,
         )
+        self.rate_input.pack(side="left", padx=4)
         ttk.Button(bottom, text="Noter", command=self._rate).pack(side="left")
         self.status = ttk.Label(
             self,
@@ -183,7 +189,16 @@ class WatcherApp(ttk.Frame):
         self._run_async(self.engine.auto_improve, "Improve")
 
     def _rate(self) -> None:
-        score = self.rate_var.get()
+        try:
+            score = float(self.rate_var.get())
+        except (tk.TclError, TypeError, ValueError):
+            messagebox.showerror(APP_NAME, "La note doit être un nombre entre 0.0 et 1.0.")
+            return
+
+        if not 0.0 <= score <= 1.0:
+            messagebox.showerror(APP_NAME, "La note doit être comprise entre 0.0 et 1.0.")
+            return
+
         msg = self.engine.add_feedback(score)
         self.out.insert("end", f"\n[Feedback] {msg}\n")
         self.out.see("end")

--- a/tests/test_ui_feedback.py
+++ b/tests/test_ui_feedback.py
@@ -1,0 +1,46 @@
+import tkinter as tk
+
+import pytest
+
+from app.ui import main
+
+
+class _DummyText:
+    def __init__(self) -> None:
+        self.buffer: list[tuple[str, str]] = []
+        self.last_seen: str | None = None
+
+    def insert(self, index: str, text: str) -> None:
+        self.buffer.append((index, text))
+
+    def see(self, index: str) -> None:
+        self.last_seen = index
+
+
+class _DummyEngine:
+    def __init__(self) -> None:
+        self.recorded: list[float] = []
+
+    def add_feedback(self, rating: float) -> str:
+        self.recorded.append(rating)
+        return "feedback enregistré"
+
+
+def test_rate_records_high_value(monkeypatch):
+    errors: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(main.messagebox, "showerror", lambda title, msg: errors.append((title, msg)))
+
+    app = main.WatcherApp.__new__(main.WatcherApp)
+    app.engine = _DummyEngine()
+    app.rate_var = tk.DoubleVar(master=tk.Tcl(), value=1.0)
+    app.out = _DummyText()
+
+    app._rate()
+
+    assert len(app.engine.recorded) == 1
+    assert app.engine.recorded[0] == pytest.approx(1.0)
+    assert errors == []
+    assert any(
+        entry.strip().endswith("feedback enregistré") for _, entry in app.out.buffer
+    )


### PR DESCRIPTION
## Summary
- change the chat feedback spinbox to use a DoubleVar on a 0.0–1.0 scale with clearer labelling
- validate the rating value before invoking the engine feedback hook
- add a regression test ensuring a high UI rating is accepted and recorded

## Testing
- pytest tests/test_ui_feedback.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe9eef34c8320bcfda4b47b814e7c