### PR TITLE
Add default cache convenience scraper

### DIFF
--- a/app/data/scraper.py
+++ b/app/data/scraper.py
@@ -117,4 +117,23 @@ async def scrape_all(
     return {url: path for url, path in results if path is not None}
 
 
-__all__ = ["scrape_all", "DomainRateLimiter"]
+async def scrape(
+    urls: Iterable[str],
+    *,
+    concurrency: int = 5,
+    cache_dir: Path | None = None,
+) -> Dict[str, str]:
+    """Convenience wrapper around :func:`scrape_all` with a default cache directory.
+
+    When *cache_dir* is :data:`None`, the cache is stored below the repository's
+    ``datasets/cache`` folder.  The directory is created automatically and the
+    mapping returned by :func:`scrape_all` is forwarded unchanged.
+    """
+
+    if cache_dir is None:
+        cache_dir = Path(__file__).resolve().parents[2] / "datasets" / "cache"
+
+    return await scrape_all(urls, cache_dir, concurrency=concurrency)
+
+
+__all__ = ["scrape_all", "scrape", "DomainRateLimiter"]

--- a/tests/test_scraper.py
+++ b/tests/test_scraper.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 from types import SimpleNamespace
 
 from app.data import scraper
@@ -43,3 +44,38 @@ def test_scraper_caches(monkeypatch, tmp_path):
     assert calls == 1
     # Cached file exists
     assert list(tmp_path.iterdir())
+
+
+def test_scrape_uses_default_cache(monkeypatch, tmp_path):
+    """scrape() should populate the default cache directory when unspecified."""
+
+    url = "https://example.com"
+    fake_repo = tmp_path / "repo"
+    fake_file = fake_repo / "app" / "data" / "scraper.py"
+    fake_file.parent.mkdir(parents=True)
+    monkeypatch.setattr(scraper, "__file__", str(fake_file))
+
+    calls = 0
+
+    def fake_urlopen(request_url: str):
+        nonlocal calls
+        calls += 1
+        assert request_url == url
+        return DummyResponse("payload")
+
+    monkeypatch.setattr(
+        scraper, "urllib_request", SimpleNamespace(urlopen=fake_urlopen)
+    )
+
+    async def _run():
+        return await scraper.scrape([url])
+
+    results = asyncio.run(_run())
+
+    default_cache = fake_repo / "datasets" / "cache"
+    assert calls == 1
+    assert default_cache.exists()
+
+    stored_path = Path(results[url])
+    assert stored_path.parent == default_cache
+    assert stored_path.read_text() == "payload"


### PR DESCRIPTION
## Summary
- add a `scrape` convenience coroutine that defaults to the repository cache directory
- expose the helper via the scraper module exports and document its behavior
- add a unit test ensuring the default cache directory is created and used

## Testing
- pytest tests/test_scraper.py

------
https://chatgpt.com/codex/tasks/task_e_68cbe9f0830883209b18bd4901d12a7a