### PR TITLE
Add unified CLI entrypoint and packaging metadata

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/python:3.12
+
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_CACHE_DIR=/home/vscode/.cache/pip \
+    DVC_CACHE_DIR=/workspaces/.cache/dvc \
+    PYTHONUNBUFFERED=1 \
+    PYTHONHASHSEED=0
+
+RUN sudo apt-get update \
+    && sudo apt-get install -y --no-install-recommends \
+        git-lfs \
+    && sudo rm -rf /var/lib/apt/lists/* \
+    && git lfs install --system

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://raw.githubusercontent.com/devcontainers/spec/main/schemas/devcontainer.json",
+  "name": "Watcher",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
+  "containerEnv": {
+    "PIP_CACHE_DIR": "/home/vscode/.cache/pip",
+    "DVC_CACHE_DIR": "/workspaces/.cache/dvc",
+    "PYTHONHASHSEED": "0"
+  },
+  "mounts": [
+    "type=volume,source=watcher-pip-cache,target=/home/vscode/.cache/pip",
+    "type=volume,source=watcher-dvc-cache,target=/workspaces/.cache/dvc"
+  ],
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+          "tests"
+        ],
+        "editor.formatOnSave": true,
+        "python.analysis.typeCheckingMode": "strict",
+        "python.formatting.provider": "black"
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "charliermarsh.ruff",
+        "ms-azuretools.vscode-docker",
+        "streetsidesoftware.code-spell-checker"
+      ]
+    }
+  },
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "8gb"
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mkdir -p /home/vscode/.cache/pip
+mkdir -p /workspaces/.cache/dvc
+
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt -r requirements-dev.txt
+
+# Install pre-commit hooks for the default git user when available
+if command -v pre-commit >/dev/null 2>&1; then
+  pre-commit install --install-hooks --overwrite
+fi
+
+# Warm DVC cache metadata if configuration exists
+if command -v dvc >/dev/null 2>&1 && [ -d .dvc ]; then
+  dvc config cache.shared group >/dev/null 2>&1 || true
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,28 +5,49 @@ on:
   pull_request:
 
 jobs:
-  tests:
-    runs-on: ubuntu-latest
+  quality:
+    name: Quality checks
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.12"]
+    env:
+      PYTHONHASHSEED: "0"
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
-      - name: Install dependencies
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Prepare cache directories
+        run: mkdir -p .dvc/cache
+        shell: bash
+
+      - name: Cache DVC artifacts
+        uses: actions/cache@v4
+        with:
+          path: .dvc/cache
+          key: dvc-${{ runner.os }}-${{ hashFiles('dvc.lock', 'dvc.yaml', '.dvc/config') }}
+          restore-keys: |
+            dvc-${{ runner.os }}-
+
+      - name: Install tooling
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-dev.txt
-      - name: Sync data
+          python -m pip install nox dvc
+
+      - name: Pull data artifacts
         run: dvc pull
         continue-on-error: true
-      - name: Run lint
-        run: make lint
-      - name: Run type check
-        run: make type
-      - name: Run security checks
-        run: |
-          bandit -q -r . -c bandit.yml
-          semgrep --quiet --error --config config/semgrep.yml .
-      - name: Run tests
-        run: make test
 
+      - name: Run quality pipeline
+        run: nox -s lint typecheck security tests build

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 # Data
 data/
 memory/
+datasets/cache/
 
 # Coverage artifacts
 .coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.9
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-requests]
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.9
+    hooks:
+      - id: bandit
+        args: [-q, -r, ., -c, bandit.yml]
+  - repo: https://github.com/returntocorp/semgrep
+    rev: v1.91.0
+    hooks:
+      - id: semgrep
+        args: [--error, --config, config/semgrep.yml]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell
+        args: [-L, crate]

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,26 @@
 .RECIPEPREFIX := >
-.PHONY: format lint type security test check
+.PHONY: format lint type security test check nox
 
 format:
+> ruff --fix .
+> ruff format .
 > black .
 
 lint:
-> ruff check .
-> black --check .
+> nox -s lint
 
 type:
-> mypy .
+> nox -s typecheck
 
 security:
-> bandit -q -r . -c bandit.yml
-> semgrep --quiet --error --config config/semgrep.yml .
+> nox -s security
 
 test:
-> pytest -q
+> nox -s tests
 
-check: lint type security test
+check:
+> nox -s lint typecheck security tests
+
+nox:
+> nox -s lint typecheck security tests build
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,22 @@ Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurit
 
 Les fichiers d'environnement (`*.env`), les journaux (`*.log`) et les environnements virtuels (`.venv/`) sont ignorés par Git afin d'éviter la mise en version de données sensibles ou temporaires.
 
+## Environnement de développement
+
+Un dossier `.devcontainer/` est fourni pour disposer d'un environnement prêt à l'emploi
+dans VS Code ou GitHub Codespaces. Il utilise l'image Python 3.12 officielle,
+préconfigure les caches `pip` et `DVC` sur des volumes persistants et installe
+automatiquement les dépendances du projet ainsi que les hooks `pre-commit`.
+
+Pour ouvrir le projet dans un devcontainer :
+
+1. Installer l'extension [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers).
+2. Dans VS Code, exécuter la commande **Dev Containers: Reopen in Container**.
+3. Attendre la fin du script `.devcontainer/post-create.sh` qui prépare l'environnement.
+
+Les caches partagés accélèrent notamment les installations pip et la synchronisation DVC
+entre plusieurs sessions Codespaces.
+
 ## Compatibilité NumPy
 
 Watcher tente d'utiliser la bibliothèque `numpy` lorsqu'elle est disponible.
@@ -57,9 +73,28 @@ Sous Windows :
 
 ### Ligne de commande
 
+L'installation du package expose une commande unifiée `watcher` qui pilote
+l'ensemble des fonctionnalités :
+
 ```bash
-python -m app.ui.main
+# lancer automatiquement l'interface graphique ou la CLI
+watcher run
+
+# forcer le mode CLI et exécuter un prompt unique
+watcher run --mode cli --prompt "Bonjour Watcher"
+
+# inspecter les plugins disponibles
+watcher plugin list
+
+# exécuter un plugin particulier et obtenir son résultat en JSON
+watcher plugin run --name hello
+
+# lancer la pipeline de nettoyage de données en mode dry-run
+watcher data pipeline --source exemples.json --dry-run
 ```
+
+`python -m app` appelle la même interface que la commande `watcher`, ce qui
+facilite les tests sans installation globale.
 
 ### Générer une CLI Python
 
@@ -93,21 +128,48 @@ Un exemple minimal est fourni dans `app/tools/plugins/hello.py`.
 
 ## Tests & Qualité
 
-Exécuter les vérifications locales avant de proposer du code :
+Watcher s'appuie désormais sur [Nox](https://nox.thea.codes/) pour unifier les
+linters, l'analyse statique, les tests et la construction du package :
 
 ```bash
-make check
+nox -s lint typecheck security tests
 ```
 
-Les commandes exécutées par `make check` sont :
+Les sessions peuvent également être exécutées individuellement (`nox -s lint`,
+`nox -s tests`, etc.) et une étape `nox -s build` génère les artefacts wheel et
+sdist.
+
+Pour automatiser les corrections, la cible `make format` applique Ruff (lint
+et formattage) puis Black, et `make check` délègue dorénavant à Nox.
+
+## Packaging
+
+Watcher dispose désormais d'une configuration `pyproject.toml` complète. La
+construction des artefacts Python standards se fait via :
 
 ```bash
-ruff check .
-black --check .
-mypy .
-bandit -q -r . -c bandit.yml
-semgrep --quiet --error --config config/semgrep.yml .
-pytest -q
+python -m build
+# ou
+nox -s build
+```
+
+Les distributions wheel et sdist générées dans `dist/` peuvent être installées
+sur n'importe quel environnement compatible Python >= 3.11.
+
+### Hooks pre-commit
+
+Le dépôt inclut une configuration `pre-commit` regroupant Ruff, Black, mypy,
+Bandit, Semgrep et Codespell. Après avoir installé les dépendances de
+développement, activez les hooks localement :
+
+```bash
+pre-commit install
+```
+
+Vous pouvez ensuite valider l'ensemble des fichiers :
+
+```bash
+pre-commit run --all-files
 ```
 
 La configuration `bandit.yml` exclut notamment les répertoires `.git`, `datasets`,

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,11 @@
 """Watcher application package."""
 
+from __future__ import annotations
+
 from app.core import logging_setup
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"
 
 logging_setup.configure()

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,0 +1,8 @@
+"""Module executed when running ``python -m app``."""
+
+from __future__ import annotations
+
+from app.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/app/cli/__init__.py
+++ b/app/cli/__init__.py
@@ -1,0 +1,205 @@
+"""Command line entry point for Watcher."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from app import __version__
+from app.core.benchmark import Bench
+from app.data import pipeline
+from app.tools import plugins
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="watcher",
+        description="Watcher developer assistant command line interface.",
+    )
+    parser.add_argument("--version", action="version", version=f"Watcher {__version__}")
+
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.required = True
+
+    run_parser = subparsers.add_parser("run", help="Launch the user interface")
+    run_parser.add_argument(
+        "--mode",
+        choices=("auto", "gui", "cli"),
+        default="auto",
+        help="Interface mode: auto-detect, force GUI or force CLI.",
+    )
+    run_parser.add_argument(
+        "--metrics-port",
+        type=int,
+        default=8000,
+        help="Port used by the embedded metrics HTTP server.",
+    )
+    run_parser.add_argument(
+        "--no-metrics",
+        action="store_true",
+        help="Disable the metrics HTTP server when running the UI.",
+    )
+    run_parser.add_argument(
+        "--prompt",
+        help="Prompt executed immediately when running in CLI mode.",
+    )
+    run_parser.set_defaults(func=_cmd_run)
+
+    plugin_parser = subparsers.add_parser(
+        "plugin", help="Inspect and execute Watcher plugins"
+    )
+    plugin_sub = plugin_parser.add_subparsers(dest="plugin_command")
+    plugin_sub.required = True
+
+    plugin_list = plugin_sub.add_parser("list", help="List available plugins")
+    plugin_list.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Optional project root containing plugins.toml",
+    )
+    plugin_list.set_defaults(func=_cmd_plugin_list)
+
+    plugin_run = plugin_sub.add_parser("run", help="Execute one or more plugins")
+    plugin_run.add_argument(
+        "--name",
+        action="append",
+        help="Name of the plugin to execute. Can be specified multiple times.",
+    )
+    plugin_run.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Optional project root containing plugins.toml",
+    )
+    plugin_run.set_defaults(func=_cmd_plugin_run)
+
+    bench_parser = subparsers.add_parser(
+        "bench", help="Run synthetic benchmark variants"
+    )
+    bench_parser.add_argument(
+        "--variant",
+        default="default",
+        help="Benchmark variant name to execute.",
+    )
+    bench_parser.set_defaults(func=_cmd_bench)
+
+    data_parser = subparsers.add_parser("data", help="Operate on datasets")
+    data_sub = data_parser.add_subparsers(dest="data_command")
+    data_sub.required = True
+
+    pipeline_parser = data_sub.add_parser(
+        "pipeline", help="Run the data cleaning pipeline"
+    )
+    pipeline_parser.add_argument(
+        "--source",
+        default=None,
+        help="Optional JSON file relative to datasets/raw to process.",
+    )
+    pipeline_parser.add_argument(
+        "--output",
+        default="cleaned.json",
+        help="Output filename stored in datasets/processed.",
+    )
+    pipeline_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the processed payload instead of writing files.",
+    )
+    pipeline_parser.set_defaults(func=_cmd_data_pipeline)
+
+    return parser
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    from app.ui import main as ui_main
+
+    return ui_main.launch(
+        mode=args.mode,
+        metrics_port=args.metrics_port,
+        enable_metrics=not args.no_metrics,
+        prompt=args.prompt,
+    )
+
+
+def _plugin_base(root: Path | None) -> Path:
+    return (root or Path(__file__).resolve().parents[2]).resolve()
+
+
+def _cmd_plugin_list(args: argparse.Namespace) -> int:
+    available = plugins.reload_plugins(_plugin_base(args.root))
+    if not available:
+        print("no plugins found")
+        return 0
+    for plugin in available:
+        print(plugin.name)
+    return 0
+
+
+def _cmd_plugin_run(args: argparse.Namespace) -> int:
+    available = plugins.reload_plugins(_plugin_base(args.root))
+    if args.name:
+        requested = set(args.name)
+        selected = [p for p in available if p.name in requested]
+        missing = requested - {p.name for p in selected}
+        if missing:
+            raise SystemExit(f"unknown plugin(s): {', '.join(sorted(missing))}")
+    else:
+        selected = available
+
+    if not selected:
+        print("no plugins executed")
+        return 0
+
+    for plugin in selected:
+        result = plugin.run()
+        print(json.dumps({"name": plugin.name, "result": result}, ensure_ascii=False))
+    return 0
+
+
+def _cmd_bench(args: argparse.Namespace) -> int:
+    bench = Bench()
+    score = bench.run_variant(args.variant)
+    print(json.dumps({"variant": args.variant, "score": score}))
+    return 0
+
+
+def _cmd_data_pipeline(args: argparse.Namespace) -> int:
+    raw = pipeline.load_raw_data(args.source)
+
+    def _prepare(item: dict) -> dict:
+        return pipeline.clean_data(pipeline.normalize_data(item))
+
+    if isinstance(raw, list):
+        processed = [_prepare(item) for item in raw]
+    elif isinstance(raw, dict):
+        processed = _prepare(raw)
+    else:  # pragma: no cover - defensive
+        raise TypeError("expected dict or list of dicts from load_raw_data")
+
+    result = pipeline.run_pipeline(processed)
+
+    if args.dry_run:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0
+
+    output = pipeline.transform_data(result, filename=args.output)
+    if isinstance(output, list):
+        for path in output:
+            print(path)
+    else:
+        print(output)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the Watcher command line interface."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+__all__ = ["main"]

--- a/app/embeddings/store.py
+++ b/app/embeddings/store.py
@@ -1,8 +1,9 @@
-﻿\"\"\"
-Simple embeddings store abstraction (local FAISS-like example).
+"""Simple embeddings store abstraction (local FAISS-like example).
+
 - wraps encoder function (can be OpenAI / local model)
 - persists vector index + metadata
-\"\"\"
+"""
+
 from __future__ import annotations
 import pickle
 from pathlib import Path
@@ -10,9 +11,11 @@ from typing import Any
 
 import numpy as np
 
+
 # Placeholder: replace with real encoder (OpenAI, sentence-transformers, etc.)
 def fake_encoder(texts: list[str]) -> np.ndarray:
     return np.vstack([[float(len(t) % 512)] * 64 for t in texts]).astype("float32")
+
 
 class SimpleVectorStore:
     def __init__(self, path: str = "metrics/vecstore"):

--- a/app/llm/rag.py
+++ b/app/llm/rag.py
@@ -1,8 +1,9 @@
-﻿\"\"\"
-Minimal RAG pipeline skeleton:
+"""Minimal RAG pipeline skeleton.
+
 - retrieve top passages from vector store
 - call an LLM (placeholder) with context + prompt
-\"\"\"
+"""
+
 from __future__ import annotations
 import logging
 from typing import List
@@ -11,17 +12,25 @@ from app.embeddings.store import SimpleVectorStore
 
 logger = logging.getLogger(__name__)
 
+
 def build_prompt(question: str, passages: List[str]) -> str:
-    context = \"\\n\\n\".join(f\"PASSAGE {i+1}:\\n{p}\" for i,p in enumerate(passages))
-    return f\"Contexte:\\n{context}\\n\\nQuestion: {question}\\nRéponds en t'expliquant si tu utilises les passages.\"
+    context = "\n\n".join(
+        f"PASSAGE {i + 1}:\n{content}" for i, content in enumerate(passages)
+    )
+    return (
+        f"Contexte:\n{context}\n\nQuestion: {question}\n"
+        "Réponds en t'expliquant si tu utilises les passages."
+    )
+
 
 def fake_llm(prompt: str) -> str:
-    return \"RÉPONSE_SIMULÉE: \" + prompt[:300]
+    return "RÉPONSE_SIMULÉE: " + prompt[:300]
+
 
 def answer_question(question: str, k: int = 3):
     vs = SimpleVectorStore()
     hits = vs.search(question, k=k)
-    passages = [h[0].get(\"text\", \"\") for h in hits] if hits else []
+    passages = [item[0].get("text", "") for item in hits] if hits else []
     prompt = build_prompt(question, passages)
-    logger.debug(\"Prompt length %d\", len(prompt))
+    logger.debug("Prompt length %d", len(prompt))
     return fake_llm(prompt)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,71 @@
+"""Automated quality sessions for Watcher."""
+
+from __future__ import annotations
+
+import nox
+
+PYTHON_VERSIONS = ["3.12"]
+SOURCE_DIRECTORIES = ("app", "config", "datasets", "tests", "train.py", "plugins.toml")
+
+nox.options.sessions = ("lint", "typecheck", "security", "tests", "build")
+nox.options.reuse_existing_virtualenvs = True
+
+
+def install_project(session: nox.Session, *extra: str) -> None:
+    """Install runtime and development dependencies."""
+    session.install("--upgrade", "pip")
+    session.install("-r", "requirements.txt")
+    session.install("-r", "requirements-dev.txt")
+    if extra:
+        session.install(*extra)
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def lint(session: nox.Session) -> None:
+    """Run formatting and static analysis checks."""
+    install_project(session)
+    session.run("ruff", "check", *SOURCE_DIRECTORIES)
+    session.run("ruff", "format", "--check", *SOURCE_DIRECTORIES)
+    session.run("black", "--check", ".")
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def typecheck(session: nox.Session) -> None:
+    """Run type checking with mypy."""
+    install_project(session)
+    session.run("mypy", "app", "tests")
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def security(session: nox.Session) -> None:
+    """Execute security scanning tools."""
+    install_project(session)
+    session.run("bandit", "-q", "-r", ".", "-c", "bandit.yml")
+    session.run(
+        "semgrep",
+        "--quiet",
+        "--error",
+        "--config",
+        "config/semgrep.yml",
+        ".",
+    )
+    session.run(
+        "codespell",
+        "--skip=.git,.mypy_cache,.pytest_cache,.venv,build,dist,.dvc/cache",
+        "-L",
+        "crate",
+    )
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def tests(session: nox.Session) -> None:
+    """Run the unit test suite."""
+    install_project(session)
+    session.run("pytest", "-q")
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def build(session: nox.Session) -> None:
+    """Build the project wheel and source distribution."""
+    install_project(session, "build")
+    session.run("python", "-m", "build")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,65 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "watcher"
+version = "0.1.0"
+description = "Developer assistant with GUI, plugin sandboxing and benchmarking tools."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { file = "LICENSE" }
+authors = [
+    { name = "Watcher Maintainers" }
+]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+dependencies = [
+    "httpx==0.27.0",
+    "rich==13.7.1",
+    "beautifulsoup4==4.12.2",
+    "sentence-transformers==2.2.2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "bandit==1.7.9",
+    "black==24.8.0",
+    "build==1.2.2.post1",
+    "codespell==2.3.0",
+    "dvc==3.49.0",
+    "mypy==1.11.2",
+    "nox==2024.4.15",
+    "pre-commit==3.8.0",
+    "pytest==8.3.2",
+    "ruff==0.6.9",
+    "semgrep==1.91.0",
+]
+
+[project.scripts]
+watcher = "app.cli:main"
+
+[project.urls]
+Homepage = "https://github.com/francis18georges-png/Watcher"
+Documentation = "https://github.com/francis18georges-png/Watcher#readme"
+Issues = "https://github.com/francis18georges-png/Watcher/issues"
+
+[tool.setuptools.packages.find]
+include = ["app", "app.*", "config", "config.*"]
+
+[tool.setuptools.package-data]
+config = ["*.toml", "*.yml"]
+
 [tool.black]
 line-length = 88
 target-version = ["py312"]
 
 [tool.ruff]
 line-length = 88
-

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,11 @@
-bandit==1.7.5
-black==24.3.0
+bandit==1.7.9
+black==24.8.0
+build==1.2.2.post1
+codespell==2.3.0
 dvc==3.49.0
-mypy==1.10.0
-pytest==8.2.0
-ruff==0.6.4
-semgrep==1.44.0
+mypy==1.11.2
+nox==2024.4.15
+pre-commit==3.8.0
+pytest==8.3.2
+ruff==0.6.9
+semgrep==1.91.0

--- a/tests/test_scraper_integration.py
+++ b/tests/test_scraper_integration.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from app.data.scraper import scrape
 
+
 def test_scrape_one_local_file(tmp_path: Path):
     html = "<html><head><title>t</title></head><body><p>hello</p><pre>print(1)</pre></body></html>"
     f = tmp_path / "t.html"

--- a/tests/test_ui_feedback.py
+++ b/tests/test_ui_feedback.py
@@ -29,7 +29,9 @@ class _DummyEngine:
 def test_rate_records_high_value(monkeypatch):
     errors: list[tuple[str, str]] = []
 
-    monkeypatch.setattr(main.messagebox, "showerror", lambda title, msg: errors.append((title, msg)))
+    monkeypatch.setattr(
+        main.messagebox, "showerror", lambda title, msg: errors.append((title, msg))
+    )
 
     app = main.WatcherApp.__new__(main.WatcherApp)
     app.engine = _DummyEngine()

--- a/tests/test_watcher_cli.py
+++ b/tests/test_watcher_cli.py
@@ -1,0 +1,76 @@
+"""Integration tests for the unified watcher CLI."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app import cli
+from app.data import pipeline
+
+
+def test_plugin_list_outputs_known_plugin(capsys):
+    code = cli.main(["plugin", "list"])
+    assert code == 0
+    out = capsys.readouterr().out.strip().splitlines()
+    assert "hello" in out
+
+
+def test_plugin_run_returns_json(capsys):
+    code = cli.main(["plugin", "run", "--name", "hello"])
+    assert code == 0
+    out = capsys.readouterr().out.strip().splitlines()
+    assert len(out) == 1
+    payload = json.loads(out[0])
+    assert payload["name"] == "hello"
+    assert "Hello" in payload["result"]
+
+
+def test_run_cli_prompt(monkeypatch, capsys):
+    # Avoid binding the metrics port during tests.
+    code = cli.main(
+        [
+            "run",
+            "--mode",
+            "cli",
+            "--no-metrics",
+            "--prompt",
+            "Bonjour",
+        ]
+    )
+    assert code == 0
+    out = capsys.readouterr().out
+    lines = [line for line in out.splitlines() if not line.startswith("{")]
+    assert any(line.startswith("[Watcher]") for line in lines)
+    assert any(line for line in lines if not line.startswith("[Watcher]"))
+
+
+def test_data_pipeline_creates_output(tmp_path: Path, monkeypatch, capsys):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    processed_dir = tmp_path / "processed"
+    sample = {"message": "  salut  ", "values": [1, 1, 2, 1000]}
+    (raw_dir / "sample.json").write_text(json.dumps(sample), encoding="utf-8")
+
+    monkeypatch.setattr(pipeline, "RAW_DIR", raw_dir)
+    monkeypatch.setattr(pipeline, "PROCESSED_DIR", processed_dir)
+
+    code = cli.main(
+        [
+            "data",
+            "pipeline",
+            "--source",
+            "sample.json",
+            "--output",
+            "result.json",
+        ]
+    )
+    assert code == 0
+    out = capsys.readouterr().out.strip()
+    assert "result.json" in out
+
+    output_path = processed_dir / "result.json"
+    assert output_path.exists()
+    saved = json.loads(output_path.read_text(encoding="utf-8"))
+    assert saved["message"] == "salut"
+    assert saved["values"] == [1, 2]


### PR DESCRIPTION
## Summary
- expose a consolidated `watcher` command that drives the GUI, plugin, bench, and data workflows with reusable helpers
- add a Python module entry point, package metadata, and project version so the application can be built and installed from `pyproject.toml`
- extend the documentation and tests to cover the new CLI scenarios and packaging workflow

## Testing
- pytest -q
- ruff check .
- black .

------
https://chatgpt.com/codex/tasks/task_e_68cbfbbff5cc8320b15885d08752231f