### PR TITLE
Ensure CLI loads plugin manifest from package

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -1,0 +1,44 @@
+"""Command line interface for Watcher."""
+
+from __future__ import annotations
+
+import argparse
+from importlib import resources
+from importlib.resources.abc import Traversable
+from typing import Sequence
+
+from app.tools import plugins
+
+#: Base location containing the plugin manifest.
+_plugin_base: Traversable = resources.files("app")
+
+
+def _iter_plugins() -> list[plugins.Plugin]:
+    """Return all configured plugin instances."""
+
+    return plugins.reload_plugins(_plugin_base)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point for the :mod:`watcher` command."""
+
+    parser = argparse.ArgumentParser(prog="watcher", description="Watcher CLI")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    plugin_parser = sub.add_parser("plugin", help="Plugin related commands")
+    plugin_sub = plugin_parser.add_subparsers(dest="plugin_command", required=True)
+    plugin_sub.add_parser("list", help="List available plugins")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "plugin" and args.plugin_command == "list":
+        for plugin in _iter_plugins():
+            print(plugin.name)
+        return 0
+
+    parser.error("unknown command")
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
+    raise SystemExit(main())

--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -346,7 +346,7 @@ class Engine:
     def _load_plugins(self) -> None:
         """Populate :attr:`plugins` from ``plugins.toml``."""
 
-        self.plugins = plugins.reload_plugins(self.base)
+        self.plugins = plugins.reload_plugins()
 
     def reload_plugins(self) -> str:
         """Reload plugins without restarting the engine."""

--- a/app/plugins.toml
+++ b/app/plugins.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+path = "app.tools.plugins.hello:HelloPlugin"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ target-version = ["py312"]
 [tool.ruff]
 line-length = 88
 
+[tool.setuptools.package-data]
+"app" = ["plugins.toml"]
+

--- a/tests/test_plugin_reload.py
+++ b/tests/test_plugin_reload.py
@@ -1,23 +1,26 @@
-from pathlib import Path
+from importlib import resources
+from importlib.resources.abc import Traversable
 
 from app.core.engine import Engine
 from tests.dummy_plugin import DummyPlugin
 
 
 def test_reload_plugins():
-    cfg = Path("plugins.toml")
-    original = cfg.read_text(encoding="utf-8")
-    engine = Engine()
-    assert not any(isinstance(p, DummyPlugin) for p in engine.plugins)
+    manifest: Traversable = resources.files("app").joinpath("plugins.toml")
+    with resources.as_file(manifest) as cfg_path:
+        original = cfg_path.read_text(encoding="utf-8")
 
-    cfg.write_text(
-        original + '\n[[plugins]]\npath = "tests.dummy_plugin:DummyPlugin"\n',
-        encoding="utf-8",
-    )
-    try:
-        engine.reload_plugins()
-        assert any(isinstance(p, DummyPlugin) for p in engine.plugins)
-        outputs = engine.run_plugins()
-        assert "dummy plugin loaded" in outputs
-    finally:
-        cfg.write_text(original, encoding="utf-8")
+        engine = Engine()
+        assert not any(isinstance(p, DummyPlugin) for p in engine.plugins)
+
+        cfg_path.write_text(
+            original + '\n[[plugins]]\npath = "tests.dummy_plugin:DummyPlugin"\n',
+            encoding="utf-8",
+        )
+        try:
+            engine.reload_plugins()
+            assert any(isinstance(p, DummyPlugin) for p in engine.plugins)
+            outputs = engine.run_plugins()
+            assert "dummy plugin loaded" in outputs
+        finally:
+            cfg_path.write_text(original, encoding="utf-8")

--- a/tests/test_watcher_cli.py
+++ b/tests/test_watcher_cli.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+import pytest
+
+from app import cli
+
+
+def _assert_lists_hello(capsys, exit_code: int) -> None:
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "hello" in {line.strip() for line in captured.out.splitlines()}
+
+
+def test_plugin_list_shows_default_plugin(capsys):
+    _assert_lists_hello(capsys, cli.main(["plugin", "list"]))
+
+
+def test_plugin_list_installed_layout(tmp_path, capsys):
+    manifest = Path("plugins.toml")
+    if not manifest.exists():
+        pytest.skip("source-layout manifest not present")
+
+    backup = tmp_path / "plugins.toml.bak"
+    manifest.rename(backup)
+    try:
+        _assert_lists_hello(capsys, cli.main(["plugin", "list"]))
+    finally:
+        backup.rename(manifest)


### PR DESCRIPTION
## Summary
- add an `app.cli` module that exposes the `watcher plugin list` command using package resources
- ship `plugins.toml` inside the `app` package and resolve it via `importlib.resources`
- update plugin reload and CLI tests to cover the installed layout scenario

## Testing
- pytest -q tests/test_plugins.py tests/test_plugin_reload.py tests/test_watcher_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cd20997b8c8320be9a362ff2f28156