### PR TITLE
Ensure CLI uses packaged plugin manifest

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -9,8 +9,8 @@ from typing import Sequence
 
 from app.tools import plugins
 
-#: Base location containing the plugin manifest.
-_plugin_base: Traversable = resources.files("app")
+#: Location of the plugin manifest bundled with the :mod:`app` package.
+_plugin_base: Traversable = resources.files("app").joinpath("plugins.toml")
 
 
 def _iter_plugins() -> list[plugins.Plugin]:

--- a/app/tools/plugins/__init__.py
+++ b/app/tools/plugins/__init__.py
@@ -72,6 +72,12 @@ def discover_entry_point_plugins(group: str = "watcher.plugins") -> list[Plugin]
 Location = Path | Traversable
 
 
+def _default_manifest() -> Traversable:
+    """Return the plugin manifest bundled with the :mod:`app` package."""
+
+    return resources.files("app").joinpath("plugins.toml")
+
+
 def _resolve_manifest(base: Location | None) -> Location | None:
     """Return the manifest file corresponding to *base*.
 
@@ -82,7 +88,7 @@ def _resolve_manifest(base: Location | None) -> Location | None:
     """
 
     if base is None:
-        manifest = resources.files("app").joinpath("plugins.toml")
+        manifest = _default_manifest()
     elif isinstance(base, Traversable):
         manifest = base if base.is_file() else base.joinpath("plugins.toml")
     else:
@@ -112,10 +118,10 @@ def reload_plugins(base: Location | None = None) -> list[Plugin]:
     ----------
     base:
         Optional base directory containing the ``plugins.toml`` file.  When
-        ``None`` the project root is used.
+        ``None`` the manifest embedded in :mod:`app` is used.
     """
 
-    manifest = _resolve_manifest(base)
+    manifest = _resolve_manifest(base if base is not None else _default_manifest())
     plugins: list[Plugin] = []
     if manifest is not None:
         try:

--- a/tests/test_watcher_cli.py
+++ b/tests/test_watcher_cli.py
@@ -1,6 +1,5 @@
+from contextlib import contextmanager
 from pathlib import Path
-
-import pytest
 
 from app import cli
 
@@ -15,14 +14,23 @@ def test_plugin_list_shows_default_plugin(capsys):
     _assert_lists_hello(capsys, cli.main(["plugin", "list"]))
 
 
-def test_plugin_list_installed_layout(tmp_path, capsys):
+@contextmanager
+def _hide_source_manifest(tmp_path: Path):
+    """Temporarily move the repository manifest out of the way."""
+
     manifest = Path("plugins.toml")
     if not manifest.exists():
-        pytest.skip("source-layout manifest not present")
+        yield
+        return
 
-    backup = tmp_path / "plugins.toml.bak"
+    backup = tmp_path / manifest.name
     manifest.rename(backup)
     try:
-        _assert_lists_hello(capsys, cli.main(["plugin", "list"]))
+        yield
     finally:
         backup.rename(manifest)
+
+
+def test_plugin_list_installed_layout(tmp_path, capsys):
+    with _hide_source_manifest(tmp_path):
+        _assert_lists_hello(capsys, cli.main(["plugin", "list"]))


### PR DESCRIPTION
## Summary
- resolve the CLI plugin manifest via `importlib.resources` so the packaged copy is used
- centralize default manifest resolution in the plugin loader for both source and installed layouts
- hide the repository manifest during the CLI test to exercise the installed-layout code path

## Testing
- pytest tests/test_watcher_cli.py
- pip wheel . -w dist (fails: missing network access for build dependencies)
- pip wheel . -w dist --no-build-isolation (fails: project metadata lacks version)


------
https://chatgpt.com/codex/tasks/task_e_68cd2baa5d748320a84ec17c1bf50c3d