### PR TITLE
Load plugin manifest from package resources

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -9,8 +9,8 @@ from typing import Sequence
 
 from app.tools import plugins
 
-#: Location of the plugin manifest bundled with the :mod:`app` package.
-_plugin_base: Traversable = resources.files("app").joinpath("plugins.toml")
+#: Base location containing the plugin manifest bundled with the :mod:`app` package.
+_plugin_base: Traversable = resources.files("app")
 
 
 def _iter_plugins() -> list[plugins.Plugin]:

--- a/app/tools/plugins/__init__.py
+++ b/app/tools/plugins/__init__.py
@@ -72,12 +72,6 @@ def discover_entry_point_plugins(group: str = "watcher.plugins") -> list[Plugin]
 Location = Path | Traversable
 
 
-def _default_manifest() -> Traversable:
-    """Return the plugin manifest bundled with the :mod:`app` package."""
-
-    return resources.files("app").joinpath("plugins.toml")
-
-
 def _resolve_manifest(base: Location | None) -> Location | None:
     """Return the manifest file corresponding to *base*.
 
@@ -88,8 +82,9 @@ def _resolve_manifest(base: Location | None) -> Location | None:
     """
 
     if base is None:
-        manifest = _default_manifest()
-    elif isinstance(base, Traversable):
+        base = resources.files("app")
+
+    if isinstance(base, Traversable):
         manifest = base if base.is_file() else base.joinpath("plugins.toml")
     else:
         base_path = Path(base)
@@ -121,7 +116,7 @@ def reload_plugins(base: Location | None = None) -> list[Plugin]:
         ``None`` the manifest embedded in :mod:`app` is used.
     """
 
-    manifest = _resolve_manifest(base if base is not None else _default_manifest())
+    manifest = _resolve_manifest(base)
     plugins: list[Plugin] = []
     if manifest is not None:
         try:

--- a/tests/test_watcher_cli.py
+++ b/tests/test_watcher_cli.py
@@ -26,6 +26,7 @@ def _hide_source_manifest(tmp_path: Path):
     backup = tmp_path / manifest.name
     manifest.rename(backup)
     try:
+        assert not manifest.exists()
         yield
     finally:
         backup.rename(manifest)


### PR DESCRIPTION
## Summary
- resolve the CLI's plugin base from importlib.resources so the packaged manifest is used in all layouts
- teach the plugin reloader to fall back to importlib.resources when no base is provided instead of relying on filesystem paths
- tighten the CLI test by temporarily removing the source-tree manifest to simulate the installed layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce9f89f6c483208d41a4fa9c90af60