### PR TITLE
Add end-of-file-fixer pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,7 @@ repos:
     hooks:
       - id: codespell
         args: [-L, crate]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: end-of-file-fixer

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ et formattage) puis Black, et `make check` délègue dorénavant à Nox.
 ### Hooks pre-commit
 
 Le dépôt inclut une configuration `pre-commit` regroupant Ruff, Black, mypy,
-Bandit, Semgrep et Codespell. Après avoir installé les dépendances de
+Bandit, Semgrep, Codespell ainsi que le correcteur `end-of-file-fixer`. Après avoir installé les dépendances de
 développement, activez les hooks localement :
 
 ```bash


### PR DESCRIPTION
## Summary
- add the official `pre-commit-hooks` repository with the `end-of-file-fixer` hook to the shared configuration
- document the new hook in the README so contributors know it runs automatically

## Testing
- ⚠️ `pre-commit install` *(fails because `pre-commit` is not available in the execution environment and `pip install pre-commit` is blocked by proxy restrictions)*
- ⚠️ `pre-commit run --all-files` *(cannot run for the same reason as above)*

------
https://chatgpt.com/codex/tasks/task_e_68cea524abf88320827c53c8f1ae2d19