### PR TITLE
Add Windows installer build and release signing workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,42 @@ jobs:
 
       - name: Run quality pipeline
         run: nox -s lint typecheck security tests build
+
+  windows-installer:
+    name: Build Windows installer
+    needs: quality
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pyinstaller
+
+      - name: Build Windows executable
+        shell: pwsh
+        run: pyinstaller packaging/watcher.spec --noconfirm
+
+      - name: Create installer archive
+        shell: pwsh
+        run: |
+          $archive = "dist/Watcher-Setup.zip"
+          if (Test-Path $archive) {
+            Remove-Item $archive
+          }
+          Compress-Archive -Path "dist/Watcher/*" -DestinationPath $archive
+
+      - name: Upload Windows installer artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Watcher-Setup
+          path: dist/Watcher-Setup.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-windows-installer:
+    name: Publish signed Windows installer
+    runs-on: windows-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Validate SemVer tag
+        shell: pwsh
+        run: |
+          if (-not ($env:GITHUB_REF_NAME -match '^v\d+\.\d+\.\d+$')) {
+            Write-Error "Release tag '$env:GITHUB_REF_NAME' must match vMAJOR.MINOR.PATCH"
+          }
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install build dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip install pyinstaller
+
+      - name: Build Windows executable
+        shell: pwsh
+        run: pyinstaller packaging/watcher.spec --noconfirm
+
+      - name: Sign executable with Sigstore
+        uses: sigstore/gh-action@v2.1.1
+        with:
+          artifact: dist/Watcher/Watcher.exe
+          bundle: dist/Watcher/Watcher.exe.sigstore
+
+      - name: Package installer archive
+        shell: pwsh
+        run: |
+          $archive = "dist/Watcher-Setup.zip"
+          if (Test-Path $archive) {
+            Remove-Item $archive
+          }
+          Compress-Archive -Path "dist/Watcher/*" -DestinationPath $archive
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/Watcher-Setup.zip
+            dist/Watcher/Watcher.exe.sigstore

--- a/packaging/watcher.spec
+++ b/packaging/watcher.spec
@@ -1,0 +1,53 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+import pathlib
+
+block_cipher = None
+
+project_root = pathlib.Path(__file__).resolve().parent.parent
+
+
+a = Analysis(
+    ['app/cli.py'],
+    pathex=[project_root.as_posix()],
+    binaries=[],
+    datas=[('app/plugins.toml', 'app')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='Watcher',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='Watcher',
+)


### PR DESCRIPTION
## Summary
- add a PyInstaller spec to package the Watcher CLI along with its plugin manifest
- extend the CI pipeline with a Windows job that builds and uploads a Watcher-Setup.zip installer
- add a release workflow that signs the Windows executable with Sigstore and publishes the signed artifacts

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cea526c7e88320bdc5e6e3e0babce1