### PR TITLE
Test Windows installer and launcher in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,5 +49,32 @@ jobs:
         run: dvc pull
         continue-on-error: true
 
+      - name: Run Windows installer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: ./installer.ps1 -SkipOllama
+
+      - name: Smoke test launcher in headless mode
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          DISPLAY: ""
+        run: |
+          $script = Join-Path $PWD.Path 'run.ps1'
+          $job = Start-Job -ScriptBlock { param($path) & $path } -ArgumentList $script
+          Start-Sleep -Seconds 5
+          if ($job.State -eq 'Failed') {
+            Receive-Job -Job $job | Out-String | Write-Host
+            throw 'run.ps1 failed to start.'
+          }
+          if ($job.State -eq 'Completed') {
+            $output = Receive-Job -Job $job | Out-String
+            Write-Host $output
+            throw 'run.ps1 exited prematurely.'
+          }
+          Stop-Job -Job $job | Out-Null
+          Receive-Job -Job $job | Out-String | Write-Host
+          Remove-Job -Job $job
+
       - name: Run quality pipeline
         run: nox -s lint typecheck security tests build

--- a/README.md
+++ b/README.md
@@ -68,8 +68,17 @@ pour bénéficier automatiquement de ce mécanisme.
 
 Sous Windows :
 
-1. `./installer.ps1`
+1. `./installer.ps1 -SkipOllama` pour installer l'environnement local sans télécharger les modèles Ollama.
+   Omettez l'option `-SkipOllama` pour déclencher l'installation complète lorsque vous avez besoin des modèles.
 2. `./run.ps1`
+
+Dans un environnement sans serveur d'affichage (CI, sessions distantes), forcez le mode headless en vidant `DISPLAY`
+avant d'exécuter le lanceur :
+
+```powershell
+$env:DISPLAY = ""
+./run.ps1
+```
 
 ### Ligne de commande
 


### PR DESCRIPTION
## Summary
- invoke the Windows installer in CI with the SkipOllama flag
- add a headless smoke test for run.ps1 on Windows runners
- document the installer and headless execution in the README

## Testing
- not run (covered by CI)

------
https://chatgpt.com/codex/tasks/task_e_68cea53a4c4c8320a2dcecae6ff04611