### PR TITLE
Add MkDocs documentation and deployment workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,37 @@
+name: Deploy MkDocs site
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install MkDocs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material[diagrams]
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: site
+          force_orphan: true

--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@
 Atelier local d'IA de programmation autonome (offline par défaut).
 Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurité.
 
+## Documentation
+
+La documentation technique est générée avec [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)
+et déployée automatiquement sur GitHub Pages : https://<github-username>.github.io/Watcher/.
+
+Pour la prévisualiser localement :
+
+```bash
+pip install -r requirements-dev.txt
+mkdocs serve
+```
+
+Le workflow GitHub Actions `deploy-docs.yml` publie le site statique à chaque push sur `main`.
+
 ## Installation
 
 1. Cloner ce dépôt.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,85 @@
+# Architecture
+
+Watcher orchestre plusieurs composants pour fournir un atelier d'IA local, sûr et traçable.
+Cette page résume leurs responsabilités et les interactions majeures.
+
+## Composants principaux
+
+- **Interface utilisateur** : scripts CLI (`python -m app.ui.main`) et automatisations (`run.ps1`) qui
+  déclenchent les scénarios d'entraînement ou d'évaluation.
+- **Orchestrateur** : modules `app.core` qui planifient les tâches, exécutent les agents et pilotent
+  le curriculum adaptatif.
+- **Agents et outils** : classes sous `app.agents` et `app.tools` responsables de la génération de code,
+  de l'analyse et de la rétroaction utilisateur.
+- **Mémoire vectorielle** : stockage persistant des connaissances et contextes dans `app.core.memory`.
+- **Qualité et sécurité** : bancs d'essai (`tests/`, `metrics/`, `QA.md`) et garde-fous (`bandit.yml`,
+  `pyproject.toml` pour les linters et hooks).
+- **Journalisation** : configuration centralisée via `app.core.logging_setup` pour tracer toutes les
+  décisions et actions.
+
+## Vue globale
+
+```mermaid
+flowchart TD
+    User[Utilisateur]
+    CLI[CLI & Scripts]
+    Core[Orchestrateur]
+    Agents[Agents spécialisés]
+    Memory[(Mémoire vectorielle)]
+    QA[Qualité & Benchmarks]
+    Logs[(Journal JSON)]
+
+    User --> CLI
+    CLI --> Core
+    Core --> Agents
+    Agents --> Memory
+    Agents --> QA
+    Core --> Logs
+    QA --> Core
+    Memory --> Agents
+```
+
+La figure met en évidence la boucle de rétroaction : les agents consultent la mémoire vectorielle,
+exécutent des outils, puis alimentent les bancs d'essai et les journaux. Les résultats réinjectés dans
+l'orchestrateur lui permettent d'affiner la stratégie d'entraînement.
+
+## Interactions détaillées
+
+```plantuml
+@startuml
+skinparam componentStyle rectangle
+skinparam shadowing false
+
+actor Utilisateur as User
+
+package "Watcher" {
+  [Interface CLI] as CLI
+  [Orchestrateur] as Orchestrator
+  [Gestion des plugins] as Plugins
+  [Curriculum adaptatif] as Curriculum
+  [Mémoire vectorielle] as VectorStore
+  [Qualité & sécurité] as Quality
+}
+
+User --> CLI : Configure & lance les runs
+CLI --> Orchestrator : Commandes
+Orchestrator --> Plugins : Découverte & exécution
+Orchestrator --> Curriculum : Mise à jour des objectifs
+Orchestrator --> VectorStore : Lecture/écriture de contexte
+Orchestrator --> Quality : Benchmarks & garde-fous
+Quality --> Orchestrator : Rapports
+VectorStore --> Plugins : Fournit le contexte
+@enduml
+```
+
+Ces interactions soulignent l'importance de la modularité : chaque composant peut être remplacé ou étendu
+sans casser la chaîne de valeur à condition de respecter les interfaces documentées.
+
+## Points d'extension
+
+- **Plugins** : `plugins.toml` et les entry points `watcher.plugins` permettent d'ajouter des capacités sans
+  modifier le noyau.
+- **Pipelines de qualité** : de nouveaux scénarios peuvent être ajoutés dans `tests/` ou `metrics/` pour
+  renforcer les contrôles.
+- **Sources de données** : les ensembles DVC sous `datasets/` peuvent être étendus avec de nouveaux corpus
+  tout en conservant la reproductibilité.

--- a/docs/ethics.md
+++ b/docs/ethics.md
@@ -1,0 +1,7 @@
+# Engagements éthiques
+
+La charte est maintenue à la racine du dépôt pour rester proche du code source.
+Elle est intégrée ci-dessous afin de pouvoir la consulter directement depuis la
+documentation construite par MkDocs.
+
+--8<-- "ETHICS.md"

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,30 @@
+# Documentation Watcher
+
+Bienvenue dans l'espace de référence du projet **Watcher**, l'atelier local d'IA de programmation autonome.
+Cette documentation complète le README et les guides techniques du dépôt en présentant la structure du
+système, son modèle de sécurité et les pratiques d'exploitation.
+
+## Organisation
+
+- Une vue d'ensemble de l'[architecture](architecture.md) décrit comment les composants principaux
+  coopèrent (agents, curriculum adaptatif, mémoire vectorielle, bancs d'essais et journalisation).
+- Le [modèle de menaces](threat-model.md) recense les actifs critiques, les risques majeurs et les
+  mesures de mitigation mises en place.
+- Les conventions de [journalisation](logging.md) détaillent la configuration du logger JSON et les bons
+  réflexes pour instrumenter le code.
+- Les feuilles de route et journaux historiques sont conservés dans
+  [ROADMAP.md](ROADMAP.md), [CHANGELOG.md](CHANGELOG.md) et le [journal de conception](journal/).
+
+!!! tip "Charte éthique"
+    La charte éthique du projet est publiée avec la documentation : consultez la page
+    [Engagements éthiques](ethics.md) pour la parcourir ou la télécharger.
+
+## Prévisualiser la documentation localement
+
+```bash
+pip install -r requirements-dev.txt
+mkdocs serve
+```
+
+La commande `mkdocs serve` démarre un serveur de développement à `http://127.0.0.1:8000` avec rechargement
+à chaud des pages lorsque les fichiers Markdown sont modifiés.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,43 @@
+# Modèle de menaces
+
+Cette analyse synthétise les actifs critiques de Watcher, les vecteurs d'attaque plausibles et les
+contre-mesures disponibles. Elle complète la charte publiée dans [ETHICS.md](ethics.md).
+
+## Actifs protégés
+
+| Actif | Description | Priorité |
+| --- | --- | --- |
+| Données utilisateur | Projets, journaux, ensembles DVC stockés localement. | Élevée |
+| Mémoire vectorielle | Représentations persistantes des apprentissages agents. | Élevée |
+| Chaîne d'exécution | Scripts Python, plugins et automatisations. | Moyenne |
+| Journal d'audit | Traces JSON (`watcher.log`) et historiques d'évaluations. | Moyenne |
+
+## Surfaces d'attaque
+
+1. **Plugins malveillants** : injection de code via `plugins.toml` ou entry points.
+2. **Manipulation de jeux de données** : corruption d'artefacts DVC ou de la mémoire vectorielle.
+3. **Fuite d'informations** : export ou transmission involontaire de journaux sensibles.
+4. **Escalade locale** : exploitation d'un script d'automatisation ou d'un outil externe mal configuré.
+
+## Mesures de mitigation
+
+- **Isolation des dépendances** : utilisation d'environnements virtuels (`.venv/`) et contrôle des versions
+  via `requirements*.txt`.
+- **Revue de code** : hooks `pre-commit`, linting (Ruff), analyse statique (mypy) et audits de sécurité
+  (Bandit, Semgrep) exécutés par Nox et CI.
+- **Surveillance** : journalisation JSON centralisée et rotation configurable pour tracer chaque action.
+- **Gouvernance des données** : DVC impose un suivi précis des jeux de données et facilite les vérifications
+  d'intégrité.
+- **Contrôles utilisateurs** : la charte [ETHICS.md](ethics.md) rappelle les bonnes pratiques de gestion des
+  retours et des données sensibles.
+
+## Recommandations opérationnelles
+
+!!! warning "Limiter la surface réseau"
+    Le projet est conçu pour fonctionner hors ligne. Désactiver ou auditer toute communication externe
+    ajoutée par des plugins tiers.
+
+!!! note "Scénarios d'incident"
+    - Maintenir des sauvegardes chiffrées de la mémoire vectorielle et des datasets.
+    - Documenter les procédures de révocation de plugins douteux.
+    - Consigner les analyses post-mortem dans `docs/journal/` pour capitaliser sur les retours d'expérience.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,62 @@
+site_name: "Watcher"
+site_description: "Documentation technique et opérationnelle de l'atelier Watcher"
+site_url: "https://<github-username>.github.io/Watcher/"
+repo_url: "https://github.com/<github-username>/Watcher"
+theme:
+  name: material
+  language: fr
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+    - toc.follow
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - toc:
+      permalink: "#"
+  - pymdownx.details
+  - pymdownx.highlight
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      base_path:
+        - docs
+        - .
+      check_paths: true
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+        - name: plantuml
+          class: plantuml
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:pymdownx.emoji.to_svg
+  - pymdownx.plantuml:
+      server: https://www.plantuml.com/plantuml
+plugins:
+  - search
+nav:
+  - Accueil: index.md
+  - Architecture:
+      - Vue d'ensemble: architecture.md
+      - Journal de conception:
+          - 2025-09-12: journal/2025-09-12.md
+          - 2025-09-14: journal/2025-09-14.md
+          - 2025-09-19: journal/2025-09-19.md
+  - Exploitation:
+      - Conventions de logging: logging.md
+      - Feuille de route: ROADMAP.md
+      - Journal des modifications: CHANGELOG.md
+  - Sécurité:
+      - Modèle de menaces: threat-model.md
+      - Charte éthique: ethics.md
+extra_javascript:
+  - https://unpkg.com/mermaid@10.9.1/dist/mermaid.min.js

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,5 @@ pre-commit==3.8.0
 pytest==8.3.2
 ruff==0.6.9
 semgrep==1.91.0
+mkdocs==1.6.0
+mkdocs-material[diagrams]==9.5.25


### PR DESCRIPTION
## Summary
- add a MkDocs configuration using the Material theme and diagram support
- restructure docs/ with index, architecture, threat model, and ethics pages
- configure a GitHub Actions workflow to build and publish the site and document the Pages URL in the README

## Testing
- pip install mkdocs mkdocs-material[diagrams] *(fails: proxy 403 when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_68cea53a19e48320a858c5a8159c2baa