### PR TITLE
Ensure packaged plugin manifest is used by CLI

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -9,14 +9,14 @@ from typing import Sequence
 
 from app.tools import plugins
 
-#: Base location containing the plugin manifest bundled with the :mod:`app` package.
-_plugin_base: Traversable = resources.files("app")
+#: Manifest bundled with the :mod:`app` package.
+_PLUGIN_MANIFEST: Traversable = resources.files("app") / "plugins.toml"
 
 
 def _iter_plugins() -> list[plugins.Plugin]:
     """Return all configured plugin instances."""
 
-    return plugins.reload_plugins(_plugin_base)
+    return plugins.reload_plugins(_PLUGIN_MANIFEST)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/app/tools/plugins/__init__.py
+++ b/app/tools/plugins/__init__.py
@@ -82,22 +82,26 @@ def _resolve_manifest(base: Location | None) -> Location | None:
     """
 
     if base is None:
-        base = resources.files("app")
-
-    if isinstance(base, Traversable):
-        manifest = base if base.is_file() else base.joinpath("plugins.toml")
+        manifest: Location = resources.files("app") / "plugins.toml"
     else:
-        base_path = Path(base)
-        manifest = base_path if base_path.is_file() else base_path / "plugins.toml"
+        manifest = base
 
     if isinstance(manifest, Traversable):
-        if not manifest.is_file():
-            return None
-        return manifest
-
-    if not manifest.exists():
+        if manifest.is_file():
+            return manifest
+        candidate = manifest / "plugins.toml"
+        if candidate.is_file():
+            return candidate
         return None
-    return manifest
+
+    base_path = Path(manifest)
+    if base_path.is_file():
+        return base_path
+
+    candidate_path = base_path / "plugins.toml"
+    if candidate_path.exists():
+        return candidate_path
+    return None
 
 
 def _read_manifest(manifest: Location) -> str:
@@ -112,8 +116,8 @@ def reload_plugins(base: Location | None = None) -> list[Plugin]:
     Parameters
     ----------
     base:
-        Optional base directory containing the ``plugins.toml`` file.  When
-        ``None`` the manifest embedded in :mod:`app` is used.
+        Optional base directory or manifest file containing ``plugins.toml``.
+        When ``None`` the manifest embedded in :mod:`app` is used.
     """
 
     manifest = _resolve_manifest(base)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ target-version = ["py312"]
 [tool.ruff]
 line-length = 88
 
+[tool.setuptools]
+include-package-data = true
+
 [tool.setuptools.package-data]
 "app" = ["plugins.toml"]
 

--- a/tests/test_watcher_cli.py
+++ b/tests/test_watcher_cli.py
@@ -19,19 +19,19 @@ def _hide_source_manifest(tmp_path: Path):
     """Temporarily move the repository manifest out of the way."""
 
     manifest = Path("plugins.toml")
-    if not manifest.exists():
-        yield
-        return
-
-    backup = tmp_path / manifest.name
-    manifest.rename(backup)
+    backup = None
+    if manifest.exists():
+        backup = tmp_path / manifest.name
+        manifest.rename(backup)
     try:
         assert not manifest.exists()
         yield
     finally:
-        backup.rename(manifest)
+        if backup is not None:
+            backup.rename(manifest)
 
 
 def test_plugin_list_installed_layout(tmp_path, capsys):
     with _hide_source_manifest(tmp_path):
+        assert not Path("plugins.toml").exists()
         _assert_lists_hello(capsys, cli.main(["plugin", "list"]))


### PR DESCRIPTION
## Summary
- include the plugins.toml manifest in the wheel by enabling setuptools package data
- load the packaged manifest via importlib.resources in the CLI and plugin loader
- extend the CLI test to cover the absence of the repository manifest

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cea5274b68832095467ddbf12433cf