### PR TITLE
Add workflow governance docs and templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Consultez README.md pour la gouvernance des revues et la signification des labels.
+# Les équipes référencées doivent exister dans l'organisation GitHub hébergeant ce dépôt.
+
+*               @WatcherOrg/maintainers
+app/            @WatcherOrg/maintainers
+config/         @WatcherOrg/security-team
+docs/           @WatcherOrg/documentation
+tests/          @WatcherOrg/qa
+.github/        @WatcherOrg/maintainers

--- a/.github/DISCUSSION_TEMPLATE/guidance.yml
+++ b/.github/DISCUSSION_TEMPLATE/guidance.yml
@@ -1,0 +1,28 @@
+name: Support & architecture
+description: Poser une question sur l'architecture, le design ou l'utilisation de Watcher.
+title: "[Discussion]: "
+labels:
+  - discussion
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Utilisez ce modèle pour recueillir l'avis de la communauté ou valider une approche avant d'ouvrir une Pull Request.
+  - type: textarea
+    id: question
+    attributes:
+      label: Sujet
+      description: Décrivez la question principale ou le point de décision.
+      placeholder: "Quel module dois-je étendre pour ... ?"
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Contexte
+      description: Précisez ce que vous avez déjà essayé et fournissez les liens utiles.
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Pistes envisagées
+      description: Si vous avez une solution en tête, décrivez-la ici.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Rapport de bug
+description: Signaler un comportement inattendu ou une régression.
+title: "[Bug]: "
+labels:
+  - bug
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Merci de décrire clairement le bug rencontré. Consultez la documentation QA pour vérifier les étapes de reproduction.
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prérequis
+      description: Vérifiez ces points avant de soumettre un bug.
+      options:
+        - label: J'ai vérifié qu'une issue similaire n'existe pas déjà.
+          required: true
+        - label: J'ai exécuté `make check` (ou `nox -s lint typecheck security tests`) et fourni les journaux pertinents.
+          required: false
+        - label: J'ai inclus les informations de version/environnement nécessaires.
+          required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description du bug
+      description: Résumez le comportement observé et le comportement attendu.
+      placeholder: "Le bouton X reste désactivé après..."
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Étapes de reproduction
+      description: Listez les étapes pour reproduire le bug.
+      placeholder: |
+        1. Aller sur...
+        2. Cliquer sur...
+        3. Observer...
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs et sorties
+      description: Collez les logs, traces ou captures d'écran utiles.
+      render: shell
+  - type: input
+    id: environment
+    attributes:
+      label: Environnement
+      description: Système d'exploitation, version Python, commit, etc.
+      placeholder: ex. Ubuntu 22.04, Python 3.12, commit abc1234
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation QA
+    url: https://github.com/WatcherOrg/Watcher/blob/main/QA.md
+    about: Consultez la check-list QA avant d'ouvrir un ticket.
+  - name: Guide des labels et des revues
+    url: https://github.com/WatcherOrg/Watcher/blob/main/docs/merge-policy.md
+    about: Résumé du workflow de tri, des labels et de l'automerge.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Demande de fonctionnalité
+description: Proposer une amélioration ou une nouvelle fonctionnalité.
+title: "[Feature]: "
+labels:
+  - enhancement
+  - needs-triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Merci de détailler la valeur ajoutée pour les utilisateurs ainsi que les impacts potentiels.
+  - type: checkboxes
+    id: impact
+    attributes:
+      label: Alignement
+      options:
+        - label: Cette demande respecte les objectifs décrits dans `docs/ROADMAP.md`.
+        - label: J'ai vérifié qu'aucune issue ouverte ne couvre déjà ce besoin.
+          required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Description
+      description: Expliquez la proposition et le problème sous-jacent.
+      placeholder: "En tant qu'utilisateur, je voudrais..."
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution proposée
+      description: Détaillez l'approche technique ou UX pressentie.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives envisagées
+      description: Mentionnez les autres options étudiées et pourquoi elles n'ont pas été retenues.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Contexte supplémentaire
+      description: Ajouter des liens, maquettes, références ou contraintes.

--- a/QA.md
+++ b/QA.md
@@ -6,6 +6,9 @@
 2. Commits atomiques (`feat: …`, `fix: …`, `docs: …`)
 3. `git push` puis ouverture d'une Pull Request
 4. Revue externe et fusion après `make check`
+5. Laisser le label par défaut `needs-triage` sur la PR ; un mainteneur le
+   retirera après revue. Une fois la CI verte, seul un mainteneur pose
+   `automerge` pour déclencher la fusion automatique.
 
 ## Manual Verification
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,22 @@ La configuration `bandit.yml` exclut notamment les répertoires `.git`, `dataset
 `.venv`, `build`, `dist` et `*.egg-info` afin d'éviter l'analyse de contenus
 non pertinents.
 
+## Gouvernance des contributions
+
+- Les modèles disponibles dans `.github/ISSUE_TEMPLATE/` ajoutent automatiquement
+  les labels `needs-triage` et `bug`/`enhancement` selon le type d'issue. Le
+  modèle de discussion sous `.github/DISCUSSION_TEMPLATE/` applique le label
+  `discussion`.
+- Le fichier `.github/CODEOWNERS` assigne les revues aux équipes responsables.
+  Adaptez les alias (`@WatcherOrg/...`) à votre organisation GitHub.
+- Avant toute fusion, assurez-vous que `nox -s lint typecheck security tests
+  build` est vert sur la CI et qu'au moins un CODEOWNER a approuvé la PR. Un
+  mainteneur peut ensuite poser le label `automerge` qui déclenchera la fusion
+  automatique.
+
+Pour plus de détails (priorités, gestion du label `blocked`, etc.), consultez
+`docs/merge-policy.md`.
+
 ## Reproductibilité
 
 Un utilitaire `set_seed` permet de fixer la graine aléatoire pour Python,

--- a/docs/merge-policy.md
+++ b/docs/merge-policy.md
@@ -1,0 +1,43 @@
+# Gouvernance des issues et des Pull Requests
+
+Ce document complète le README en décrivant la façon dont les labels, les CODEOWNERS et
+automations GitHub sont utilisés pour assurer un cycle de revue cohérent.
+
+## Triage et labels
+
+| Label            | Usage | Responsable |
+| ---------------- | ----- | ----------- |
+| `needs-triage`   | Ajouté automatiquement tant que la demande n'a pas été classée. | Mainteneurs |
+| `bug`            | Rattaché aux rapports créés via le template dédié. | Demandeur |
+| `enhancement`    | Attaché aux demandes de fonctionnalités. | Demandeur |
+| `discussion`     | Appliqué automatiquement pour les discussions d'architecture. | Demandeur |
+| `blocked`        | Indique qu'une PR est en attente d'une dépendance externe. | Mainteneurs |
+| `automerge`      | Déclenche la fusion automatique une fois la CI verte et les revues obtenues. | Mainteneurs |
+
+Lors du tri, le mainteneur assigne un propriétaire fonctionnel, met à jour les
+labels (ex. priorité, composant) et retire `needs-triage`.
+
+## CODEOWNERS et revues
+
+Le fichier `.github/CODEOWNERS` enregistre les équipes responsables des
+composants. Toute Pull Request modifiant un répertoire listé déclenche
+automatiquement une demande de revue auprès de l'équipe correspondante.
+
+- Les équipes renseignées doivent exister dans l'organisation GitHub du dépôt
+  (ex. `@WatcherOrg/maintainers`).
+- Si un sous-répertoire n'est pas couvert, ajoutez une entrée dédiée afin
+  d'expliciter le propriétaire.
+
+## Conditions de fusion
+
+1. Les jobs `nox -s lint typecheck security tests build` déclenchés par la CI
+   doivent réussir sur les trois plateformes supportées.
+2. Au moins un membre de l'équipe CODEOWNER concernée approuve la PR.
+3. Le label `automerge` peut être posé par un mainteneur une fois les points 1 et
+   2 respectés. Le workflow `.github/workflows/automerge.yml` fusionne alors la PR
+   avec la méthode `merge`.
+4. En cas de fusion manuelle, les mainteneurs suivent la même check-list et
+   retirent `automerge` si la fusion doit être différée.
+
+Pour des modifications sensibles (sécurité, configuration), ajoutez
+`blocked` jusqu'à la validation explicite du plan d'action.


### PR DESCRIPTION
## Summary
- add GitHub issue and discussion templates with triage labels
- document reviewers in a CODEOWNERS file and describe label usage
- update README and QA guide with automerge workflow details

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cea538b6508320aa59d0dcdd9b2080