### PR TITLE
Add Alembic migrations and optional SQLCipher support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,44 @@ Un utilitaire `create_python_cli` (dans `app.tools.scaffold`) permet de
 générer un squelette de projet sous `app/projects/<nom>`. Passer
 `force=True` écrase les fichiers existants sans demande de confirmation.
 
+## Base de données
+
+Watcher persiste ses souvenirs dans une base SQLite configurée automatiquement en
+mode `WAL`, avec les clés étrangères, un délai d'attente de 5 secondes et
+`secure_delete`. Le module FTS5 est enregistré lors de la première connexion pour
+préparer les futures recherches plein texte.
+
+Le schéma est piloté par [Alembic](https://alembic.sqlalchemy.org/). Les
+migrations présentes dans le dossier `migrations/` sont appliquées au démarrage
+de l'application (`alembic upgrade head`). Vous pouvez également les exécuter
+manuellement :
+
+```bash
+alembic upgrade head
+```
+
+### SQLCipher
+
+La base peut être chiffrée avec [SQLCipher](https://www.zetetic.net/sqlcipher/)
+si la bibliothèque est disponible sur votre système. Pour l'activer :
+
+1. Installer SQLite/SQLCipher compatible (par exemple via les paquets de votre
+   distribution ou les binaires officiels).
+2. Activer la section `[memory.sqlcipher]` dans `config/settings.toml` :
+
+   ```toml
+   [memory.sqlcipher]
+   enabled = true
+   password_env = "WATCHER_SQLCIPHER_PASSWORD"
+   ```
+
+3. Fournir un mot de passe soit via la variable d'environnement indiquée,
+   soit directement avec la clé `password`.
+
+Watcher vérifie automatiquement la présence de SQLCipher ; si la fonctionnalité
+est activée mais que la bibliothèque n'est pas détectée, l'initialisation
+échoue explicitement afin d'éviter d'utiliser une base non chiffrée.
+
 ## Plugins
 
 Watcher peut être étendu par des plugins implémentant l'interface

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,40 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+
+# This value is overridden at runtime by Memory._run_migrations.
+sqlalchemy.url = sqlite:///memory/mem.db
+
+db_module = sqlite3
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)s %(name)s %(message)s

--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -41,7 +41,7 @@ class Engine:
         if not path.is_absolute():
             path = self.base / path
 
-        self.mem = Memory(path)
+        self.mem = Memory(path, sqlcipher=cfg.get("sqlcipher"))
         self.qg = QualityGate()
         self.bench = Bench()
         self.learner = Learner(self.bench, self.base / "data")

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -26,6 +26,10 @@ embed_model = "nomic-embed-text"
 embed_host = "127.0.0.1:11434"
 summary_max_tokens = 512
 
+[memory.sqlcipher]
+enabled = false
+password_env = "WATCHER_SQLCIPHER_PASSWORD"
+
 [learn]
 optimizer = "adam"
 learning_rate = 0.1

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.engine import Connection
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# There is no SQLAlchemy metadata to reflect because the project relies on raw SQL.
+target_metadata = None
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode."""
+
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode."""
+
+    connectable: Connection | None = config.attributes.get("connection")
+
+    if connectable is None:
+        connectable = engine_from_config(
+            config.get_section(config.config_ini_section, {}),
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+        ).connect()
+
+    try:
+        context.configure(connection=connectable, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+    finally:
+        if config.attributes.get("connection") is None:
+            connectable.close()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,27 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/0001_create_memory_schema.py
+++ b/migrations/versions/0001_create_memory_schema.py
@@ -1,0 +1,52 @@
+"""Create baseline memory schema
+
+Revision ID: 0001_create_memory_schema
+Revises: 
+Create Date: 2024-10-07 00:00:00
+
+"""
+from __future__ import annotations
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "0001_create_memory_schema"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS items(
+            id INTEGER PRIMARY KEY,
+            kind TEXT,
+            text TEXT,
+            vec BLOB,
+            ts REAL
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_items_kind_ts ON items(kind, ts)"
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS feedback(
+            id INTEGER PRIMARY KEY,
+            kind TEXT,
+            prompt TEXT,
+            answer TEXT,
+            rating REAL,
+            ts REAL
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS feedback")
+    op.execute("DROP INDEX IF EXISTS idx_items_kind_ts")
+    op.execute("DROP TABLE IF EXISTS items")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
-﻿httpx==0.27.0
+httpx==0.27.0
 rich==13.7.1
 beautifulsoup4==4.12.2
 sentence-transformers==2.2.2
+SQLAlchemy==2.0.32
+alembic==1.13.2


### PR DESCRIPTION
## Summary
- configure the SQLite memory backend to apply WAL mode, foreign keys, busy timeout, secure delete, and optional SQLCipher with FTS5 registration
- wire Alembic migrations that run automatically on startup with a safe fallback when Alembic is unavailable
- document the database workflow and SQLCipher activation while updating configuration and dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cea52e9c3c8320994742d10b577928