### PR TITLE
refactor: isolate psutil stub

### DIFF
--- a/app/core/engine.py
+++ b/app/core/engine.py
@@ -29,6 +29,11 @@ from app.data import pipeline
 from app.data.validation import validate_feedback_schema
 from app.tools import plugins
 from app.utils.metrics import metrics
+
+try:  # pragma: no cover - optional dependency
+    import psutil  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - fallback
+    from app.utils import psutil_stub as psutil  # type: ignore[assignment]
 from app.core.logging_setup import get_logger
 from app.core import sandbox
 

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,4 +1,5 @@
 from .np import np
 from .metrics import metrics, PerformanceMetrics
+from . import psutil_stub
 
-__all__ = ["np", "metrics", "PerformanceMetrics"]
+__all__ = ["np", "metrics", "PerformanceMetrics", "psutil_stub"]

--- a/app/utils/psutil_stub.py
+++ b/app/utils/psutil_stub.py
@@ -1,0 +1,97 @@
+"""Minimal psutil replacement used when the third-party dependency is absent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Iterator
+
+__all__ = [
+    "STUB_CPU_PERCENT",
+    "STUB_MEMORY_TOTAL",
+    "STUB_MEMORY_AVAILABLE",
+    "STUB_MEMORY_USED",
+    "STUB_MEMORY_PERCENT",
+    "cpu_percent",
+    "virtual_memory",
+    "Process",
+    "process_iter",
+]
+
+# Deterministic values exposed for tests that rely on predictable metrics.
+STUB_CPU_PERCENT: float = 12.5
+STUB_MEMORY_TOTAL: int = 8 * 1024 * 1024 * 1024
+STUB_MEMORY_AVAILABLE: int = 5 * 1024 * 1024 * 1024
+STUB_MEMORY_USED: int = STUB_MEMORY_TOTAL - STUB_MEMORY_AVAILABLE
+STUB_MEMORY_PERCENT: float = round((STUB_MEMORY_USED / STUB_MEMORY_TOTAL) * 100.0, 1)
+
+
+@dataclass(frozen=True)
+class _VirtualMemory:
+    """Subset of :func:`psutil.virtual_memory` result used by Watcher."""
+
+    total: int
+    available: int
+    percent: float
+    used: int
+    free: int
+
+
+@dataclass(frozen=True)
+class _ProcessMemoryInfo:
+    """Lightweight stand-in for :class:`psutil.Process` memory info."""
+
+    rss: int
+    vms: int
+
+
+class Process:
+    """Simplified representation of :class:`psutil.Process`."""
+
+    def __init__(self, pid: int | None = None) -> None:
+        self.pid = pid if pid is not None else os.getpid()
+
+    def cpu_percent(self, interval: float | None = None) -> float:
+        """Return the deterministic CPU percentage used by the stub."""
+
+        return STUB_CPU_PERCENT
+
+    def memory_info(self) -> _ProcessMemoryInfo:
+        """Return fake RSS/VMS metrics mimicking :mod:`psutil`."""
+
+        return _ProcessMemoryInfo(rss=STUB_MEMORY_USED, vms=STUB_MEMORY_USED)
+
+    def num_threads(self) -> int:
+        return 1
+
+    def name(self) -> str:
+        return "watcher"
+
+
+def cpu_percent(interval: float | None = None) -> float:
+    """Return the deterministic CPU percentage used by tests."""
+
+    return STUB_CPU_PERCENT
+
+
+def virtual_memory() -> _VirtualMemory:
+    """Return predictable virtual memory information."""
+
+    return _VirtualMemory(
+        total=STUB_MEMORY_TOTAL,
+        available=STUB_MEMORY_AVAILABLE,
+        percent=STUB_MEMORY_PERCENT,
+        used=STUB_MEMORY_USED,
+        free=STUB_MEMORY_AVAILABLE,
+    )
+
+
+def process_iter(attrs: tuple[str, ...] | None = None) -> Iterator[Process]:  # noqa: ARG001
+    """Yield a single stub :class:`Process` instance.
+
+    The real :func:`psutil.process_iter` returns an iterator over running
+    processes. The stub only needs to provide enough structure for tests that
+    inspect the currently running process.
+    """
+
+    yield Process()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+"""Shared pytest fixtures for the Watcher test suite."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+@pytest.fixture
+def psutil_stub(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Provide the lightweight :mod:`psutil` fallback used in tests."""
+
+    try:
+        stub = importlib.import_module("app.utils.psutil_stub")
+    except Exception:  # pragma: no cover - dependency bootstrap
+        module_name = "app.utils.psutil_stub"
+        path = Path(__file__).resolve().parents[1] / "app" / "utils" / "psutil_stub.py"
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        if spec is None or spec.loader is None:  # pragma: no cover - defensive
+            raise ImportError("unable to load psutil_stub module")
+        stub = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = stub
+        spec.loader.exec_module(stub)
+    monkeypatch.setitem(sys.modules, "psutil", stub)
+    return stub


### PR DESCRIPTION
## Summary
- add a dedicated `app/utils/psutil_stub.py` module with deterministic CPU and memory metrics
- expose the stub through `app.utils` and update `Engine` to prefer the real `psutil` package before falling back
- provide a pytest fixture that loads the stub on demand so tests can opt into deterministic behaviour

## Testing
- pytest tests/test_plugins.py tests/test_watcher_cli.py tests/test_ui_feedback.py *(fails: missing optional dependency `pydantic` required by app configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ceada2e8ac8320b875f65c7aec6b8a