### PR TITLE
Ensure packaged plugin manifest works without repository file

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-from importlib import resources
 from importlib.resources.abc import Traversable
 from typing import Sequence
 
@@ -11,7 +10,7 @@ from config import get_settings
 from app.tools import plugins
 
 #: Manifest bundled with the :mod:`app` package.
-_PLUGIN_MANIFEST: Traversable = resources.files("app") / "plugins.toml"
+_PLUGIN_MANIFEST: Traversable = plugins.DEFAULT_MANIFEST
 
 
 def _iter_plugins() -> list[plugins.Plugin]:

--- a/app/tools/plugins/__init__.py
+++ b/app/tools/plugins/__init__.py
@@ -16,6 +16,9 @@ from typing import Iterable, Protocol
 
 import tomllib
 
+#: Manifest bundled with the :mod:`app` package.
+DEFAULT_MANIFEST: Traversable = resources.files("app") / "plugins.toml"
+
 
 class Plugin(Protocol):
     """Interface commune à toutes les extensions Watcher.
@@ -200,7 +203,7 @@ def _resolve_manifest(base: Location | None) -> Location | None:
     """
 
     if base is None:
-        manifest: Location = resources.files("app") / "plugins.toml"
+        manifest: Location = DEFAULT_MANIFEST
     else:
         manifest = base
 
@@ -308,6 +311,7 @@ __all__ = [
     "Plugin",
     "LoadedPlugin",
     "SUPPORTED_PLUGIN_API_VERSION",
+    "DEFAULT_MANIFEST",
     "compute_module_signature",
     "reload_plugins",
     "discover_entry_point_plugins",

--- a/tests/test_watcher_cli.py
+++ b/tests/test_watcher_cli.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+from importlib import resources
 from pathlib import Path
 
 from app import cli
@@ -34,4 +35,6 @@ def _hide_source_manifest(tmp_path: Path):
 def test_plugin_list_installed_layout(tmp_path, capsys):
     with _hide_source_manifest(tmp_path):
         assert not Path("plugins.toml").exists()
+        manifest = resources.files("app") / "plugins.toml"
+        assert manifest.is_file()
         _assert_lists_hello(capsys, cli.main(["plugin", "list"]))


### PR DESCRIPTION
## Summary
- expose a shared `DEFAULT_MANIFEST` pointing at the packaged `plugins.toml`
- reuse the shared manifest inside the CLI entry point
- extend the CLI test to cover the repository manifest being hidden while the packaged copy remains available

## Testing
- pytest tests/test_watcher_cli.py -q *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68cebfcd085c8320905ce96cc957397f