### PR TITLE
Configure pre-commit EOF fixer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,3 +33,4 @@ repos:
     rev: v4.6.0
     hooks:
       - id: end-of-file-fixer
+        name: Ensure files end with a newline

--- a/QA.md
+++ b/QA.md
@@ -25,6 +25,13 @@ Install the development dependencies:
 pip install -r requirements-dev.txt
 ```
 
+Install the Git hooks once the dependencies are available:
+
+```
+pre-commit install
+pre-commit run --all-files
+```
+
 Run Bandit to scan the codebase while ignoring Git metadata:
 
 ```


### PR DESCRIPTION
## Summary
- configure the `pre-commit-hooks` repository to run the `end-of-file-fixer` hook with a descriptive name
- mention running `pre-commit install` and `pre-commit run --all-files` in the QA checklist for static analysis setup

## Testing
- `pre-commit install` *(fails: `pre-commit` executable unavailable; pip install blocked by proxy)*
- `pre-commit run --all-files` *(fails: `pre-commit` executable unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68cec572a2008320a67f1501ba49c0e7