### PR TITLE
Ensure plugin manifest available from installed package

### DIFF
--- a/app/tools/plugins/__init__.py
+++ b/app/tools/plugins/__init__.py
@@ -242,6 +242,20 @@ def reload_plugins(base: Location | None = None) -> list[LoadedPlugin]:
     """
 
     manifest = _resolve_manifest(base)
+    if manifest is None:
+        try:
+            candidate = resources.files("app") / "plugins.toml"
+        except ModuleNotFoundError:
+            logging.debug(
+                "Unable to locate packaged plugin manifest; app package missing"
+            )
+        else:
+            if candidate.is_file():
+                manifest = candidate
+            else:
+                logging.debug(
+                    "Unable to locate packaged plugin manifest inside app package"
+                )
     plugins: list[LoadedPlugin] = []
     if manifest is not None:
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,5 @@ line-length = 88
 include-package-data = true
 
 [tool.setuptools.package-data]
-"app" = ["plugins.toml"]
+"app" = ["*.toml"]
 


### PR DESCRIPTION
## Summary
- include all TOML resources from the `app` package in the wheel so the plugin manifest ships with the distribution
- fall back to the packaged `plugins.toml` when reloading plugins if a filesystem manifest is missing
- harden CLI and plugin reload tests by masking the repository manifest and stubbing configuration loading

## Testing
- pytest tests/test_watcher_cli.py tests/test_plugin_reload.py

------
https://chatgpt.com/codex/tasks/task_e_68cec57394a08320bcf6f80fbdcdab07