### PR TITLE
Add typed settings sections and logging configuration support

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -23,6 +23,7 @@ from app.configuration import (
     DatasetSettings,
     DevSettings,
     EmbeddingsSettings,
+    LoggingSettings,
     IntelligenceSettings,
     LLMSettings,
     LearningSettings,
@@ -122,6 +123,9 @@ class _TomlSettingsSource(PydanticBaseSettingsSource):
                 )
         return data
 
+    def get_field_value(self, field_name: str, field, value: Any) -> tuple[Any, bool]:
+        return value, False
+
 
 class Settings(BaseSettings):
     """Typed configuration object backed by ``pydantic-settings``."""
@@ -150,6 +154,7 @@ class Settings(BaseSettings):
     dataset: DatasetSettings = Field(default_factory=DatasetSettings)
     embeddings: EmbeddingsSettings = Field(default_factory=EmbeddingsSettings)
     sandbox: SandboxSettings = Field(default_factory=SandboxSettings)
+    logging: LoggingSettings = Field(default_factory=LoggingSettings)
     critic: CriticSettings = Field(default_factory=CriticSettings)
 
     @classmethod

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -15,6 +15,9 @@ fallback_phrase = "Echo"
 logging = "debug"
 trace_requests = false
 
+[logging]
+fallback_level = "INFO"
+
 [planner]
 default_platform = "windows"
 default_license = "MIT"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ def test_load_existing_config():
     settings = get_settings()
     assert settings.llm.model == "llama3.2:3b"
     assert settings.llm.backend == "ollama"
+    assert settings.logging.fallback_level == "INFO"
 
 
 def test_missing_base_file(monkeypatch):

--- a/tests/test_settings_validation.py
+++ b/tests/test_settings_validation.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from app.configuration import (
     LLMSettings,
+    LoggingSettings,
     MemorySettings,
     PathsSettings,
     SandboxSettings,
@@ -30,3 +31,13 @@ def test_paths_resolve_relative(tmp_path: Path) -> None:
     paths = PathsSettings(base_dir=tmp_path)
     resolved = paths.resolve(Path("subdir") / "file.txt")
     assert resolved == (tmp_path / "subdir" / "file.txt").resolve()
+
+
+def test_logging_level_must_be_known() -> None:
+    with pytest.raises(ValidationError):
+        LoggingSettings(fallback_level="invalid")
+
+
+def test_logging_level_normalised() -> None:
+    cfg = LoggingSettings(fallback_level="debug")
+    assert cfg.fallback_level == "DEBUG"


### PR DESCRIPTION
## Summary
- convert all configuration sections to `BaseSettings` via a shared helper and add a dedicated `LoggingSettings`
- expose the typed logging section through the global `Settings` factory and honour it when configuring logging
- extend the default TOML configuration and validation tests for the new logging options

## Testing
- pytest tests/test_settings_validation.py tests/test_config.py tests/test_config_profiles.py tests/test_app_config_env.py tests/test_config_invalid_toml.py tests/test_structured_logs.py

------
https://chatgpt.com/codex/tasks/task_e_68cec5764ecc8320aabe12adca1bc5bd