### PR TITLE
Add deterministic seeding controls across CLI and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12"]
     env:
-      PYTHONHASHSEED: "0"
+      PYTHONHASHSEED: "42"
+      WATCHER_TRAINING__SEED: "42"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -191,6 +191,14 @@ NumPy et, si disponible, PyTorch. Le fichier de configuration `config/settings.t
 contient un paramètre `seed` dans la section `[training]` qui peut être adapté
 pour garantir des exécutions déterministes.
 
+La commande CLI `watcher` applique automatiquement cette graine dès son
+démarrage afin d'initialiser toutes les bibliothèques stochastiques. Une
+option `--seed` est disponible pour surcharger ponctuellement la valeur par
+défaut définie dans `config/settings.toml`. Pour les exécutions automatisées,
+exportez `PYTHONHASHSEED` ainsi que `WATCHER_TRAINING__SEED` avant de lancer
+Nox ou vos scripts afin d'aligner l'environnement avec la configuration
+versionnée.
+
 ## Données
 
 La pipeline [DVC](https://dvc.org/) décrite dans `dvc.yaml` prépare et valide le

--- a/app/cli.py
+++ b/app/cli.py
@@ -7,6 +7,7 @@ from importlib.resources.abc import Traversable
 from typing import Sequence
 
 from config import get_settings
+from app.core.reproducibility import set_seed
 from app.tools import plugins
 
 #: Manifest bundled with the :mod:`app` package.
@@ -30,6 +31,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"{settings.llm.backend} / model: {settings.llm.model})"
         ),
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=settings.training.seed,
+        help=(
+            "Graine aléatoire utilisée pour toutes les composantes stochastiques. "
+            "Par défaut, celle définie dans config/settings.toml."
+        ),
+    )
+
     sub = parser.add_subparsers(dest="command", required=True)
 
     plugin_parser = sub.add_parser("plugin", help="Plugin related commands")
@@ -37,6 +48,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     plugin_sub.add_parser("list", help="List available plugins")
 
     args = parser.parse_args(argv)
+
+    set_seed(args.seed)
 
     if args.command == "plugin" and args.plugin_command == "list":
         for plugin in _iter_plugins():

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -11,6 +11,7 @@ import os
 import tomllib
 
 from pydantic import Field
+from pydantic.fields import FieldInfo
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -105,6 +106,18 @@ class _TomlSettingsSource(PydanticBaseSettingsSource):
 
     def __init__(self, settings_cls: type[BaseSettings]) -> None:
         super().__init__(settings_cls)
+        self._data: dict[str, Any] | None = None
+
+    def get_field_value(
+        self, field: FieldInfo, field_name: str
+    ) -> tuple[Any, str, bool]:
+        """Return stored TOML values for a specific field."""
+
+        if self._data is None:
+            return None, field_name, False
+        value = self._data.get(field_name)
+        is_complex = isinstance(value, (dict, list))
+        return value, field_name, is_complex
 
     def __call__(self) -> dict[str, Any]:
         base_path = _CONFIG_DIR / "settings.toml"
@@ -120,6 +133,7 @@ class _TomlSettingsSource(PydanticBaseSettingsSource):
                 logger.warning(
                     "Profile configuration file not found: %s", profile_path
                 )
+        self._data = data
         return data
 
 

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import os
 import random
 
+from app import cli
 from app.core.reproducibility import set_seed
 from app.utils import np
 
@@ -18,3 +20,38 @@ def test_set_seed_reproducible():
     assert py_vals == [random.random() for _ in range(3)]
     if HAS_NUMPY_RNG:
         assert np.allclose(np_vals, np.random.rand(3))
+
+
+def _run_cli_and_sample(args: list[str]) -> tuple[str | None, list[float]]:
+    random.seed(999)
+    exit_code = cli.main(args)
+    assert exit_code == 0
+    return os.environ.get("PYTHONHASHSEED"), [random.random() for _ in range(3)]
+
+
+def test_cli_reproducibility_end_to_end(monkeypatch):
+    monkeypatch.setenv("PYTHONHASHSEED", "0")
+
+    env_seed, seq1 = _run_cli_and_sample(["plugin", "list"])
+    assert env_seed == "42"
+
+    env_seed_repeat, seq2 = _run_cli_and_sample(["plugin", "list"])
+    assert env_seed_repeat == "42"
+    assert seq1 == seq2
+
+    env_seed_custom, seq_custom1 = _run_cli_and_sample([
+        "--seed",
+        "123",
+        "plugin",
+        "list",
+    ])
+    assert env_seed_custom == "123"
+
+    env_seed_custom_repeat, seq_custom2 = _run_cli_and_sample([
+        "--seed",
+        "123",
+        "plugin",
+        "list",
+    ])
+    assert env_seed_custom_repeat == "123"
+    assert seq_custom1 == seq_custom2


### PR DESCRIPTION
## Summary
- seed the Watcher CLI at startup using the configured training seed and expose a `--seed` override
- fix the TOML settings source to work with recent pydantic-settings releases and document the seeding policy
- export consistent seed environment variables in CI and add an end-to-end reproducibility test

## Testing
- pytest tests/test_reproducibility.py tests/test_watcher_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cec580dff483208ddee180b49292bc