### PR TITLE
chore: refresh governance templates and automerge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,34 @@
-# Consultez README.md pour la gouvernance des revues et la signification des labels.
-# Les équipes référencées doivent exister dans l'organisation GitHub hébergeant ce dépôt.
+# Consultez README.md et docs/merge-policy.md pour la gouvernance des revues et
+# la signification des labels.
+# Les équipes référencées doivent exister dans l'organisation GitHub hébergeant
+# ce dépôt et être autorisées à relire les zones assignées.
 
-*               @WatcherOrg/maintainers
-app/            @WatcherOrg/maintainers
-config/         @WatcherOrg/security-team
-docs/           @WatcherOrg/documentation
-tests/          @WatcherOrg/qa
-.github/        @WatcherOrg/maintainers
+*                         @WatcherOrg/maintainers
+
+# Front et API utilisateur
+app/                      @WatcherOrg/app-core
+app/ui/                   @WatcherOrg/design-system
+
+# Expérience développeur et automatisation
+.github/workflows/        @WatcherOrg/release-engineering
+automation-playbook.sh    @WatcherOrg/release-engineering
+scripts/                  @WatcherOrg/release-engineering
+
+# Données et pipeline ML
+datasets/                 @WatcherOrg/ml-research
+train.py                  @WatcherOrg/ml-research
+
+# Documentation et gouvernance
+docs/                     @WatcherOrg/documentation
+
+# Sécurité et configuration sensible
+config/                   @WatcherOrg/security-team
+plugins.toml              @WatcherOrg/security-team
+
+# Qualité et tests
+tests/                    @WatcherOrg/qa
+QA.md                     @WatcherOrg/qa
+
+# Infrastructure GitHub
+.github/ISSUE_TEMPLATE/   @WatcherOrg/maintainers
+.github/CODEOWNERS        @WatcherOrg/maintainers

--- a/.github/ISSUE_TEMPLATE/architecture_discussion.yml
+++ b/.github/ISSUE_TEMPLATE/architecture_discussion.yml
@@ -1,8 +1,10 @@
-name: Support & architecture
+name: Discussion architecture & support
 description: Poser une question sur l'architecture, le design ou l'utilisation de Watcher.
 title: "[Discussion]: "
 labels:
-  - discussion
+  - status:needs-triage
+  - type:discussion
+discussion_category_name: Support & architecture
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,8 +2,8 @@ name: Rapport de bug
 description: Signaler un comportement inattendu ou une régression.
 title: "[Bug]: "
 labels:
-  - bug
-  - needs-triage
+  - status:needs-triage
+  - type:bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Consultez la check-list QA avant d'ouvrir un ticket.
   - name: Guide des labels et des revues
     url: https://github.com/WatcherOrg/Watcher/blob/main/docs/merge-policy.md
-    about: Résumé du workflow de tri, des labels et de l'automerge.
+    about: Résumé du workflow de tri, des labels et du label `status:ready-to-merge`.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,8 +2,8 @@ name: Demande de fonctionnalité
 description: Proposer une amélioration ou une nouvelle fonctionnalité.
 title: "[Feature]: "
 labels:
-  - enhancement
-  - needs-triage
+  - status:needs-triage
+  - type:feature
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,11 +1,11 @@
-﻿name: automerge
+name: ready-to-merge
 on:
   pull_request_target:
     types: [labeled, opened, synchronize]
 
 jobs:
   automerge:
-    name: Automerge when labeled
+    name: Merge PR when label is ready
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
@@ -17,9 +17,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Automerge if labelled and checks passed
+      - name: Merge if ready-to-merge and checks passed
         uses: pascalgn/automerge-action@v0.14.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           merge_method: merge
-          label: automerge
+          label: status:ready-to-merge

--- a/QA.md
+++ b/QA.md
@@ -6,9 +6,9 @@
 2. Commits atomiques (`feat: …`, `fix: …`, `docs: …`)
 3. `git push` puis ouverture d'une Pull Request
 4. Revue externe et fusion après `make check`
-5. Laisser le label par défaut `needs-triage` sur la PR ; un mainteneur le
+5. Laisser le label par défaut `status:needs-triage` sur la PR ; un mainteneur le
    retirera après revue. Une fois la CI verte, seul un mainteneur pose
-   `automerge` pour déclencher la fusion automatique.
+   `status:ready-to-merge` pour déclencher la fusion automatique.
 
 ## Manual Verification
 

--- a/README.md
+++ b/README.md
@@ -170,16 +170,15 @@ non pertinents.
 
 ## Gouvernance des contributions
 
-- Les modèles disponibles dans `.github/ISSUE_TEMPLATE/` ajoutent automatiquement
-  les labels `needs-triage` et `bug`/`enhancement` selon le type d'issue. Le
-  modèle de discussion sous `.github/DISCUSSION_TEMPLATE/` applique le label
-  `discussion`.
+- Les formulaires présents dans `.github/ISSUE_TEMPLATE/` ajoutent
+  systématiquement `status:needs-triage` ainsi qu'un label `type:*`
+  (`type:bug`, `type:feature`, `type:discussion`).
 - Le fichier `.github/CODEOWNERS` assigne les revues aux équipes responsables.
   Adaptez les alias (`@WatcherOrg/...`) à votre organisation GitHub.
 - Avant toute fusion, assurez-vous que `nox -s lint typecheck security tests
   build` est vert sur la CI et qu'au moins un CODEOWNER a approuvé la PR. Un
-  mainteneur peut ensuite poser le label `automerge` qui déclenchera la fusion
-  automatique.
+  mainteneur peut ensuite poser `status:ready-to-merge` qui déclenchera la
+  fusion automatique.
 
 Pour plus de détails (priorités, gestion du label `blocked`, etc.), consultez
 `docs/merge-policy.md`.

--- a/automation-playbook.sh
+++ b/automation-playbook.sh
@@ -217,7 +217,7 @@ fi
 
 # 5) List workflows and recent runs
 echo
-echo "5) Listing workflows and recent runs (automerge/auto-label)"
+echo "5) Listing workflows and recent runs (ready-to-merge/auto-label)"
 if [[ "$DRY_RUN" -eq 0 ]]; then
   if [[ "$USE_GH" -eq 1 ]]; then
     gh workflow list --repo "$OWNER/$REPO" || true
@@ -232,20 +232,20 @@ else
   echo "(dry-run) would list workflows and runs"
 fi
 
-# 6) Optionally label a PR to test automerge workflow
+# 6) Optionally label a PR to test ready-to-merge workflow
 if [[ -n "$PR_TO_LABEL" ]]; then
   echo
-  echo "6) Adding label 'automerge' to PR #$PR_TO_LABEL (test trigger)"
-  confirm_or_exit "Proceed to add label 'automerge' to PR #$PR_TO_LABEL?"
+  echo "6) Adding label 'status:ready-to-merge' to PR #$PR_TO_LABEL (test trigger)"
+  confirm_or_exit "Proceed to add label 'status:ready-to-merge' to PR #$PR_TO_LABEL?"
   if [[ "$DRY_RUN" -eq 0 ]]; then
     if [[ "$USE_GH" -eq 1 ]]; then
-      gh pr edit "$PR_TO_LABEL" --add-label automerge --repo "$OWNER/$REPO"
+      gh pr edit "$PR_TO_LABEL" --add-label "status:ready-to-merge" --repo "$OWNER/$REPO"
     else
-      curl -sS -X POST -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/issues/$PR_TO_LABEL/labels" -d '["automerge"]'
+      curl -sS -X POST -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/issues/$PR_TO_LABEL/labels" -d '["status:ready-to-merge"]'
     fi
     echo "Label added (check Actions tab / PR checks)"
   else
-    echo "(dry-run) would add label automerge to PR #$PR_TO_LABEL"
+    echo "(dry-run) would add label status:ready-to-merge to PR #$PR_TO_LABEL"
   fi
 fi
 

--- a/automerge-apply.ps1
+++ b/automerge-apply.ps1
@@ -1,5 +1,5 @@
 <#
-PowerShell script to push current branch, create "automerge" label if needed,
+PowerShell script to push current branch, create "status:ready-to-merge" label if needed,
 and add the label to a PR to trigger auto-label/auto-merge workflows.
 
 Usage:
@@ -39,9 +39,9 @@ if ($LASTEXITCODE -ne 0) {
 }
 Write-Info "Push OK."
 
-$labelName = "automerge"
-$labelColor = "F1C40F"
-$labelDesc = "Auto-merge when CI is green"
+$labelName = "status:ready-to-merge"
+$labelColor = "2ECC71"
+$labelDesc = "Auto-merge when CI is green and approvals obtained"
 
 # Try GitHub CLI first
 $ghPath = Get-Command gh -ErrorAction SilentlyContinue
@@ -114,7 +114,7 @@ try {
   $resp = Invoke-RestMethod -Method Post -Uri "$apiBase/repos/$owner/$repoName/labels" -Headers @{
     Authorization = "token $token"
     Accept = "application/vnd.github+json"
-    "User-Agent" = "automerge-script"
+    "User-Agent" = "ready-to-merge-script"
   } -Body $labelBody -ErrorAction Stop
   Write-Info "Label created."
 } catch {
@@ -135,7 +135,7 @@ try {
   $resp2 = Invoke-RestMethod -Method Post -Uri "$apiBase/repos/$owner/$repoName/issues/$Pr/labels" -Headers @{
     Authorization = "token $token"
     Accept = "application/vnd.github+json"
-    "User-Agent" = "automerge-script"
+    "User-Agent" = "ready-to-merge-script"
   } -Body $labelAddBody -ErrorAction Stop
   Write-Info "Label added to PR #$Pr."
   exit 0

--- a/docs/merge-policy.md
+++ b/docs/merge-policy.md
@@ -1,43 +1,55 @@
 # Gouvernance des issues et des Pull Requests
 
-Ce document complète le README en décrivant la façon dont les labels, les CODEOWNERS et
-automations GitHub sont utilisés pour assurer un cycle de revue cohérent.
+Ce document complète le README en décrivant la façon dont les labels, les
+CODEOWNERS et les automatisations GitHub sont utilisés pour assurer un cycle de
+revue cohérent.
 
 ## Triage et labels
 
-| Label            | Usage | Responsable |
-| ---------------- | ----- | ----------- |
-| `needs-triage`   | Ajouté automatiquement tant que la demande n'a pas été classée. | Mainteneurs |
-| `bug`            | Rattaché aux rapports créés via le template dédié. | Demandeur |
-| `enhancement`    | Attaché aux demandes de fonctionnalités. | Demandeur |
-| `discussion`     | Appliqué automatiquement pour les discussions d'architecture. | Demandeur |
-| `blocked`        | Indique qu'une PR est en attente d'une dépendance externe. | Mainteneurs |
-| `automerge`      | Déclenche la fusion automatique une fois la CI verte et les revues obtenues. | Mainteneurs |
+Les formulaires présents dans `.github/ISSUE_TEMPLATE/` appliquent deux familles
+de labels :
 
-Lors du tri, le mainteneur assigne un propriétaire fonctionnel, met à jour les
-labels (ex. priorité, composant) et retire `needs-triage`.
+| Label                        | Usage | Responsable |
+| ---------------------------- | ----- | ----------- |
+| `status:needs-triage`        | Ajouté automatiquement tant que la demande n'a pas été classée. | Mainteneurs |
+| `status:blocked`             | Indique qu'une PR est en attente d'une dépendance externe ou d'une décision. | Mainteneurs |
+| `status:ready-to-merge`      | Déclenche la fusion automatique une fois la CI verte et les revues obtenues. | Mainteneurs |
+| `type:bug`                   | Rapport de bug créé via le template dédié. | Demandeur |
+| `type:feature`               | Demande de fonctionnalité. | Demandeur |
+| `type:discussion`            | Discussion d'architecture ou de support. | Demandeur |
+| `type:maintenance` (option)  | Changement purement technique (refactoring, dépendances). | Mainteneur |
+
+Lors du tri, un mainteneur :
+
+1. Assigne un propriétaire fonctionnel et ajoute les labels de composant
+   nécessaires (`scope:docs`, `scope:security`, etc.).
+2. Retire `status:needs-triage` une fois la demande classée.
+3. Ajoute `status:blocked` si une action externe est requise.
 
 ## CODEOWNERS et revues
 
 Le fichier `.github/CODEOWNERS` enregistre les équipes responsables des
-composants. Toute Pull Request modifiant un répertoire listé déclenche
+composants. Toute Pull Request modifiant un chemin listé déclenche
 automatiquement une demande de revue auprès de l'équipe correspondante.
 
 - Les équipes renseignées doivent exister dans l'organisation GitHub du dépôt
-  (ex. `@WatcherOrg/maintainers`).
-- Si un sous-répertoire n'est pas couvert, ajoutez une entrée dédiée afin
+  (ex. `@WatcherOrg/release-engineering`).
+- Ajoutez une entrée dédiée pour tout sous-répertoire non couvert afin
   d'expliciter le propriétaire.
+- Les mainteneurs peuvent surclasser une demande en ajoutant des réviseurs
+  supplémentaires au besoin (sécurité, performance, UX…).
 
 ## Conditions de fusion
 
 1. Les jobs `nox -s lint typecheck security tests build` déclenchés par la CI
-   doivent réussir sur les trois plateformes supportées.
-2. Au moins un membre de l'équipe CODEOWNER concernée approuve la PR.
-3. Le label `automerge` peut être posé par un mainteneur une fois les points 1 et
-   2 respectés. Le workflow `.github/workflows/automerge.yml` fusionne alors la PR
-   avec la méthode `merge`.
-4. En cas de fusion manuelle, les mainteneurs suivent la même check-list et
-   retirent `automerge` si la fusion doit être différée.
+   doivent réussir sur les plateformes supportées.
+2. Au moins un membre de chaque équipe CODEOWNER concernée approuve la PR.
+3. Une fois les points 1 et 2 remplis, un mainteneur peut ajouter le label
+   `status:ready-to-merge`. Le workflow `.github/workflows/automerge.yml` fusionne
+   alors la PR avec la méthode `merge`.
+4. En cas de fusion manuelle, retirez `status:ready-to-merge` si la fusion doit
+   être différée ou si de nouveaux commits sont poussés avant validation.
 
-Pour des modifications sensibles (sécurité, configuration), ajoutez
-`blocked` jusqu'à la validation explicite du plan d'action.
+Pour des modifications sensibles (sécurité, configuration), laissez `status:blocked`
+jusqu'à la validation explicite du plan d'action ou la mise à jour des tests de
+régression.


### PR DESCRIPTION
## Summary
- expand CODEOWNERS ownership to cover automation, data and documentation surfaces
- refresh issue templates and add a discussion form that apply the new status/type labels
- document the ready-to-merge policy and retarget automerge tooling to the new label

## Testing
- nox -s lint *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cec59081908320b3925b4d56098219