### PR TITLE
test: validate Windows installer and CLI in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,29 +52,38 @@ jobs:
       - name: Run Windows installer
         if: runner.os == 'Windows'
         shell: pwsh
-        run: ./installer.ps1 -SkipOllama
+        run: pwsh -NoProfile -File ./installer.ps1 -SkipOllama
 
-      - name: Smoke test launcher in headless mode
+      - name: Validate Windows CLI launcher
         if: runner.os == 'Windows'
         shell: pwsh
         env:
           DISPLAY: ""
         run: |
-          $script = Join-Path $PWD.Path 'run.ps1'
-          $job = Start-Job -ScriptBlock { param($path) & $path } -ArgumentList $script
-          Start-Sleep -Seconds 5
-          if ($job.State -eq 'Failed') {
-            Receive-Job -Job $job | Out-String | Write-Host
-            throw 'run.ps1 failed to start.'
+          $env:DISPLAY = ""
+          $runScript = Join-Path $PWD.Path 'run.ps1'
+          $psi = New-Object System.Diagnostics.ProcessStartInfo
+          $psi.FileName = 'pwsh'
+          $psi.ArgumentList.Add('-NoProfile') | Out-Null
+          $psi.ArgumentList.Add('-File') | Out-Null
+          $psi.ArgumentList.Add($runScript) | Out-Null
+          $psi.RedirectStandardInput = $true
+          $psi.RedirectStandardOutput = $true
+          $psi.RedirectStandardError = $true
+          $psi.UseShellExecute = $false
+          $process = New-Object System.Diagnostics.Process
+          $process.StartInfo = $psi
+          $null = $process.Start()
+          $process.StandardInput.WriteLine('exit')
+          $process.StandardInput.Close()
+          $process.WaitForExit()
+          $stdout = $process.StandardOutput.ReadToEnd()
+          $stderr = $process.StandardError.ReadToEnd()
+          if ($stdout) { Write-Host $stdout }
+          if ($stderr) { Write-Host $stderr }
+          if ($process.ExitCode -ne 0) {
+            throw "run.ps1 failed with exit code $($process.ExitCode)"
           }
-          if ($job.State -eq 'Completed') {
-            $output = Receive-Job -Job $job | Out-String
-            Write-Host $output
-            throw 'run.ps1 exited prematurely.'
-          }
-          Stop-Job -Job $job | Out-Null
-          Receive-Job -Job $job | Out-String | Write-Host
-          Remove-Job -Job $job
 
       - name: Run quality pipeline
         run: nox -s lint typecheck security tests build

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ Les sessions peuvent également être exécutées individuellement (`nox -s lint
 `nox -s tests`, etc.) et une étape `nox -s build` génère les artefacts wheel et
 sdist.
 
+Sur la CI, la matrice Windows exécute `pwsh ./installer.ps1 -SkipOllama` pour
+valider que l'installeur prépare bien l'environnement PowerShell. Le workflow
+relance ensuite `pwsh ./run.ps1` en mode headless (variable `DISPLAY` vidée) et
+alimente la CLI avec la commande `exit`. Tout code de retour non nul provoque
+explicitement l'échec du job.
+
 Pour automatiser les corrections, la cible `make format` applique Ruff (lint
 et formattage) puis Black, et `make check` délègue dorénavant à Nox.
 


### PR DESCRIPTION
## Summary
- run the Windows installer through `pwsh ./installer.ps1 -SkipOllama` in the CI matrix
- execute the CLI launcher in headless mode and fail if it exits with a non-zero code
- document the new Windows validations in the README

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68cec59ad9a883208142537a43929953