### PR TITLE
Add plugin metrics panel and offline controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,17 @@ $env:DISPLAY = ""
 ./run.ps1
 ```
 
+L'onglet **Chat** propose un tableau « Utilisation plugins » rafraîchi en continu qui affiche le CPU et la RAM consommés par chaque plugin via `psutil`. Un bouton « Mode offline » permet d'activer ou de désactiver à la volée les appels réseau/LLM afin de travailler hors ligne.
+
 ### Ligne de commande
 
+Pour piloter Watcher sans interface graphique :
+
 ```bash
-python -m app.ui.main
+watcher run --offline --prompt "bonjour"
 ```
+
+L'option `--offline` force le mode hors ligne (aucun appel réseau/LLM n'est effectué) et `--prompt` envoie un message unique avant de quitter. Utilisez `--online` pour lever explicitement le mode offline. Le lanceur historique reste disponible via `python -m app.ui.main`.
 
 ### Générer une CLI Python
 

--- a/app/utils/psutil_stub.py
+++ b/app/utils/psutil_stub.py
@@ -67,6 +67,9 @@ class Process:
     def name(self) -> str:
         return "watcher"
 
+    def cmdline(self) -> list[str]:
+        return ["python", "watcher"]
+
 
 def cpu_percent(interval: float | None = None) -> float:
     """Return the deterministic CPU percentage used by tests."""

--- a/tests/test_engine_chat.py
+++ b/tests/test_engine_chat.py
@@ -3,8 +3,23 @@ import sqlite3
 
 from app.core.memory import Memory
 from app.core.engine import Engine
-from app.core.critic import Critic
+from types import SimpleNamespace
 
+
+class _StubCritic:
+    def __init__(self, response=None):
+        self._response = response
+
+    def suggest(self, prompt: str):
+        if callable(self._response):
+            return list(self._response(prompt))
+        if self._response is None:
+            return []
+        return list(self._response)
+
+
+def _configure_engine(eng):
+    eng.settings = SimpleNamespace(memory=SimpleNamespace(cache_size=128))
 
 def test_chat_saves_distinct_kinds(tmp_path, monkeypatch):
     # Avoid heavy embedding and network calls
@@ -20,8 +35,9 @@ def test_chat_saves_distinct_kinds(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    _configure_engine(eng)
     eng.client = DummyClient()
-    eng.critic = Critic()
+    eng.critic = _StubCritic()
 
     prompt = "please " + "word " * 60 + "thank you"
     answer = eng.chat(prompt)
@@ -45,7 +61,8 @@ def test_chat_includes_retrieved_terms(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
-    eng.critic = Critic()
+    _configure_engine(eng)
+    eng.critic = _StubCritic()
 
     def fake_search(self, query: str, top_k: int = 8):
         return [(0.9, 1, "ctx", "alpha beta")]
@@ -82,8 +99,9 @@ def test_chat_suggests_details_without_llm(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    _configure_engine(eng)
     eng.client = DummyClient()
-    eng.critic = Critic()
+    eng.critic = _StubCritic(["detail"])
 
     answer = eng.chat("ping")
     assert "Voici quelques détails supplémentaires." in answer
@@ -114,8 +132,9 @@ def test_chat_uses_cache_for_identical_prompts(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    _configure_engine(eng)
     eng.client = DummyClient()
-    eng.critic = Critic()
+    eng.critic = _StubCritic()
 
     prompt = "please " + "word " * 60 + "thank you"
 
@@ -143,8 +162,9 @@ def test_chat_evicts_least_recent(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    _configure_engine(eng)
     eng.client = DummyClient()
-    eng.critic = Critic()
+    eng.critic = _StubCritic()
     eng._cache_size = 2
 
     def make_prompt(tag: str) -> str:
@@ -162,3 +182,32 @@ def test_chat_evicts_least_recent(tmp_path, monkeypatch):
     assert eng.client.calls.count(p2) == 1
     assert eng.client.calls.count(p3) == 1
     assert p3 not in eng._cache
+
+
+def test_chat_respects_offline_mode(tmp_path, monkeypatch):
+    def fake_embed(texts, model="nomic-embed-text"):
+        return [np.array([1.0])]
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+    monkeypatch.setattr(Memory, "search", lambda self, q, top_k=8: [])
+
+    class DummyClient:
+        def __init__(self) -> None:
+            self.calls = 0
+            self.fallback_phrase = "Offline"
+
+        def generate(self, prompt: str) -> tuple[str, str]:
+            self.calls += 1
+            return "pong", "dummy-trace"
+
+    eng = Engine.__new__(Engine)
+    eng.mem = Memory(tmp_path / "mem.db")
+    _configure_engine(eng)
+    eng.client = DummyClient()
+    eng.critic = _StubCritic()
+    eng.set_offline_mode(True)
+
+    answer = eng.chat("hello there")
+
+    assert eng.client.calls == 0
+    assert answer.startswith("Offline: ")

--- a/tests/test_ui_offline.py
+++ b/tests/test_ui_offline.py
@@ -1,0 +1,82 @@
+import tkinter as tk
+from types import SimpleNamespace
+
+import pytest
+
+from app.ui import main
+from app.tools.plugins import LoadedPlugin, SUPPORTED_PLUGIN_API_VERSION
+
+
+def _make_plugin(name: str, path: str) -> LoadedPlugin:
+    return LoadedPlugin(
+        name=name,
+        module=path,
+        attribute="Plugin",
+        api_version=SUPPORTED_PLUGIN_API_VERSION,
+        signature="dummy",
+    )
+
+
+def test_toggle_offline_updates_status_label():
+    app = main.WatcherApp.__new__(main.WatcherApp)
+    app.settings = SimpleNamespace(
+        ui=SimpleNamespace(mode="Sur"),
+        llm=SimpleNamespace(backend="ollama", model="llama3"),
+    )
+
+    class DummyEngine:
+        def __init__(self) -> None:
+            self._offline = False
+
+        def set_offline_mode(self, value: bool) -> None:
+            self._offline = bool(value)
+
+        def is_offline(self) -> bool:
+            return self._offline
+
+    app.engine = DummyEngine()
+    app.status_var = tk.StringVar(master=tk.Tcl())
+    app.offline_var = tk.BooleanVar(master=tk.Tcl(), value=False)
+
+    main.WatcherApp._update_status_label(app)
+    assert "désactivé" in app.status_var.get()
+
+    app.offline_var.set(True)
+    main.WatcherApp._toggle_offline_mode(app)
+    assert app.engine.is_offline() is True
+    assert "activé" in app.status_var.get()
+
+
+def test_collect_plugin_stats_matches_process(monkeypatch):
+    app = main.WatcherApp.__new__(main.WatcherApp)
+    plugins = [
+        _make_plugin("alpha", "tests.alpha"),
+        _make_plugin("beta", "tests.beta"),
+    ]
+    app.engine = SimpleNamespace(plugins=plugins)
+
+    class DummyProcess:
+        def __init__(self, import_path: str, cpu: float, rss_mb: float) -> None:
+            self._path = import_path
+            self._cpu = cpu
+            self._rss = rss_mb * 1024 * 1024
+
+        def cmdline(self):
+            return ["python", "-m", "app.tools.plugins.runner", "--path", self._path]
+
+        def cpu_percent(self, interval=None):  # noqa: ARG002
+            return self._cpu
+
+        def memory_info(self):
+            return SimpleNamespace(rss=self._rss)
+
+    def fake_iter():
+        yield DummyProcess(plugins[0].import_path, 25.0, 64.0)
+
+    monkeypatch.setattr(main.psutil, "process_iter", lambda: fake_iter())
+    stats = main.WatcherApp._collect_plugin_stats(app)
+
+    assert stats["alpha"]["cpu"] == pytest.approx(25.0)
+    assert stats["alpha"]["memory"] == pytest.approx(64.0)
+    assert stats["beta"]["cpu"] == pytest.approx(0.0)
+    assert stats["beta"]["memory"] == pytest.approx(0.0)

--- a/tests/test_watcher_cli.py
+++ b/tests/test_watcher_cli.py
@@ -1,6 +1,7 @@
 from contextlib import contextmanager
 from importlib import resources
 from pathlib import Path
+from types import SimpleNamespace
 
 from app import cli
 
@@ -11,7 +12,18 @@ def _assert_lists_hello(capsys, exit_code: int) -> None:
     assert "hello" in {line.strip() for line in captured.out.splitlines()}
 
 
-def test_plugin_list_shows_default_plugin(capsys):
+def _patch_settings(monkeypatch) -> None:
+    monkeypatch.setattr(
+        cli,
+        "get_settings",
+        lambda: SimpleNamespace(
+            llm=SimpleNamespace(backend="ollama", model="llama3"),
+        ),
+    )
+
+
+def test_plugin_list_shows_default_plugin(monkeypatch, capsys):
+    _patch_settings(monkeypatch)
     _assert_lists_hello(capsys, cli.main(["plugin", "list"]))
 
 
@@ -32,9 +44,67 @@ def _hide_source_manifest(tmp_path: Path):
             backup.rename(manifest)
 
 
-def test_plugin_list_installed_layout(tmp_path, capsys):
+def test_plugin_list_installed_layout(tmp_path, monkeypatch, capsys):
+    _patch_settings(monkeypatch)
     with _hide_source_manifest(tmp_path):
         assert not Path("plugins.toml").exists()
         manifest = resources.files("app") / "plugins.toml"
         assert manifest.is_file()
         _assert_lists_hello(capsys, cli.main(["plugin", "list"]))
+
+
+def test_run_command_offline_prompt(monkeypatch, capsys):
+    _patch_settings(monkeypatch)
+    created = []
+
+    class DummyEngine:
+        def __init__(self) -> None:
+            self._offline = False
+            self.calls: list[str] = []
+            created.append(self)
+
+        def set_offline_mode(self, value: bool) -> None:
+            self._offline = bool(value)
+
+        def is_offline(self) -> bool:
+            return self._offline
+
+        def chat(self, prompt: str) -> str:
+            self.calls.append(prompt)
+            return f"offline={self._offline}"
+
+    monkeypatch.setattr(cli, "Engine", DummyEngine)
+
+    exit_code = cli.main(["run", "--offline", "--prompt", "salut"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Mode offline activé" in captured.out
+    assert "offline=True" in captured.out
+    assert created[0]._offline is True
+    assert created[0].calls == ["salut"]
+
+
+def test_run_command_online_override(monkeypatch, capsys):
+    _patch_settings(monkeypatch)
+
+    class DummyEngine:
+        def __init__(self) -> None:
+            self._offline = True
+
+        def set_offline_mode(self, value: bool) -> None:
+            self._offline = bool(value)
+
+        def is_offline(self) -> bool:
+            return self._offline
+
+        def chat(self, prompt: str) -> str:  # pragma: no cover - not used
+            raise AssertionError("chat should not be called")
+
+    monkeypatch.setattr(cli, "Engine", DummyEngine)
+
+    exit_code = cli.main(["run", "--online"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Mode offline désactivé" in captured.out


### PR DESCRIPTION
## Summary
- add a plugin CPU/RAM monitoring panel with live refresh and an offline toggle in the GUI
- teach the engine and CLI about offline mode and update the README accordingly
- extend the automated tests to cover the new offline controls across UI and CLI

## Testing
- pytest tests/test_engine_chat.py tests/test_ui_offline.py tests/test_watcher_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cec592fc848320aa4e521e945b543f