### PR TITLE
Add end-of-file fixer pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,4 @@ repos:
     hooks:
       - id: end-of-file-fixer
         name: Ensure files end with a newline
+        types: [text]

--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ et formattage) puis Black, et `make check` délègue dorénavant à Nox.
 ### Hooks pre-commit
 
 Le dépôt inclut une configuration `pre-commit` regroupant Ruff, Black, mypy,
-Bandit, Semgrep, Codespell ainsi que le correcteur `end-of-file-fixer`. Après avoir installé les dépendances de
+Bandit, Semgrep, Codespell ainsi que le correcteur `end-of-file-fixer` afin de
+garantir qu'une ligne de fin est toujours présente dans les fichiers texte.
+Après avoir installé les dépendances de
 développement, activez les hooks localement :
 
 ```bash


### PR DESCRIPTION
## Summary
- ensure the pre-commit configuration pulls in the pre-commit-hooks repository and applies the end-of-file-fixer on text files
- document that the hook keeps a trailing newline in project files

## Testing
- pre-commit install *(fails: `pre-commit` command is unavailable in the execution environment)*
- pre-commit run --all-files *(fails: `pre-commit` command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cedeca629083209d895e91a5ec639f