### PR TITLE
Sign Windows installer artifacts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,9 @@ jobs:
     name: Build Windows installer
     needs: quality
     runs-on: windows-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -119,8 +122,16 @@ jobs:
           }
           Compress-Archive -Path "dist/Watcher/*" -DestinationPath $archive
 
+      - name: Sign installer archive
+        uses: sigstore/gh-action@v2.1.1
+        with:
+          artifact: dist/Watcher-Setup.zip
+          bundle: dist/Watcher-Setup.zip.sigstore
+
       - name: Upload Windows installer artifact
         uses: actions/upload-artifact@v4
         with:
           name: Watcher-Setup
-          path: dist/Watcher-Setup.zip
+          path: |
+            dist/Watcher-Setup.zip
+            dist/Watcher-Setup.zip.sigstore


### PR DESCRIPTION
## Summary
- allow the Windows installer job to request an OIDC token and sign the generated archive with sigstore
- upload both the installer zip and its signature in CI artifacts

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ceded560f08320aa1d985d5ccc8af0