### PR TITLE
Add SBOM generation and SLSA provenance to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish-windows-installer:
-    name: Publish signed Windows installer
+  build-windows-installer:
+    name: Build and sign Windows installer
     runs-on: windows-latest
     permissions:
       contents: write
       id-token: write
+    outputs:
+      artifact-sha256: ${{ steps.artifact-digest.outputs.sha256 }}
     steps:
       - name: Validate SemVer tag
         shell: pwsh
@@ -42,9 +44,19 @@ jobs:
           python -m pip install -r requirements.txt
           python -m pip install pyinstaller
 
+      - name: Install SBOM tooling
+        shell: pwsh
+        run: python -m pip install cyclonedx-bom cyclonedx-py
+
       - name: Build Windows executable
         shell: pwsh
         run: pyinstaller packaging/watcher.spec --noconfirm
+
+      - name: Generate SBOM
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          cyclonedx-py environment --format json --output-file dist/Watcher-sbom.json
 
       - name: Package installer archive
         shell: pwsh
@@ -61,6 +73,61 @@ jobs:
           artifact: dist/Watcher-Setup.zip
           bundle: dist/Watcher-Setup.zip.sigstore
 
+      - name: Compute artifact digest
+        id: artifact-digest
+        shell: pwsh
+        run: |
+          $hash = Get-FileHash dist/Watcher-Setup.zip -Algorithm SHA256
+          "sha256=sha256:$($hash.Hash.ToLower())" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-assets
+          if-no-files-found: error
+          path: |
+            dist/Watcher-Setup.zip
+            dist/Watcher-Setup.zip.sigstore
+            dist/Watcher-sbom.json
+
+  generate-provenance:
+    name: Generate SLSA provenance
+    needs: build-windows-installer
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.10.0
+    with:
+      build-artifacts: release-assets
+      provenance-subject-name: Watcher-Setup.zip
+      provenance-subject-digest: ${{ needs.build-windows-installer.outputs.artifact-sha256 }}
+
+  publish-release:
+    name: Publish GitHub release
+    needs:
+      - build-windows-installer
+      - generate-provenance
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Normalize provenance filename
+        run: |
+          set -euo pipefail
+          PROVENANCE=$(find dist -name "*.intoto.jsonl" -print -quit)
+          if [ -z "$PROVENANCE" ]; then
+            echo "Provenance file not found" >&2
+            exit 1
+          fi
+          mv "$PROVENANCE" dist/Watcher-Setup.intoto.jsonl
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v1
         with:
@@ -73,5 +140,7 @@ jobs:
           files: |
             dist/Watcher-Setup.zip
             dist/Watcher-Setup.zip.sigstore
+            dist/Watcher-sbom.json
+            dist/Watcher-Setup.intoto.jsonl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,19 @@ mkdocs serve
 Le workflow GitHub Actions [`deploy-docs.yml`](.github/workflows/deploy-docs.yml) construit le site avec `mkdocs build --strict`
 avant de le publier sur l'environnement **GitHub Pages** à chaque push sur `main`.
 
+## Releases, SBOM et provenance
+
+Chaque tag SemVer (`vMAJOR.MINOR.PATCH`) déclenche le workflow [`release.yml`](.github/workflows/release.yml) qui produit
+un installeur Windows signé, un SBOM CycloneDX et une attestation de provenance SLSA niveau 3.
+
+- `Watcher-Setup.zip` : archive contenant l'installeur généré par PyInstaller.
+- `Watcher-Setup.zip.sigstore` : bundle Sigstore pour vérifier la signature du binaire (`sigstore verify --bundle ...`).
+- `Watcher-sbom.json` : inventaire CycloneDX des dépendances Python installées lors du build (`cyclonedx-bom` / `cyclonedx-py`).
+- `Watcher-Setup.intoto.jsonl` : provenance SLSA générée par [`slsa-github-generator`](https://github.com/slsa-framework/slsa-github-generator).
+
+Ces fichiers sont publiés en tant qu'artefacts de release. Téléchargez le SBOM pour auditer les composants et la provenance
+`*.intoto.jsonl` pour tracer la chaîne de build ou alimenter un vérificateur SLSA.
+
 ## Benchmarks
 
 Le script `python -m app.core.benchmark run` exécute trois scénarios représentatifs

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,9 @@ système, son modèle de sécurité et les pratiques d'exploitation.
   [ROADMAP.md](ROADMAP.md), [CHANGELOG.md](CHANGELOG.md) et le [journal de conception](journal/).
 - Pour les règles de fusion et la gouvernance de projet, référez-vous à la
   [politique de merge](merge-policy.md).
+- Chaque release `vMAJOR.MINOR.PATCH` publie un installeur Windows signé, un SBOM CycloneDX (`Watcher-sbom.json`) et une
+  provenance SLSA (`Watcher-Setup.intoto.jsonl`). Ces artefacts permettent de vérifier l'intégrité du binaire et d'auditer
+  la liste des dépendances Python utilisées lors du build.
 
 ## Prévisualiser la documentation localement
 


### PR DESCRIPTION
## Summary
- split the release workflow to build on Windows, generate SLSA provenance and publish assets
- install cyclonedx tooling during the build and export a CycloneDX SBOM alongside the installer
- attach the installer, signature, SBOM and provenance to the GitHub release and document how to consume them

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68ceded5647483209b2d63679ca326a1