### PR TITLE
feat(logging): support configurable trace metadata fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,8 +319,9 @@ export LOGGING_CONFIG_PATH=./config/logging.yml
 export LOGGING_CONFIG_PATH=./config/logging.json
 ```
 
-Les deux fichiers décrivent un pipeline avec un formatter JSON et un filtre d'échantillonnage (`SamplingFilter`). Adaptez le
-paramètre `sample_rate` pour contrôler la proportion de messages conservés :
+Les deux fichiers décrivent un pipeline avec un formatter JSON et un filtre de contexte (`RequestIdFilter`) capable d'injecter les
+identifiants de requête et de trace, ainsi qu'un filtre d'échantillonnage (`SamplingFilter`). Adaptez le paramètre `sample_rate`
+pour contrôler la proportion de messages conservés :
 
 ```yaml
 filters:
@@ -329,8 +330,11 @@ filters:
     sample_rate: 0.1  # ne journalise qu'environ 10 % des messages
 ```
 
-Le module `app.core.logging_setup` expose également `set_trace_context(trace_id, sample_rate)` pour propager dynamiquement ces
-valeurs dans les journaux structurés.
+Les clés `request_id_field`, `trace_id_field` et `sample_rate_field` peuvent être
+personnalisées dans les fichiers YAML/JSON afin d'aligner les noms de colonnes
+avec vos outils d'observabilité. Le module `app.core.logging_setup` expose
+également `set_trace_context(trace_id, sample_rate)` pour propager dynamiquement
+ces valeurs dans les journaux structurés.
 
 Si `LOGGING_CONFIG_PATH` est absent ou que le fichier fourni est introuvable, le fichier `config/logging.yml` inclus dans le
 projet est utilisé. En dernier recours, Watcher applique la configuration basique de Python (`logging.basicConfig`) avec le

--- a/config/logging.json
+++ b/config/logging.json
@@ -3,16 +3,24 @@
   "disable_existing_loggers": false,
   "formatters": {
     "json": {
-      "()": "app.core.logging_setup.JSONFormatter"
+      "()": "app.core.logging_setup.JSONFormatter",
+      "request_id_field": "request_id",
+      "trace_id_field": "trace_id",
+      "sample_rate_field": "sample_rate",
+      "sample_rate": 1.0
     }
   },
   "filters": {
     "request_id": {
-      "()": "app.core.logging_setup.RequestIdFilter"
+      "()": "app.core.logging_setup.RequestIdFilter",
+      "request_id_field": "request_id",
+      "trace_id_field": "trace_id",
+      "sample_rate_field": "sample_rate"
     },
     "sampling": {
       "()": "app.core.logging_setup.SamplingFilter",
-      "sample_rate": 1.0
+      "sample_rate": 1.0,
+      "sample_rate_field": "sample_rate"
     }
   },
   "handlers": {

--- a/config/logging.yml
+++ b/config/logging.yml
@@ -4,13 +4,21 @@ disable_existing_loggers: False
 formatters:
   json:
     (): app.core.logging_setup.JSONFormatter
+    request_id_field: request_id
+    trace_id_field: trace_id
+    sample_rate_field: sample_rate
+    sample_rate: 1.0
 
 filters:
   request_id:
     (): app.core.logging_setup.RequestIdFilter
+    request_id_field: request_id
+    trace_id_field: trace_id
+    sample_rate_field: sample_rate
   sampling:
     (): app.core.logging_setup.SamplingFilter
     sample_rate: 1.0
+    sample_rate_field: sample_rate
 
 handlers:
   console:

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -5,10 +5,25 @@ Le projet utilise un logging structuré au format JSON pour toutes les sorties.
 ## Configuration
 
 Le module `app.core.logging_setup` centralise la configuration du logging et
-fournit un logger unique nommé ``watcher``.  Il lit un fichier YAML
-`config/logging.yml` ou la variable d'environnement `LOGGING_CONFIG_PATH`. Les
-messages sont enrichis d'un identifiant de requête (`request_id`) lorsqu'il est
-défini via `logging_setup.set_request_id()`.
+fournit un logger unique nommé ``watcher``.  Il lit un fichier YAML ou JSON et
+expose deux configurations prêtes à l'emploi : `config/logging.yml` et
+`config/logging.json`.  Changez de variante en définissant la variable
+d'environnement `LOGGING_CONFIG_PATH` :
+
+```bash
+export LOGGING_CONFIG_PATH=./config/logging.json  # ou ./config/logging.yml
+```
+
+Chaque fichier configure un formatter JSON, un filtre de contexte
+(`RequestIdFilter`) et un filtre d'échantillonnage (`SamplingFilter`).  Les clés
+`request_id_field`, `trace_id_field` et `sample_rate_field` contrôlent le nom
+des champs sérialisés dans la sortie JSON tandis que `sample_rate` détermine la
+proportion de messages conservés.  Ajustez ces valeurs pour faire correspondre
+la structure de vos pipelines d'observabilité.
+
+Les messages sont enrichis d'un identifiant de requête (`request_id`) ou de
+trace (`trace_id`) lorsqu'ils sont définis via
+`logging_setup.set_request_id()` et `logging_setup.set_trace_context()`.
 
 Pour activer le logging, appelez `logging_setup.configure()` au démarrage de
 votre script puis obtenez un logger via `logging_setup.get_logger(__name__)`.


### PR DESCRIPTION
## Summary
- extend the bundled YAML and JSON logging configurations with sampling and trace metadata fields
- enhance `logging_setup` to accept configurable field names, normalise custom callables, and better tolerate early imports
- document the `LOGGING_CONFIG_PATH` switch and add coverage for custom metadata names in structured log tests

## Testing
- pytest tests/test_structured_logs.py
- pytest *(fails: numerous pre-existing suite failures unrelated to the logging changes)*

------
https://chatgpt.com/codex/tasks/task_e_68cededf7ea083208c6a92e2c1b3fe86