### PR TITLE
Align governance docs and automations with new labels

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,34 +1,51 @@
-# Consultez README.md et docs/merge-policy.md pour la gouvernance des revues et
-# la signification des labels.
-# Les équipes référencées doivent exister dans l'organisation GitHub hébergeant
-# ce dépôt et être autorisées à relire les zones assignées.
+# Consultez docs/merge-policy.md pour comprendre la gouvernance des revues,
+# la cartographie des labels `scope:*` et la procédure d'automatisation.
+# Chaque équipe référencée doit exister dans l'organisation GitHub hébergeant
+# ce dépôt et être autorisée à relire les zones assignées.
 
+# Couverture par défaut : toute modification doit être validée par les mainteneurs.
 *                         @WatcherOrg/maintainers
 
-# Front et API utilisateur
+# scope:app — Application Watcher (API, UI, packaging client)
 app/                      @WatcherOrg/app-core
+app/api/                  @WatcherOrg/app-core
 app/ui/                   @WatcherOrg/design-system
+packaging/                @WatcherOrg/app-core
 
-# Expérience développeur et automatisation
+# scope:ops — Automatisation, CI/CD et outillage développeur
 .github/workflows/        @WatcherOrg/release-engineering
+.github/auto_merge.yml    @WatcherOrg/release-engineering
 automation-playbook.sh    @WatcherOrg/release-engineering
+auto_flow.sh              @WatcherOrg/release-engineering
+noxfile.py                @WatcherOrg/release-engineering
 scripts/                  @WatcherOrg/release-engineering
+Makefile                  @WatcherOrg/release-engineering
+requirements*.txt         @WatcherOrg/release-engineering
 
-# Données et pipeline ML
+# scope:ml — Données, entraînement et pipelines ML
 datasets/                 @WatcherOrg/ml-research
+metrics/                  @WatcherOrg/ml-research
 train.py                  @WatcherOrg/ml-research
+dvc.yaml                  @WatcherOrg/ml-research
+params.yaml               @WatcherOrg/ml-research
 
-# Documentation et gouvernance
+# scope:docs — Documentation produit et gouvernance
+README.md                 @WatcherOrg/documentation
+CHANGELOG.md              @WatcherOrg/documentation
+ETHICS.md                 @WatcherOrg/documentation
 docs/                     @WatcherOrg/documentation
+METRICS.md                @WatcherOrg/documentation
+QA.md                     @WatcherOrg/documentation
 
-# Sécurité et configuration sensible
+# scope:security — Configuration sensible et secrets
 config/                   @WatcherOrg/security-team
 plugins.toml              @WatcherOrg/security-team
+example.env               @WatcherOrg/security-team
 
-# Qualité et tests
+# scope:quality — Tests, contrôle qualité et couverture
+pytest.ini                @WatcherOrg/qa
 tests/                    @WatcherOrg/qa
-QA.md                     @WatcherOrg/qa
 
-# Infrastructure GitHub
+# Infrastructure GitHub (templates, CODEOWNERS, règles)
 .github/ISSUE_TEMPLATE/   @WatcherOrg/maintainers
 .github/CODEOWNERS        @WatcherOrg/maintainers

--- a/.github/ISSUE_TEMPLATE/architecture_discussion.yml
+++ b/.github/ISSUE_TEMPLATE/architecture_discussion.yml
@@ -10,6 +10,20 @@ body:
     attributes:
       value: |
         Utilisez ce modèle pour recueillir l'avis de la communauté ou valider une approche avant d'ouvrir une Pull Request.
+        Consultez également `docs/merge-policy.md` pour connaître la signification des labels appliqués lors du tri.
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Zone concernée
+      description: Identifier la zone de code ou de documentation concernée facilite l'assignation des CODEOWNERS.
+      options:
+        - scope:app — Interface ou API utilisateur
+        - scope:ml — Pipelines de données ou d'entraînement
+        - scope:docs — Documentation, guides ou métriques
+        - scope:ops — CI/CD, packaging ou scripts
+        - scope:quality — Tests automatisés et qualité
+        - scope:security — Configuration sensible, secrets, permissions
+        - Non déterminé / Autre
   - type: textarea
     id: question
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,20 @@ body:
   - type: markdown
     attributes:
       value: |
-        Merci de décrire clairement le bug rencontré. Consultez la documentation QA pour vérifier les étapes de reproduction.
+        Merci de décrire clairement le bug rencontré. Consultez la documentation QA ainsi que `docs/merge-policy.md` pour comprendre comment les labels `status:*` et `scope:*` seront appliqués.
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Zone impactée
+      description: Sélectionnez la zone qui semble la plus concernée pour aider le tri initial.
+      options:
+        - scope:app — Interface ou API utilisateur
+        - scope:ml — Pipelines de données ou d'entraînement
+        - scope:docs — Documentation, guides ou métriques
+        - scope:ops — CI/CD, packaging ou scripts
+        - scope:quality — Tests automatisés et qualité
+        - scope:security — Configuration sensible, secrets, permissions
+        - Non déterminé / Autre
   - type: checkboxes
     id: prerequisites
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Consultez la check-list QA avant d'ouvrir un ticket.
   - name: Guide des labels et des revues
     url: https://github.com/WatcherOrg/Watcher/blob/main/docs/merge-policy.md
-    about: Résumé du workflow de tri, des labels et du label `status:ready-to-merge`.
+    about: Résumé du workflow de tri, des labels `scope:*` et du label `status:auto-merge`.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,20 @@ body:
   - type: markdown
     attributes:
       value: |
-        Merci de détailler la valeur ajoutée pour les utilisateurs ainsi que les impacts potentiels.
+        Merci de détailler la valeur ajoutée pour les utilisateurs ainsi que les impacts potentiels. Consultez `docs/merge-policy.md` pour comprendre comment votre demande sera triée et labellisée.
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Zone impactée
+      description: Sélectionnez la zone fonctionnelle principale liée à la demande.
+      options:
+        - scope:app — Interface ou API utilisateur
+        - scope:ml — Pipelines de données ou d'entraînement
+        - scope:docs — Documentation, guides ou métriques
+        - scope:ops — CI/CD, packaging ou scripts
+        - scope:quality — Tests automatisés et qualité
+        - scope:security — Configuration sensible, secrets, permissions
+        - Non déterminé / Autre
   - type: checkboxes
     id: impact
     attributes:

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -1,0 +1,43 @@
+name: Tâche de maintenance
+description: Documenter une dette technique, une mise à jour de dépendance ou un travail de refactoring.
+title: "[Maintenance]: "
+labels:
+  - status:needs-triage
+  - type:maintenance
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Utilisez ce modèle pour les changements internes (refactoring, mise à jour de dépendances, amélioration de tooling).
+        Pensez à mentionner les risques éventuels pour la production et les vérifications attendues.
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Zone impactée
+      description: Identifiez la zone qui bénéficiera de la maintenance pour guider les CODEOWNERS.
+      options:
+        - scope:app — Interface ou API utilisateur
+        - scope:ml — Pipelines de données ou d'entraînement
+        - scope:docs — Documentation, guides ou métriques
+        - scope:ops — CI/CD, packaging ou scripts
+        - scope:quality — Tests automatisés et qualité
+        - scope:security — Configuration sensible, secrets, permissions
+        - Non déterminé / Autre
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Contexte et objectif
+      description: Pourquoi cette maintenance est-elle nécessaire maintenant ? Quels sont les objectifs de qualité/performance ?
+      placeholder: "Mettre à jour la bibliothèque XYZ pour corriger..."
+    validations:
+      required: true
+  - type: textarea
+    id: plan
+    attributes:
+      label: Plan de travail
+      description: Décrivez les étapes prévues, les risques et les plans de rollback éventuels.
+  - type: textarea
+    id: validation
+    attributes:
+      label: Vérifications prévues
+      description: Tests, revues supplémentaires, validations manuelles à prévoir.

--- a/.github/auto_merge.yml
+++ b/.github/auto_merge.yml
@@ -1,2 +1,6 @@
 auto-merge:
   method: merge
+  required-labels:
+    - status:auto-merge
+  blocking-labels:
+    - status:blocked

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,10 +1,14 @@
 name: ready-to-merge
 on:
   pull_request_target:
-    types: [labeled, opened, synchronize]
+    types: [labeled, unlabeled, opened, synchronize, ready_for_review]
 
 jobs:
   automerge:
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'status:auto-merge')
+      && contains(github.event.pull_request.labels.*.name, 'status:ready-to-merge')
+      && !contains(github.event.pull_request.labels.*.name, 'status:blocked')
     name: Merge PR when label is ready
     runs-on: ubuntu-latest
     permissions:
@@ -22,4 +26,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           merge_method: merge
-          label: status:ready-to-merge
+          label: status:auto-merge


### PR DESCRIPTION
## Summary
- reorganize CODEOWNERS by scope labels and expand component coverage for each team
- refresh the issue/discussion templates and add a maintenance form with scope guidance
- document the updated label workflow and require the new status:auto-merge label in automerge configs

## Testing
- `nox -s lint` *(fails: nox is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cedef06f10832083eb0eba05f3f8a6