### PR TITLE
Enhance MkDocs site structure and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurit
 
 La documentation technique est générée avec [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)
 et déployée automatiquement via GitHub Pages : https://<github-username>.github.io/Watcher/.
+Elle regroupe notamment :
+
+- une [vue d'ensemble de l'architecture](docs/architecture.md) illustrée par des diagrammes Mermaid et PlantUML ;
+- un [modèle de menaces](docs/threat-model.md) détaillant les actifs critiques et les mesures de mitigation ;
+- les guides d'exploitation (journalisation, feuille de route, politique de merge, etc.).
 
 Pour la prévisualiser localement :
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,21 +1,40 @@
 # Architecture
 
 Watcher orchestre plusieurs composants pour fournir un atelier d'IA local, sûr et traçable.
-Cette page résume leurs responsabilités et les interactions majeures.
+Cette page résume leurs responsabilités, leurs interactions et les points d'extension.
+
+!!! info "Configurations clés"
+    Les paramètres globaux proviennent de `config/` et des variables d'environnement consommées par
+    `app.configuration`. Ils alimentent l'orchestrateur au démarrage pour activer ou non certaines
+    capacités (sandbox, outils externes, limites d'exécution, etc.).
 
 ## Composants principaux
 
-- **Interface utilisateur** : scripts CLI (`python -m app.ui.main`) et automatisations (`run.ps1`) qui
-  déclenchent les scénarios d'entraînement ou d'évaluation.
-- **Orchestrateur** : modules `app.core` qui planifient les tâches, exécutent les agents et pilotent
-  le curriculum adaptatif.
-- **Agents et outils** : classes sous `app.agents` et `app.tools` responsables de la génération de code,
-  de l'analyse et de la rétroaction utilisateur.
-- **Mémoire vectorielle** : stockage persistant des connaissances et contextes dans `app.core.memory`.
+- **Interface utilisateur** : scripts CLI (`python -m app.ui.main`) et automatisations (`run.ps1`,
+  `automation-playbook.sh`) qui déclenchent les scénarios d'entraînement ou d'évaluation.
+- **Orchestrateur** : modules `app.core` (planner, learner, pipeline) qui planifient les tâches,
+  orchestrent les agents et pilotent le curriculum adaptatif.
+- **Agents et outils** : classes sous `app.agents`, `app.tools` et `app.llm` responsables de la
+  génération de code, de l'analyse et de la rétroaction utilisateur.
+- **Mémoire vectorielle** : stockage persistant des connaissances et contextes dans
+  `app.core.memory` appuyé sur SQLite/SQLCipher.
 - **Qualité et sécurité** : bancs d'essai (`tests/`, `metrics/`, `QA.md`) et garde-fous (`bandit.yml`,
-  `pyproject.toml` pour les linters et hooks).
-- **Journalisation** : configuration centralisée via `app.core.logging_setup` pour tracer toutes les
-  décisions et actions.
+  `pyproject.toml`, `noxfile.py`) exécutés via CI.
+- **Journalisation** : configuration centralisée via `app.core.logging_setup` et conventions détaillées dans
+  `docs/logging.md`.
+
+## Cartographie des couches
+
+| Couche | Rôle | Modules clés | Artefacts associés |
+| --- | --- | --- | --- |
+| Interface & déclencheurs | Prendre les entrées utilisateurs et exposer les scénarios. | `app.cli`, `app.ui`, `run.ps1` | `README.md`, `automation-playbook.sh` |
+| Orchestration & raisonnement | Distribuer les tâches, piloter les agents, gérer les itérations. | `app.core.planner`, `app.core.engine`, `app.core.pipeline` | `config/`, `params.yaml` |
+| Exécution agents | Implémenter les stratégies spécialisées (autograder, evaluator, critic). | `app.agents`, `app.core.autograder`, `app.core.critic` | `datasets/`, `plugins.toml` |
+| Mémoire & données | Conserver le contexte vectoriel, indexer les runs, charger les embeddings. | `app.core.memory`, `app.embeddings`, `app.data` | `metrics/`, `alembic/` |
+| Assurance & sécurité | Valider les sorties, imposer des garde-fous, orchestrer les audits. | `tests/`, `noxfile.py`, `bandit.yml`, `QA.md` | `docs/threat-model.md`, `docs/ethics.md` |
+
+Cette vue synthétique permet d'identifier rapidement où intégrer un nouvel outil ou une nouvelle
+politique de contrôle.
 
 ## Vue globale
 
@@ -104,6 +123,31 @@ EventBus --> Orchestrator : Décisions automatisées
 Ces interactions soulignent l'importance de la modularité : chaque composant peut être remplacé ou étendu
 sans casser la chaîne de valeur à condition de respecter les interfaces documentées.
 
+## Cycle d'une exécution type
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CLI as CLI / API
+    participant Engine as Orchestrateur
+    participant Agent as Agent spécialisé
+    participant Memory as Mémoire vectorielle
+    participant QA as Garde-fous qualité
+
+    CLI->>Engine: Soumission d'une tâche
+    Engine->>Memory: Chargement du contexte
+    Engine->>Agent: Mandat + objectifs
+    Agent-->>Memory: Requêtes d'embeddings
+    Agent->>QA: Résultats intermédiaires
+    QA-->>Agent: Feedback / exigences
+    Agent->>Engine: Proposition consolidée
+    Engine->>CLI: Restitution & rapports
+    Engine->>Memory: Persistance des traces
+```
+
+Ce scénario illustre la boucle de rétroaction : les agents s'appuient sur la mémoire vectorielle pour
+produire une solution, la font valider par les garde-fous, puis renvoient les résultats à l'orchestrateur.
+
 ## Chaîne d'observabilité
 
 ```mermaid
@@ -126,8 +170,10 @@ autorise l'export vers des tableaux de bord tout en conservant la traçabilité 
 ## Points d'extension
 
 - **Plugins** : `plugins.toml` et les entry points `watcher.plugins` permettent d'ajouter des capacités sans
-  modifier le noyau.
+  modifier le noyau (voir `app.plugins` pour les helpers de découverte).
 - **Pipelines de qualité** : de nouveaux scénarios peuvent être ajoutés dans `tests/` ou `metrics/` pour
-  renforcer les contrôles.
+  renforcer les contrôles automatisés et nourrir le tableau de bord de performances.
 - **Sources de données** : les ensembles DVC sous `datasets/` peuvent être étendus avec de nouveaux corpus
   tout en conservant la reproductibilité.
+- **Instrumentation** : les handlers définis dans `app.core.logging_setup` acceptent des destinations
+  supplémentaires (fichiers, flux réseau) tant que le format JSON structuré est conservé.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,30 +1,43 @@
 # Documentation Watcher
 
-Bienvenue dans l'espace de référence du projet **Watcher**, l'atelier local d'IA de programmation autonome.
-Cette documentation complète le README et les guides techniques du dépôt en présentant la structure du
-système, son modèle de sécurité et les pratiques d'exploitation.
+Bienvenue dans l'espace de référence du projet **Watcher**, l'atelier local d'IA de programmation autonome
+axé sur la traçabilité et la sécurité des runs.
 
-## Parcours recommandé
+!!! abstract "Ce que couvre cette documentation"
+    *Architecture* : comment l'orchestrateur, les agents et les ressources partagées coopèrent.
+    *Sécurité* : quelles menaces sont prises en compte, comment elles sont détectées et atténuées.
+    *Opérations* : les conventions de logging, la feuille de route et les politiques de contribution.
 
-1. Découvrir la [vue d'ensemble de l'architecture](architecture.md) pour comprendre comment l'orchestrateur,
-   les agents spécialisés, la mémoire vectorielle et les garde-fous qualité coopèrent.
-2. Lire le [modèle de menaces](threat-model.md) afin d'identifier les actifs critiques, les attaques possibles
-   et les contre-mesures.
-3. Consulter la [charte éthique officielle](ethics.md) (extraite de [`ETHICS.md`](https://github.com/<github-username>/Watcher/blob/main/ETHICS.md)) qui encadre la
-   gouvernance des données et l'utilisation responsable de Watcher.
+## Structure de la documentation
 
-!!! tip "Navigation rapide"
-    Les onglets en haut de page regroupent l'architecture, la sécurité et l'exploitation. Utilisez la barre de
-    recherche pour accéder rapidement aux journaux de conception ou aux conventions spécifiques.
+| Section | Contenu | Points clés |
+| --- | --- | --- |
+| [Architecture](architecture.md) | Description des composants principaux, flux d'exécution et interfaces. | Diagrammes Mermaid & PlantUML pour visualiser l'orchestrateur et ses dépendances. |
+| [Sécurité et conformité](threat-model.md) | Modèle de menaces, scénarios d'incident et charte éthique. | Tableaux de risques, diagrammes de mitigation et procédures de réponse. |
+| [Exploitation](logging.md) | Conventions de journalisation, feuille de route et politique de merge. | Référentiel des pratiques d'exploitation et du suivi projet. |
 
-## Ressources complémentaires
+!!! tip "Astuces de navigation"
+    - Utilisez ++Ctrl+K++ / ++Cmd+K++ pour ouvrir la recherche instantanée du thème Material.
+    - Les onglets du bandeau supérieur regroupent Architecture, Sécurité et Exploitation.
+    - Les diagrammes sont interactifs : survolez les nœuds Mermaid pour afficher les détails.
 
-- Les conventions de [journalisation](logging.md) détaillent la configuration du logger JSON et les bons
-  réflexes pour instrumenter le code.
-- Les feuilles de route et journaux historiques sont conservés dans
-  [ROADMAP.md](ROADMAP.md), [CHANGELOG.md](CHANGELOG.md) et le [journal de conception](journal/).
-- Pour les règles de fusion et la gouvernance de projet, référez-vous à la
-  [politique de merge](merge-policy.md).
+## Architecture en bref
+
+- **Orchestrateur** : modules `app.core` (planner, learner, pipeline) qui synchronisent agents et tâches.
+- **Agents spécialisés** : `app.agents` et `app.tools` fournissent génération, évaluation et actions système.
+- **Mémoire vectorielle** : `app.core.memory.Memory` et `app.embeddings` conservent les contextes durables.
+- **Observabilité** : `app.core.logging_setup` diffuse les journaux structurés et `metrics/` stocke les mesures.
+
+Le [document d'architecture](architecture.md) fournit des vues d'ensemble et des diagrammes séquentiels pour
+suivre chaque interaction.
+
+## Sécurité en bref
+
+- **Hypothèses** : fonctionnement majoritairement hors-ligne, dépendances versionnées et environnements isolés.
+- **Actifs critiques** : jeux de données DVC, mémoire vectorielle, scripts d'orchestration et journaux d'audit.
+- **Mesures** : contrôles CI (`nox`, `bandit`, `mypy`), rotation des journaux, politiques de fusion et charte éthique.
+
+Consultez le [modèle de menaces](threat-model.md) pour la cartographie complète et les plans de réponse.
 
 ## Prévisualiser la documentation localement
 
@@ -33,5 +46,5 @@ pip install -r requirements-dev.txt
 mkdocs serve
 ```
 
-La commande `mkdocs serve` démarre un serveur de développement à `http://127.0.0.1:8000` avec rechargement
-à chaud des pages lorsque les fichiers Markdown sont modifiés.
+La commande `mkdocs serve` démarre un serveur de développement à `http://127.0.0.1:8000` avec rechargement à
+chaud lorsque les fichiers Markdown sont modifiés.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,10 @@ site_name: "Watcher"
 site_description: "Documentation technique et opérationnelle de l'atelier Watcher"
 site_url: "https://<github-username>.github.io/Watcher/"
 repo_url: "https://github.com/<github-username>/Watcher"
+repo_name: "Watcher"
+edit_uri: "blob/main/docs/"
+
+strict: true
 
 theme:
   name: material
@@ -24,9 +28,13 @@ theme:
     - navigation.sections
     - navigation.top
     - navigation.indexes
+    - navigation.footer
     - content.code.copy
     - content.code.annotate
+    - content.tabs.link
     - toc.follow
+  icon:
+    logo: material/robot-happy
 
 markdown_extensions:
   - admonition
@@ -48,6 +56,7 @@ markdown_extensions:
       custom_fences:
         - name: mermaid
           class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_div_format
         - name: plantuml
           class: plantuml
           format: !!python/name:pymdownx.superfences.fence_code_format
@@ -57,6 +66,9 @@ markdown_extensions:
       emoji_generator: !!python/name:pymdownx.emoji.to_svg
   - pymdownx.plantuml:
       server: https://www.plantuml.com/plantuml
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.keys
 
 plugins:
   - search


### PR DESCRIPTION
## Summary
- tighten the MkDocs configuration (strict mode, repo metadata, extra Material features) and extend markdown extensions for Mermaid/PlantUML diagrams
- reorganize the landing, architecture and threat-model pages with richer guidance, diagrams and security coverage
- document the published site and key pages from the README so the GitHub Pages deployment is discoverable

## Testing
- mkdocs build --strict *(fails: mkdocs not installed in the execution environment; pip install blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cedef14cfc8320875f93f630caf662