### PR TITLE
ci: validate installer and launcher on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
         run: dvc pull
         continue-on-error: true
 
-      - name: Run Windows installer
+      - name: Validate Windows installer
         if: runner.os == 'Windows'
         shell: pwsh
-        run: ./installer.ps1 -SkipOllama
+        run: pwsh ./installer.ps1 -SkipOllama
 
       - name: Run micro benchmarks
         if: runner.os == 'Linux'
@@ -68,20 +68,39 @@ jobs:
           DISPLAY: ""
         run: |
           $script = Join-Path $PWD.Path 'run.ps1'
-          $job = Start-Job -ScriptBlock { param($path) & $path } -ArgumentList $script
-          Start-Sleep -Seconds 5
-          if ($job.State -eq 'Failed') {
-            Receive-Job -Job $job | Out-String | Write-Host
-            throw 'run.ps1 failed to start.'
+          $job = Start-Job -ScriptBlock {
+            param($path)
+            $env:DISPLAY = ""
+            pwsh -NoLogo -NoProfile -File $path
+          } -ArgumentList $script
+
+          try {
+            Start-Sleep -Seconds 5
+
+            switch ($job.State) {
+              'Failed' {
+                $errors = Receive-Job -Job $job -ErrorAction SilentlyContinue | Out-String
+                if (-not $errors) {
+                  $errors = ($job.ChildJobs | ForEach-Object { $_.JobStateInfo.Reason } | Out-String)
+                }
+                throw "run.ps1 failed to start.`n$errors"
+              }
+              'Completed' {
+                $output = Receive-Job -Job $job | Out-String
+                throw "run.ps1 exited prematurely.`n$output"
+              }
+            }
           }
-          if ($job.State -eq 'Completed') {
-            $output = Receive-Job -Job $job | Out-String
-            Write-Host $output
-            throw 'run.ps1 exited prematurely.'
+          finally {
+            if ($job.State -eq 'Running') {
+              Stop-Job -Job $job | Out-Null
+            }
+            $logs = Receive-Job -Job $job -ErrorAction SilentlyContinue | Out-String
+            if ($logs) {
+              Write-Host $logs
+            }
+            Remove-Job -Job $job
           }
-          Stop-Job -Job $job | Out-Null
-          Receive-Job -Job $job | Out-String | Write-Host
-          Remove-Job -Job $job
 
       - name: Run quality pipeline
         run: nox -s lint typecheck security tests build

--- a/QA.md
+++ b/QA.md
@@ -17,6 +17,13 @@
 3. The button disables while the response is generated.
 4. The interface remains responsive and the button re-enables once the reply appears.
 
+## Continuous Integration
+
+* The Windows job invokes `pwsh ./installer.ps1 -SkipOllama` to validate that the PowerShell installer
+  succeeds without the Ollama models.
+* The same job launches `pwsh ./run.ps1` with an empty `DISPLAY` variable to emulate headless mode. Any
+  startup failure or premature exit fails the build.
+
 ## Static Analysis
 
 Install the development dependencies:


### PR DESCRIPTION
## Summary
- ensure the CI matrix runs the Windows installer through `pwsh ./installer.ps1 -SkipOllama`
- start the headless launcher with `pwsh ./run.ps1` and fail fast on startup errors
- document the automated Windows validation in QA.md

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cedef247308320aa2f87605c98d6c3