### PR TITLE
Update mkdocs edit links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: "Watcher"
 site_description: "Documentation technique et opérationnelle de l'atelier Watcher"
 site_url: "https://<github-username>.github.io/Watcher/"
 repo_url: "https://github.com/<github-username>/Watcher"
+edit_uri: "edit/main/docs/"
 
 theme:
   name: material


### PR DESCRIPTION
## Summary
- point Material edit links at the docs/ directory on the main branch

## Testing
- ⚠️ `mkdocs build --strict` *(fails: mkdocs is not installed in the execution environment and cannot be fetched because pip cannot reach the package index through the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68cee9e4c8ec8320bf20d9e1e0542d30