### PR TITLE
Configure pages in docs deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
       - name: Set up Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
## Summary
- add configure-pages step to the documentation deployment workflow to prepare GitHub Pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cee9e34ec483208a47abdde46e755d