### PR TITLE
Add offline toggle and plugin resource monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,19 @@ $env:DISPLAY = ""
 ./run.ps1
 ```
 
+L'onglet **Bench** affiche un tableau actualisé toutes les deux secondes avec la consommation CPU/RAM
+de chaque plugin, calculée via `psutil`. L'onglet **Chat** dispose également d'une bascule *Mode offline*
+permettant de désactiver instantanément les appels réseau/LLM pour conserver un fonctionnement 100 % local.
+
 ### Ligne de commande
 
 ```bash
-python -m app.ui.main
+watcher run [--offline|--online]
 ```
+
+La commande `watcher run` lance l'interface graphique lorsque l'affichage est disponible ou bascule en mode CLI.
+L'option `--offline` force le fonctionnement sans accès réseau tandis que `--online` réactive le backend LLM.
+L'ancien raccourci `python -m app.ui.main` reste utilisable pour un démarrage direct.
 
 ### Générer une CLI Python
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -38,10 +38,22 @@ def _iter_plugins() -> list[plugins.Plugin]:
     return plugins.reload_plugins(_PLUGIN_MANIFEST)
 
 
+def _run_watcher(offline: bool) -> int:
+    """Start the Watcher application in the requested connectivity mode."""
+
+    from app.ui.main import launch_app
+
+    return launch_app(offline=offline)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point for the :mod:`watcher` command."""
 
     settings = get_settings()
+    intelligence = getattr(settings, "intelligence", None)
+    default_offline = False
+    if intelligence is not None:
+        default_offline = getattr(intelligence, "mode", "").lower() == "offline"
     parser = argparse.ArgumentParser(
         prog="watcher",
         description=(
@@ -65,9 +77,27 @@ def main(argv: Sequence[str] | None = None) -> int:
     plugin_sub = plugin_parser.add_subparsers(dest="plugin_command", required=True)
     plugin_sub.add_parser("list", help="List available plugins")
 
+    run_parser = sub.add_parser("run", help="Lancer l'interface Watcher")
+    run_parser.add_argument(
+        "--offline",
+        dest="offline",
+        action="store_true",
+        help="Force le mode offline (désactive les appels réseau/LLM).",
+    )
+    run_parser.add_argument(
+        "--online",
+        dest="offline",
+        action="store_false",
+        help="Force explicitement le mode en ligne.",
+    )
+    run_parser.set_defaults(offline=default_offline)
+
     args = parser.parse_args(argv)
 
     set_seed(args.seed)
+
+    if args.command == "run":
+        return _run_watcher(args.offline)
 
     if args.command == "plugin" and args.plugin_command == "list":
         for plugin in _iter_plugins():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -6,6 +6,7 @@ def test_client_fallback_echo() -> None:
     answer, trace = client.generate("salut")
     assert answer == "Echo: salut"
     assert "fallback" in trace
+    assert "offline" in trace
 
 
 def test_client_custom_fallback() -> None:
@@ -13,3 +14,4 @@ def test_client_custom_fallback() -> None:
     answer, trace = client.generate("hi")
     assert answer == "Offline: hi"
     assert "fallback" in trace
+    assert "offline" in trace

--- a/tests/test_ui_offline.py
+++ b/tests/test_ui_offline.py
@@ -28,6 +28,43 @@ class _DummyProcess:
         return "python"
 
 
+class _DummyTree:
+    def __init__(self) -> None:
+        self.rows: dict[str, tuple] = {}
+        self._counter = 0
+
+    def get_children(self):
+        return list(self.rows.keys())
+
+    def delete(self, item):  # pragma: no cover - simple container helper
+        self.rows.pop(item, None)
+
+    def insert(self, parent, index, values):  # noqa: ARG002
+        item_id = f"item{self._counter}"
+        self._counter += 1
+        self.rows[item_id] = values
+        return item_id
+
+
+class _DummyVar:
+    def __init__(self, value: bool) -> None:
+        self.value = value
+
+    def get(self) -> bool:
+        return self.value
+
+    def set(self, value: bool) -> None:  # pragma: no cover - optional helper
+        self.value = value
+
+
+class _DummyLabel:
+    def __init__(self) -> None:
+        self.kwargs: dict[str, str] = {}
+
+    def configure(self, **kwargs) -> None:
+        self.kwargs.update(kwargs)
+
+
 def test_collect_plugin_stats_uses_cached_handles(monkeypatch: pytest.MonkeyPatch) -> None:
     app = main.WatcherApp.__new__(main.WatcherApp)
     app._plugin_process_cache = {}
@@ -56,3 +93,93 @@ def test_collect_plugin_stats_uses_cached_handles(monkeypatch: pytest.MonkeyPatc
 
     assert creations == 1
     assert created[4242]._cpu_calls == 2
+
+
+def test_render_plugin_stats_formats_values() -> None:
+    app = main.WatcherApp.__new__(main.WatcherApp)
+    app.plugin_tree = _DummyTree()
+    stats = [
+        {
+            "plugin_name": "dummy",
+            "import_path": "tests.dummy_plugin:DummyPlugin",
+            "pid": 111,
+            "cpu_percent": 12.345,
+            "rss": 10 * 1024 * 1024,
+            "vms": 20 * 1024 * 1024,
+            "num_threads": 3,
+            "process_name": "python",
+        }
+    ]
+
+    main.WatcherApp._render_plugin_stats(app, stats)
+    values = list(app.plugin_tree.rows.values())[0]
+    assert values == ("dummy", 111, "12.3", "10.0", "20.0", 3, "python")
+
+
+def test_update_plugin_monitor_schedules_refresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = main.WatcherApp.__new__(main.WatcherApp)
+    app.plugin_tree = _DummyTree()
+    app._plugin_refresh_interval_ms = 1234
+    app._plugin_refresh_job = None
+    app.winfo_exists = lambda: True
+
+    stats = [
+        {
+            "plugin_name": "dummy",
+            "import_path": "tests.dummy_plugin:DummyPlugin",
+            "pid": 222,
+            "cpu_percent": 1.0,
+            "rss": 0,
+            "vms": 0,
+            "num_threads": 1,
+            "process_name": "python",
+        }
+    ]
+
+    def fake_collect(entries=None):  # noqa: ARG001
+        app._plugin_stats_snapshot = stats
+        return stats
+
+    app._collect_plugin_stats = fake_collect  # type: ignore[assignment]
+
+    calls: dict[str, object] = {}
+
+    def fake_after(delay: int, callback):
+        calls["delay"] = delay
+        calls["callback"] = callback
+        return "job-id"
+
+    def fake_after_cancel(job):
+        calls.setdefault("cancelled", []).append(job)
+
+    app.after = fake_after  # type: ignore[assignment]
+    app.after_cancel = fake_after_cancel  # type: ignore[assignment]
+
+    main.WatcherApp._update_plugin_monitor(app)
+    assert calls["delay"] == 1234
+    assert app._plugin_refresh_job == "job-id"
+    assert list(app.plugin_tree.rows.values()) == [("dummy", 222, "1.0", "0.0", "0.0", 1, "python")]
+
+
+def test_toggle_offline_updates_engine() -> None:
+    class _Engine:
+        def __init__(self) -> None:
+            self.offline_mode = False
+            self.calls: list[bool] = []
+
+        def set_offline_mode(self, offline: bool) -> None:
+            self.offline_mode = offline
+            self.calls.append(offline)
+
+    app = main.WatcherApp.__new__(main.WatcherApp)
+    app.engine = _Engine()
+    app.offline_var = _DummyVar(True)
+    app.status = _DummyLabel()
+    app.settings = SimpleNamespace(
+        llm=SimpleNamespace(backend="stub-backend", model="stub-model")
+    )
+
+    main.WatcherApp._toggle_offline(app)
+    assert app.engine.offline_mode is True
+    assert app.engine.calls == [True]
+    assert "Offline" in app.status.kwargs.get("text", "")


### PR DESCRIPTION
## Summary
- teach the CLI a `watcher run` command that propagates an offline flag and plumb the engine/client offline behaviour
- expose an offline toggle and a psutil-backed plugin CPU/RAM monitor inside the Tk UI with scheduled refreshes
- document the new controls and cover them with focused CLI/UI/unit tests

## Testing
- pytest tests/test_client.py tests/test_ui_offline.py tests/test_watcher_cli.py

------
https://chatgpt.com/codex/tasks/task_e_68cedeea2a4c8320b809b0600d3cea21