### PR TITLE
Track sandbox processes and update plugin monitor

### DIFF
--- a/tests/test_ui_offline.py
+++ b/tests/test_ui_offline.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
+from app.core import sandbox
+from app.core.engine import Engine
 from app.ui import main
 
 
@@ -26,6 +29,38 @@ class _DummyProcess:
 
     def name(self) -> str:
         return "python"
+
+
+class _DummyTreeview:
+    def __init__(self) -> None:
+        self.rows: list[dict[str, Any]] = []
+
+    def get_children(self):
+        return [str(index) for index in range(len(self.rows))]
+
+    def delete(self, *item_ids) -> None:
+        if not item_ids:
+            self.rows.clear()
+            return
+
+        indices: list[int] = []
+        for item in item_ids:
+            try:
+                indices.append(int(item))
+            except (TypeError, ValueError):
+                continue
+        if not indices:
+            self.rows.clear()
+            return
+        for index in sorted(set(indices), reverse=True):
+            if 0 <= index < len(self.rows):
+                del self.rows[index]
+
+    def insert(self, parent, index, iid=None, **kwargs):  # noqa: D401 - Tkinter compat
+        values = kwargs.get("values")
+        text = kwargs.get("text", "")
+        self.rows.append({"values": values, "text": text})
+        return iid or str(len(self.rows) - 1)
 
 
 def test_collect_plugin_stats_uses_cached_handles(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -56,3 +91,50 @@ def test_collect_plugin_stats_uses_cached_handles(monkeypatch: pytest.MonkeyPatc
 
     assert creations == 1
     assert created[4242]._cpu_calls == 2
+
+
+def test_update_plugin_monitor_populates_tree(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = Engine()
+    assert engine.plugins
+    engine.plugins = engine.plugins[:1]
+
+    snapshots: list[list[dict[str, Any]]] = []
+
+    def _fake_run(cmd, **kwargs):
+        on_start = kwargs.get("on_start")
+        snapshots.append(engine.get_sandbox_processes())
+        if callable(on_start):
+            proc = SimpleNamespace(pid=67890)
+            on_start(proc)
+            snapshots.append(engine.get_sandbox_processes())
+        return sandbox.SandboxResult(code=0, out="ui output")
+
+    monkeypatch.setattr("app.core.engine.sandbox.run", _fake_run)
+
+    engine.run_plugins()
+
+    populated = next((snap for snap in snapshots if snap and snap[0].get("pid")), [])
+    assert populated
+
+    pid = populated[0]["pid"]
+    assert isinstance(pid, int)
+
+    def _fake_process(pid_value: int) -> _DummyProcess:
+        return _DummyProcess(pid_value)
+
+    monkeypatch.setattr(main.psutil, "Process", _fake_process)
+
+    app = main.WatcherApp.__new__(main.WatcherApp)
+    app.engine = SimpleNamespace(
+        get_sandbox_processes=lambda: [dict(entry) for entry in populated]
+    )
+    app._plugin_process_cache = {}
+    app._sandbox_processes = []
+    app.plugin_tree = _DummyTreeview()
+    app.after = lambda *args, **kwargs: None  # type: ignore[assignment]
+
+    app._update_plugin_monitor()
+
+    assert app._sandbox_processes
+    assert len(app.plugin_tree.rows) == len(populated)
+    assert app.plugin_tree.rows[0]["values"][0] == pid


### PR DESCRIPTION
## Summary
- extend sandbox execution to invoke optional on_start callbacks when child processes spawn
- track active sandboxed plugin metadata in the engine and expose it through get_sandbox_processes
- build and refresh a plugin monitor tree in the UI using the engine data and add coverage for process tracking and monitor rendering

## Testing
- pytest tests/test_plugins.py tests/test_ui_offline.py

------
https://chatgpt.com/codex/tasks/task_e_68cefa04c48083209199187d18e53009