### PR TITLE
Ensure deterministic seeding across CLI and automation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,12 @@ on:
   push:
   pull_request:
 
+env:
+  PYTHONHASHSEED: "42"
+  WATCHER_TRAINING__SEED: "42"
+  CUBLAS_WORKSPACE_CONFIG: ":4096:8"
+  TORCH_DETERMINISTIC: "1"
+
 jobs:
   quality:
     name: Quality checks
@@ -13,11 +19,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.12"]
-    env:
-      PYTHONHASHSEED: "42"
-      WATCHER_TRAINING__SEED: "42"
-      CUBLAS_WORKSPACE_CONFIG: ":4096:8"
-      TORCH_DETERMINISTIC: "1"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -6,6 +6,12 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  PYTHONHASHSEED: "42"
+  WATCHER_TRAINING__SEED: "42"
+  CUBLAS_WORKSPACE_CONFIG: ":4096:8"
+  TORCH_DETERMINISTIC: "1"
+
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+env:
+  PYTHONHASHSEED: "42"
+  WATCHER_TRAINING__SEED: "42"
+  CUBLAS_WORKSPACE_CONFIG: ":4096:8"
+  TORCH_DETERMINISTIC: "1"
+
 jobs:
   build-windows-installer:
     name: Build and sign Windows installer

--- a/installer.ps1
+++ b/installer.ps1
@@ -1,10 +1,26 @@
-﻿param([switch]$SkipOllama)
+param([switch]$SkipOllama)
 Write-Host "== Watcher installer =="
+
+$seed = $env:WATCHER_TRAINING__SEED
+if (-not $seed -and $env:SEED) {
+    $seed = $env:SEED
+}
+if (-not $seed) {
+    $seed = "42"
+}
+$env:WATCHER_TRAINING__SEED = $seed
+$env:PYTHONHASHSEED = $seed
+if (-not $env:CUBLAS_WORKSPACE_CONFIG) {
+    $env:CUBLAS_WORKSPACE_CONFIG = ":4096:8"
+}
+if (-not $env:TORCH_DETERMINISTIC) {
+    $env:TORCH_DETERMINISTIC = "1"
+}
 
 python -m venv .venv
 .\.venv\Scripts\pip install --upgrade pip wheel
-.\.venv\Scripts\pip install rich pydantic tomli-w psutil pillow pyperclip "urllib3<3" 
-    ruff black mypy bandit semgrep pytest pytest-cov hypothesis coverage 
+.\.venv\Scripts\pip install rich pydantic tomli-w psutil pillow pyperclip "urllib3<3"
+    ruff black mypy bandit semgrep pytest pytest-cov hypothesis coverage
     requests httpx numpy scikit-learn sqlite-utils
 
 if (-not $SkipOllama) {

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+import json
 import os
 import random
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+from string import Template
+from typing import Any
 
 from app import cli
 from app.core.reproducibility import set_seed
 from app.utils import np
 
 HAS_NUMPY_RNG = hasattr(np, "random") and hasattr(np.random, "rand")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_set_seed_reproducible():
@@ -31,6 +40,58 @@ def _run_cli_and_sample(args: list[str]) -> tuple[dict[str, str | None], list[fl
         "WATCHER_TRAINING__SEED": os.environ.get("WATCHER_TRAINING__SEED"),
     }
     return env_values, [random.random() for _ in range(3)]
+
+
+def _run_cli_subprocess(
+    args: list[str],
+) -> tuple[dict[str, str | None], list[str], list[float]]:
+    template = Template(
+        """
+import json
+import os
+import random
+from app import cli
+
+random.seed(999)
+args = $ARGS
+exit_code = cli.main(args)
+payload = {
+    "exit_code": exit_code,
+    "env": {
+        "PYTHONHASHSEED": os.environ.get("PYTHONHASHSEED"),
+        "WATCHER_TRAINING__SEED": os.environ.get("WATCHER_TRAINING__SEED"),
+    },
+    "sequence": [random.random() for _ in range(3)],
+}
+print(json.dumps(payload))
+"""
+    )
+    script = textwrap.dedent(template.substitute(ARGS=repr(args)))
+    env = os.environ.copy()
+    env["PYTHONHASHSEED"] = "0"
+    env.pop("WATCHER_TRAINING__SEED", None)
+    pythonpath = env.get("PYTHONPATH")
+    repo_root = str(REPO_ROOT)
+    env["PYTHONPATH"] = (
+        repo_root if not pythonpath else f"{repo_root}{os.pathsep}{pythonpath}"
+    )
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        check=True,
+        text=True,
+        env=env,
+    )
+    stdout_lines = [line for line in completed.stdout.splitlines() if line.strip()]
+    assert stdout_lines, "CLI invocation produced no output"
+    payload: dict[str, Any] = json.loads(stdout_lines[-1])
+    assert payload["exit_code"] == 0
+    env_values = {
+        key: (value if value is None else str(value))
+        for key, value in payload["env"].items()
+    }
+    sequence = [float(value) for value in payload["sequence"]]
+    return env_values, stdout_lines[:-1], sequence
 
 
 def test_cli_reproducibility_end_to_end(monkeypatch):
@@ -66,3 +127,40 @@ def test_cli_reproducibility_end_to_end(monkeypatch):
     ])
     assert env_custom_repeat == env_custom
     assert seq_custom1 == seq_custom2
+
+
+def test_cli_reproducibility_via_subprocess():
+    env_values, output_lines, seq1 = _run_cli_subprocess(["plugin", "list"])
+    assert env_values == {
+        "PYTHONHASHSEED": "42",
+        "WATCHER_TRAINING__SEED": "42",
+    }
+    assert output_lines, "plugin listing should produce output"
+
+    env_repeat, output_repeat, seq2 = _run_cli_subprocess(["plugin", "list"])
+    assert env_repeat == env_values
+    assert output_repeat == output_lines
+    assert seq2 == seq1
+
+    env_custom, output_custom, seq_custom1 = _run_cli_subprocess([
+        "--seed",
+        "123",
+        "plugin",
+        "list",
+    ])
+    assert env_custom == {
+        "PYTHONHASHSEED": "123",
+        "WATCHER_TRAINING__SEED": "123",
+    }
+    assert output_custom == output_lines
+    assert seq_custom1 != seq1
+
+    env_custom_repeat, output_custom_repeat, seq_custom2 = _run_cli_subprocess([
+        "--seed",
+        "123",
+        "plugin",
+        "list",
+    ])
+    assert env_custom_repeat == env_custom
+    assert output_custom_repeat == output_custom
+    assert seq_custom2 == seq_custom1


### PR DESCRIPTION
## Summary
- propagate the training seed and deterministic Torch settings at the workflow level for CI, docs, and release pipelines
- export the resolved seed and Torch determinism variables in the Windows installer PowerShell script
- add a subprocess-based CLI integration test to demonstrate deterministic behaviour from argument parsing to RNG state

## Testing
- pytest tests/test_reproducibility.py

------
https://chatgpt.com/codex/tasks/task_e_68cf028620f08320a8a1d57c6d0b44ab