### PR TITLE
Align CODEOWNERS, templates and automerge workflow with new merge policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,30 +6,32 @@
 # Couverture par défaut : toute modification doit être validée par les mainteneurs.
 *                         @WatcherOrg/maintainers
 
-# scope:app — Application Watcher (API, UI, packaging client)
+# scope:app-experience — Application Watcher (API, UI, packaging client)
 app/                      @WatcherOrg/app-core
 app/api/                  @WatcherOrg/app-core
 app/ui/                   @WatcherOrg/design-system
 packaging/                @WatcherOrg/app-core
 
-# scope:ops — Automatisation, CI/CD et outillage développeur
-.github/workflows/        @WatcherOrg/release-engineering
-.github/auto_merge.yml    @WatcherOrg/release-engineering
-automation-playbook.sh    @WatcherOrg/release-engineering
-auto_flow.sh              @WatcherOrg/release-engineering
-noxfile.py                @WatcherOrg/release-engineering
-scripts/                  @WatcherOrg/release-engineering
-Makefile                  @WatcherOrg/release-engineering
-requirements*.txt         @WatcherOrg/release-engineering
+# scope:platform — Automatisation, CI/CD et outillage développeur
+.github/workflows/        @WatcherOrg/platform-engineering
+.github/auto_merge.yml    @WatcherOrg/platform-engineering
+automation-playbook.sh    @WatcherOrg/platform-engineering
+auto_flow.sh              @WatcherOrg/platform-engineering
+noxfile.py                @WatcherOrg/platform-engineering
+scripts/                  @WatcherOrg/platform-engineering
+Makefile                  @WatcherOrg/platform-engineering
+requirements*.txt         @WatcherOrg/platform-engineering
+installer.ps1             @WatcherOrg/platform-engineering
+run.ps1                   @WatcherOrg/platform-engineering
 
-# scope:ml — Données, entraînement et pipelines ML
+# scope:data-insights — Données, entraînement et pipelines ML
 datasets/                 @WatcherOrg/ml-research
 metrics/                  @WatcherOrg/ml-research
 train.py                  @WatcherOrg/ml-research
 dvc.yaml                  @WatcherOrg/ml-research
 params.yaml               @WatcherOrg/ml-research
 
-# scope:docs — Documentation produit et gouvernance
+# scope:documentation — Documentation produit et gouvernance
 README.md                 @WatcherOrg/documentation
 CHANGELOG.md              @WatcherOrg/documentation
 ETHICS.md                 @WatcherOrg/documentation

--- a/.github/ISSUE_TEMPLATE/architecture_discussion.yml
+++ b/.github/ISSUE_TEMPLATE/architecture_discussion.yml
@@ -17,10 +17,10 @@ body:
       label: Zone concernée
       description: Identifier la zone de code ou de documentation concernée facilite l'assignation des CODEOWNERS.
       options:
-        - scope:app — Interface ou API utilisateur
-        - scope:ml — Pipelines de données ou d'entraînement
-        - scope:docs — Documentation, guides ou métriques
-        - scope:ops — CI/CD, packaging ou scripts
+        - scope:app-experience — Interface ou API utilisateur, packaging client
+        - scope:data-insights — Pipelines de données, entraînement ou modèles ML
+        - scope:documentation — Documentation, guides ou métriques
+        - scope:platform — CI/CD, infrastructure développeur ou scripts
         - scope:quality — Tests automatisés et qualité
         - scope:security — Configuration sensible, secrets, permissions
         - Non déterminé / Autre

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,17 +8,17 @@ body:
   - type: markdown
     attributes:
       value: |
-        Merci de décrire clairement le bug rencontré. Consultez la documentation QA ainsi que `docs/merge-policy.md` pour comprendre comment les labels `status:*` et `scope:*` seront appliqués.
+        Merci de décrire clairement le bug rencontré. Consultez la documentation QA ainsi que `docs/merge-policy.md` pour comprendre comment les labels `status:*` (dont `status:maintainer-approved` / `status:queued-for-merge`) et `scope:*` seront appliqués.
   - type: dropdown
     id: scope
     attributes:
       label: Zone impactée
       description: Sélectionnez la zone qui semble la plus concernée pour aider le tri initial.
       options:
-        - scope:app — Interface ou API utilisateur
-        - scope:ml — Pipelines de données ou d'entraînement
-        - scope:docs — Documentation, guides ou métriques
-        - scope:ops — CI/CD, packaging ou scripts
+        - scope:app-experience — Interface ou API utilisateur, packaging client
+        - scope:data-insights — Pipelines de données, entraînement ou modèles ML
+        - scope:documentation — Documentation, guides ou métriques
+        - scope:platform — CI/CD, infrastructure développeur ou scripts
         - scope:quality — Tests automatisés et qualité
         - scope:security — Configuration sensible, secrets, permissions
         - Non déterminé / Autre

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: Consultez la check-list QA avant d'ouvrir un ticket.
   - name: Guide des labels et des revues
     url: https://github.com/WatcherOrg/Watcher/blob/main/docs/merge-policy.md
-    about: Résumé du workflow de tri, des labels `scope:*` et du label `status:auto-merge`.
+    about: Résumé du workflow de tri, des labels `scope:*` et du duo `status:maintainer-approved` / `status:queued-for-merge`.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,17 +8,17 @@ body:
   - type: markdown
     attributes:
       value: |
-        Merci de détailler la valeur ajoutée pour les utilisateurs ainsi que les impacts potentiels. Consultez `docs/merge-policy.md` pour comprendre comment votre demande sera triée et labellisée.
+        Merci de détailler la valeur ajoutée pour les utilisateurs ainsi que les impacts potentiels. Consultez `docs/merge-policy.md` pour comprendre comment votre demande sera triée et labellisée (statuts, portée et déclenchement de `status:queued-for-merge`).
   - type: dropdown
     id: scope
     attributes:
       label: Zone impactée
       description: Sélectionnez la zone fonctionnelle principale liée à la demande.
       options:
-        - scope:app — Interface ou API utilisateur
-        - scope:ml — Pipelines de données ou d'entraînement
-        - scope:docs — Documentation, guides ou métriques
-        - scope:ops — CI/CD, packaging ou scripts
+        - scope:app-experience — Interface ou API utilisateur, packaging client
+        - scope:data-insights — Pipelines de données, entraînement ou modèles ML
+        - scope:documentation — Documentation, guides ou métriques
+        - scope:platform — CI/CD, infrastructure développeur ou scripts
         - scope:quality — Tests automatisés et qualité
         - scope:security — Configuration sensible, secrets, permissions
         - Non déterminé / Autre

--- a/.github/ISSUE_TEMPLATE/maintenance.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance.yml
@@ -16,10 +16,10 @@ body:
       label: Zone impactée
       description: Identifiez la zone qui bénéficiera de la maintenance pour guider les CODEOWNERS.
       options:
-        - scope:app — Interface ou API utilisateur
-        - scope:ml — Pipelines de données ou d'entraînement
-        - scope:docs — Documentation, guides ou métriques
-        - scope:ops — CI/CD, packaging ou scripts
+        - scope:app-experience — Interface ou API utilisateur, packaging client
+        - scope:data-insights — Pipelines de données, entraînement ou modèles ML
+        - scope:documentation — Documentation, guides ou métriques
+        - scope:platform — CI/CD, infrastructure développeur ou scripts
         - scope:quality — Tests automatisés et qualité
         - scope:security — Configuration sensible, secrets, permissions
         - Non déterminé / Autre

--- a/.github/auto_merge.yml
+++ b/.github/auto_merge.yml
@@ -1,6 +1,6 @@
 auto-merge:
   method: merge
   required-labels:
-    - status:auto-merge
+    - status:queued-for-merge
   blocking-labels:
     - status:blocked

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -6,8 +6,9 @@ on:
 jobs:
   automerge:
     if: >-
-      contains(github.event.pull_request.labels.*.name, 'status:auto-merge')
-      && contains(github.event.pull_request.labels.*.name, 'status:ready-to-merge')
+      contains(github.event.pull_request.labels.*.name, 'status:queued-for-merge')
+      && contains(github.event.pull_request.labels.*.name, 'status:maintainer-approved')
+      && contains(github.event.pull_request.labels.*.name, 'status:qa-approved')
       && !contains(github.event.pull_request.labels.*.name, 'status:blocked')
     name: Merge PR when label is ready
     runs-on: ubuntu-latest
@@ -26,4 +27,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           merge_method: merge
-          label: status:auto-merge
+          label: status:queued-for-merge

--- a/QA.md
+++ b/QA.md
@@ -7,8 +7,9 @@
 3. `git push` puis ouverture d'une Pull Request
 4. Revue externe et fusion après `make check`
 5. Laisser le label par défaut `status:needs-triage` sur la PR ; un mainteneur le
-   retirera après revue. Une fois la CI verte, seul un mainteneur pose
-   `status:ready-to-merge` pour déclencher la fusion automatique.
+   retirera après revue. Une fois la CI verte, faites valider le scope par la QA
+   (`status:qa-approved`), puis un mainteneur pose `status:maintainer-approved`
+   et `status:queued-for-merge` pour déclencher la fusion automatique.
 
 ## Manual Verification
 

--- a/README.md
+++ b/README.md
@@ -282,13 +282,14 @@ non pertinents.
 
 - Les formulaires présents dans `.github/ISSUE_TEMPLATE/` ajoutent
   systématiquement `status:needs-triage` ainsi qu'un label `type:*`
-  (`type:bug`, `type:feature`, `type:discussion`).
+  (`type:bug`, `type:feature`, `type:maintenance`, `type:discussion`).
 - Le fichier `.github/CODEOWNERS` assigne les revues aux équipes responsables.
   Adaptez les alias (`@WatcherOrg/...`) à votre organisation GitHub.
 - Avant toute fusion, assurez-vous que `nox -s lint typecheck security tests
   build` est vert sur la CI et qu'au moins un CODEOWNER a approuvé la PR. Un
-  mainteneur peut ensuite poser `status:ready-to-merge` qui déclenchera la
-  fusion automatique.
+  mainteneur ajoute ensuite `status:maintainer-approved` (après validation
+  QA via `status:qa-approved`) puis `status:queued-for-merge` pour déclencher
+  la fusion automatique.
 
 Pour plus de détails (priorités, gestion du label `blocked`, etc.), consultez
 `docs/merge-policy.md`.

--- a/automation-playbook.sh
+++ b/automation-playbook.sh
@@ -217,7 +217,7 @@ fi
 
 # 5) List workflows and recent runs
 echo
-echo "5) Listing workflows and recent runs (ready-to-merge/auto-label)"
+echo "5) Listing workflows and recent runs (merge queue labels)"
 if [[ "$DRY_RUN" -eq 0 ]]; then
   if [[ "$USE_GH" -eq 1 ]]; then
     gh workflow list --repo "$OWNER/$REPO" || true
@@ -232,20 +232,20 @@ else
   echo "(dry-run) would list workflows and runs"
 fi
 
-# 6) Optionally label a PR to test ready-to-merge workflow
+# 6) Optionally label a PR to test merge queue workflow
 if [[ -n "$PR_TO_LABEL" ]]; then
   echo
-  echo "6) Adding label 'status:ready-to-merge' to PR #$PR_TO_LABEL (test trigger)"
-  confirm_or_exit "Proceed to add label 'status:ready-to-merge' to PR #$PR_TO_LABEL?"
+  echo "6) Adding labels 'status:maintainer-approved' + 'status:queued-for-merge' to PR #$PR_TO_LABEL (test trigger)"
+  confirm_or_exit "Proceed to add labels 'status:maintainer-approved' and 'status:queued-for-merge' to PR #$PR_TO_LABEL?"
   if [[ "$DRY_RUN" -eq 0 ]]; then
     if [[ "$USE_GH" -eq 1 ]]; then
-      gh pr edit "$PR_TO_LABEL" --add-label "status:ready-to-merge" --repo "$OWNER/$REPO"
+      gh pr edit "$PR_TO_LABEL" --add-label "status:maintainer-approved,status:queued-for-merge" --repo "$OWNER/$REPO"
     else
-      curl -sS -X POST -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/issues/$PR_TO_LABEL/labels" -d '["status:ready-to-merge"]'
+      curl -sS -X POST -H "Authorization: token $TOKEN" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/issues/$PR_TO_LABEL/labels" -d '["status:maintainer-approved","status:queued-for-merge"]'
     fi
     echo "Label added (check Actions tab / PR checks)"
   else
-    echo "(dry-run) would add label status:ready-to-merge to PR #$PR_TO_LABEL"
+    echo "(dry-run) would add labels status:maintainer-approved + status:queued-for-merge to PR #$PR_TO_LABEL"
   fi
 fi
 

--- a/docs/merge-policy.md
+++ b/docs/merge-policy.md
@@ -12,19 +12,21 @@ Pull Requests. Elles peuvent être combinées entre elles.
 
 ### Labels `status:*`
 
-| Label                   | Usage principal | Responsable |
-| ----------------------- | --------------- | ----------- |
-| `status:needs-triage`   | Ajouté par défaut par les templates d'issue. À retirer une fois l'analyse effectuée. | Mainteneurs |
-| `status:in-progress`    | Indique qu'une personne travaille activement sur le sujet. | Mainteneur / assigné |
-| `status:ready-for-review` | Pour les PR prêtes à être relues après la phase de développement. | Auteur de la PR |
-| `status:changes-requested` | Utilisé lorsqu'une revue demande des modifications majeures. | Reviewer |
-| `status:blocked`        | Suspend la fusion en attendant une action externe (décision produit, dépendance amont, incident…). | Mainteneurs |
-| `status:ready-to-merge` | Toutes les revues requises sont obtenues et la CI est verte. | Mainteneurs |
-| `status:auto-merge`     | Autorise le workflow d'automatisation à fusionner la PR (voir ci-dessous). | Mainteneurs |
+| Label                     | Usage principal | Responsable |
+| ------------------------- | --------------- | ----------- |
+| `status:needs-triage`     | Ajouté par défaut par les templates d'issue. À retirer une fois l'analyse effectuée. | Mainteneurs |
+| `status:in-progress`      | Indique qu'une personne travaille activement sur le sujet. | Mainteneur / assigné |
+| `status:awaiting-review`  | Pour les PR prêtes à être relues après la phase de développement. | Auteur de la PR |
+| `status:changes-requested`| Utilisé lorsqu'une revue demande des modifications majeures. | Reviewer |
+| `status:qa-approved`      | Atteste que les vérifications fonctionnelles/UX sont passées (CI verte, QA manuelle si besoin). | Équipe QA |
+| `status:maintainer-approved` | Toutes les revues CODEOWNER sont obtenues et la PR est prête à être fusionnée. | Mainteneurs |
+| `status:queued-for-merge` | Autorise le workflow d'automatisation à fusionner la PR (voir ci-dessous). | Mainteneurs |
+| `status:blocked`          | Suspend la fusion en attendant une action externe (décision produit, dépendance amont, incident…). | Mainteneurs |
 
-> ⚠️ L'ajout de `status:auto-merge` implique que `status:ready-to-merge` est
-> déjà présent et qu'aucun label bloquant n'est appliqué. Si l'un de ces
-> prérequis n'est plus respecté, retirez `status:auto-merge`.
+> ⚠️ L'ajout de `status:queued-for-merge` n'est possible qu'après
+> `status:maintainer-approved` et `status:qa-approved`. Si l'un de ces
+> prérequis n'est plus respecté (CI rouge, changement de scope, nouvelle
+> revue demandée), retirez `status:queued-for-merge`.
 
 ### Labels `type:*`
 
@@ -41,14 +43,14 @@ Les labels de portée permettent d'identifier rapidement les équipes
 concernées. Ils sont alignés sur la configuration de
 `.github/CODEOWNERS` :
 
-| Label        | Équipes CODEOWNERS impliquées | Dossiers principaux |
-| ------------ | ----------------------------- | ------------------- |
-| `scope:app`  | `@WatcherOrg/app-core`, `@WatcherOrg/design-system` | `app/`, `packaging/` |
-| `scope:ml`   | `@WatcherOrg/ml-research` | `datasets/`, `metrics/`, `train.py` |
-| `scope:docs` | `@WatcherOrg/documentation` | `docs/`, `README.md`, `CHANGELOG.md`, `ETHICS.md`, `QA.md`, `METRICS.md` |
-| `scope:ops`  | `@WatcherOrg/release-engineering` | `.github/workflows/`, `scripts/`, `noxfile.py` |
-| `scope:quality` | `@WatcherOrg/qa` | `tests/`, `pytest.ini` |
-| `scope:security` | `@WatcherOrg/security-team` | `config/`, `plugins.toml`, `example.env` |
+| Label               | Équipes CODEOWNERS impliquées | Dossiers principaux |
+| ------------------- | ----------------------------- | ------------------- |
+| `scope:app-experience`  | `@WatcherOrg/app-core`, `@WatcherOrg/design-system` | `app/`, `packaging/` |
+| `scope:data-insights`   | `@WatcherOrg/ml-research` | `datasets/`, `metrics/`, `train.py`, `dvc.yaml`, `params.yaml` |
+| `scope:documentation`   | `@WatcherOrg/documentation` | `docs/`, `README.md`, `CHANGELOG.md`, `ETHICS.md`, `QA.md`, `METRICS.md` |
+| `scope:platform`        | `@WatcherOrg/platform-engineering` | `.github/workflows/`, `.github/auto_merge.yml`, `automation-playbook.sh`, `auto_flow.sh`, `noxfile.py`, `scripts/`, `Makefile`, `requirements*.txt`, `installer.ps1`, `run.ps1` |
+| `scope:quality`         | `@WatcherOrg/qa` | `tests/`, `pytest.ini` |
+| `scope:security`        | `@WatcherOrg/security-team` | `config/`, `plugins.toml`, `example.env` |
 
 Lors du tri, les mainteneurs ajoutent au moins un label `scope:*` pour
 chaque issue/PR, idéalement sur la base des indications fournies dans les
@@ -63,14 +65,17 @@ formulaires.
    `scope:*` pertinents et retire `status:needs-triage`. Si nécessaire,
    ajoutez `status:blocked` en attendant une action externe.
 3. **Développement** : l'auteur de la PR passe le ticket en
-   `status:in-progress`, puis positionne `status:ready-for-review` lorsque
+   `status:in-progress`, puis positionne `status:awaiting-review` lorsque
    le code est prêt.
 4. **Revue CODEOWNER** : GitHub demande automatiquement la revue des
    équipes définies dans `.github/CODEOWNERS`. Chaque équipe concernée
-   doit approuver la PR.
+   doit approuver la PR. Lorsque les vérifications fonctionnelles sont
+   terminées, l'équipe QA ajoute `status:qa-approved` (ou une personne
+   mandatée si le scope ne requiert pas de QA dédiée).
 5. **Validation finale** : une fois la CI verte et les revues obtenues,
-   un mainteneur ajoute `status:ready-to-merge`. Ajoutez `status:auto-merge`
-   pour déléguer la fusion au workflow ou fusionnez manuellement.
+   un mainteneur ajoute `status:maintainer-approved`. Ajoutez ensuite
+   `status:queued-for-merge` pour déléguer la fusion au workflow ou
+   fusionnez manuellement.
 
 ## CODEOWNERS
 
@@ -87,12 +92,13 @@ assure que les équipes adéquates sont sollicitées. Quelques principes :
 1. Les jobs de CI (lint, typecheck, sécurité, tests, build) doivent être
    verts sur les branches supportées.
 2. Chaque équipe CODEOWNER impactée doit avoir approuvé la PR.
-3. Les labels `status:ready-to-merge` **et** `status:auto-merge` permettent
+3. Les labels `status:maintainer-approved`, `status:qa-approved` **et** `status:queued-for-merge` permettent
    au workflow `.github/workflows/automerge.yml` de fusionner la PR via la
    méthode `merge`. La présence de `status:blocked` empêche
    l'automatisation.
-4. Retirez `status:auto-merge` si de nouveaux commits sont poussés ou si
-   une investigation supplémentaire est nécessaire.
+4. Retirez `status:queued-for-merge` si de nouveaux commits sont poussés ou si
+   une investigation supplémentaire est nécessaire. Ajustez
+   `status:qa-approved` et `status:maintainer-approved` si les conditions changent.
 
 Les modifications sensibles (sécurité, configuration, opérations) doivent
 rester en `status:blocked` tant que le plan d'action n'est pas validé par


### PR DESCRIPTION
## Summary
- reorganize CODEOWNERS scopes under the new platform/data/documentation ownership model
- refresh issue and discussion templates to reference the updated scope labels and merge queue labels
- document the label lifecycle and update automerge workflows/scripts to use status:maintainer-approved, status:qa-approved and status:queued-for-merge

## Testing
- not run (documentation and configuration updates)


------
https://chatgpt.com/codex/tasks/task_e_68cf029028208320a1bffe65c0b78375