### PR TITLE
docs: refresh mkdocs site and deployment workflow guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurit
 
 La documentation technique est générée avec [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)
 et déployée automatiquement via GitHub Pages : https://<github-username>.github.io/Watcher/.
+Activez GitHub Pages dans les paramètres du dépôt (source : **GitHub Actions**) pour autoriser le workflow
+`deploy-docs.yml` à publier le site.
 
 Pour la prévisualiser localement :
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,23 +1,22 @@
 # Architecture
 
-Watcher orchestre plusieurs composants pour fournir un atelier d'IA local, sûr et traçable.
-Cette page résume leurs responsabilités et les interactions majeures.
+Watcher orchestre plusieurs briques spécialisées pour fournir un atelier d'IA local, sûr et traçable. Cette page
+présente les responsabilités de chaque composant et illustre les principaux échanges via des diagrammes Mermaid et
+PlantUML intégrés à la documentation.
 
-## Composants principaux
+## Vue générale
 
-- **Interface utilisateur** : scripts CLI (`python -m app.ui.main`) et automatisations (`run.ps1`) qui
-  déclenchent les scénarios d'entraînement ou d'évaluation.
-- **Orchestrateur** : modules `app.core` qui planifient les tâches, exécutent les agents et pilotent
-  le curriculum adaptatif.
-- **Agents et outils** : classes sous `app.agents` et `app.tools` responsables de la génération de code,
-  de l'analyse et de la rétroaction utilisateur.
+- **Interface utilisateur** : scripts CLI (`python -m app.ui.main`) et automatisations (`run.ps1`) qui déclenchent les
+  scénarios d'entraînement ou d'évaluation.
+- **Orchestrateur** : modules `app.core` responsables de la planification des tâches, de l'exécution des agents et du
+  pilotage du curriculum adaptatif.
+- **Agents et outils** : classes sous `app.agents` et `app.tools` chargées de la génération de code, de l'analyse et de la
+  rétroaction utilisateur.
 - **Mémoire vectorielle** : stockage persistant des connaissances et contextes dans `app.core.memory`.
-- **Qualité et sécurité** : bancs d'essai (`tests/`, `metrics/`, `QA.md`) et garde-fous (`bandit.yml`,
-  `pyproject.toml` pour les linters et hooks).
-- **Journalisation** : configuration centralisée via `app.core.logging_setup` pour tracer toutes les
-  décisions et actions.
+- **Qualité et sécurité** : bancs d'essai (`tests/`, `metrics/`, `QA.md`) et garde-fous (`bandit.yml`, `pyproject.toml`).
+- **Journalisation** : configuration centralisée via `app.core.logging_setup` pour tracer toutes les décisions et actions.
 
-## Vue globale
+## Diagramme d'ensemble (Mermaid)
 
 ```mermaid
 flowchart LR
@@ -65,11 +64,11 @@ flowchart LR
     Agents --> Datasets
 ```
 
-La figure met en évidence la boucle de rétroaction : les agents consultent la mémoire vectorielle,
-exécutent des outils, puis alimentent les bancs d'essai et les journaux. Les résultats réinjectés dans
-l'orchestrateur lui permettent d'affiner la stratégie d'entraînement.
+Le diagramme met en évidence la boucle de rétroaction : les agents consultent la mémoire vectorielle, exécutent des
+outils puis alimentent les bancs d'essai et les journaux. Les résultats réinjectés dans l'orchestrateur lui permettent
+d'affiner la stratégie d'entraînement.
 
-## Interactions détaillées
+## Interactions détaillées (PlantUML)
 
 ```plantuml
 @startuml
@@ -101,8 +100,8 @@ EventBus --> Orchestrator : Décisions automatisées
 @enduml
 ```
 
-Ces interactions soulignent l'importance de la modularité : chaque composant peut être remplacé ou étendu
-sans casser la chaîne de valeur à condition de respecter les interfaces documentées.
+Cette vue composant détaille les principaux flux applicatifs et souligne l'importance de la modularité : chaque brique
+peut être remplacée ou étendue sans casser la chaîne de valeur si les interfaces documentées sont respectées.
 
 ## Chaîne d'observabilité
 
@@ -120,14 +119,14 @@ sequenceDiagram
     Monitor-->>Agent: feedback sur dérives
 ```
 
-Cette séquence illustre comment les événements structurés alimentent la surveillance. La journalisation JSON
-autorise l'export vers des tableaux de bord tout en conservant la traçabilité locale.
+Cette séquence illustre comment les événements structurés alimentent la surveillance. La journalisation JSON autorise
+l'export vers des tableaux de bord tout en conservant la traçabilité locale.
 
 ## Points d'extension
 
-- **Plugins** : `plugins.toml` et les entry points `watcher.plugins` permettent d'ajouter des capacités sans
-  modifier le noyau.
-- **Pipelines de qualité** : de nouveaux scénarios peuvent être ajoutés dans `tests/` ou `metrics/` pour
-  renforcer les contrôles.
-- **Sources de données** : les ensembles DVC sous `datasets/` peuvent être étendus avec de nouveaux corpus
-  tout en conservant la reproductibilité.
+- **Plugins** : `plugins.toml` et les entry points `watcher.plugins` permettent d'ajouter des capacités sans modifier le
+  noyau.
+- **Pipelines de qualité** : de nouveaux scénarios peuvent être ajoutés dans `tests/` ou `metrics/` pour renforcer les
+  contrôles.
+- **Sources de données** : les ensembles DVC sous `datasets/` peuvent être étendus avec de nouveaux corpus tout en
+  conservant la reproductibilité.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,33 +1,47 @@
 # Documentation Watcher
 
 Bienvenue dans l'espace de référence du projet **Watcher**, l'atelier local d'IA de programmation autonome.
-Cette documentation complète le README et les guides techniques du dépôt en présentant la structure du
-système, son modèle de sécurité et les pratiques d'exploitation.
+Cette documentation complète le README en décrivant la structure logicielle, les mesures de sécurité et le
+mode d'exploitation de la plate-forme.
 
 ## Parcours recommandé
 
-1. Découvrir la [vue d'ensemble de l'architecture](architecture.md) pour comprendre comment l'orchestrateur,
-   les agents spécialisés, la mémoire vectorielle et les garde-fous qualité coopèrent.
-2. Lire le [modèle de menaces](threat-model.md) afin d'identifier les actifs critiques, les attaques possibles
-   et les contre-mesures.
-3. Consulter la [charte éthique officielle](ethics.md) (extraite de [`ETHICS.md`](https://github.com/<github-username>/Watcher/blob/main/ETHICS.md)) qui encadre la
-   gouvernance des données et l'utilisation responsable de Watcher.
+1. Comprendre la [vue d'ensemble de l'architecture](architecture.md) pour visualiser le dialogue entre
+   orchestrateur, agents spécialisés et mémoire vectorielle.
+2. Évaluer la surface d'attaque avec le [modèle de menaces](threat-model.md) et ses diagrammes Mermaid et
+   PlantUML.
+3. Approfondir la gouvernance via la [charte éthique](ethics.md) et les politiques opérationnelles listées ci-dessous.
 
 !!! tip "Navigation rapide"
-    Les onglets en haut de page regroupent l'architecture, la sécurité et l'exploitation. Utilisez la barre de
-    recherche pour accéder rapidement aux journaux de conception ou aux conventions spécifiques.
+    Les onglets Material en haut de page regroupent l'architecture, la sécurité et l'exploitation. Utilisez la barre de
+    recherche pour accéder directement aux journaux de conception ou aux procédures de déploiement.
 
-## Ressources complémentaires
+## Architecture et sécurité
 
-- Les conventions de [journalisation](logging.md) détaillent la configuration du logger JSON et les bons
-  réflexes pour instrumenter le code.
-- Les feuilles de route et journaux historiques sont conservés dans
-  [ROADMAP.md](ROADMAP.md), [CHANGELOG.md](CHANGELOG.md) et le [journal de conception](journal/).
-- Pour les règles de fusion et la gouvernance de projet, référez-vous à la
-  [politique de merge](merge-policy.md).
+- La page [architecture](architecture.md) cartographie les composants principaux (orchestrateur, agents, mémoire, QA)
+  et illustre leurs interactions par diagrammes Mermaid et PlantUML.
+- Le [modèle de menaces](threat-model.md) présente les actifs critiques, la cartographie des risques et la séquence de
+  réponse à incident.
+- Les conventions de [journalisation](logging.md) détaillent la configuration du logger JSON et les réflexes
+  d'observabilité à conserver hors ligne.
+
+## Exploitation et références
+
+- Les feuilles de route et journaux historiques sont conservés dans [ROADMAP.md](ROADMAP.md),
+  [CHANGELOG.md](CHANGELOG.md) et le [journal de conception](journal/).
+- Pour les règles de fusion et la gouvernance du dépôt, référez-vous à la [politique de merge](merge-policy.md).
 - Chaque release `vMAJOR.MINOR.PATCH` publie un installeur Windows signé, un SBOM CycloneDX (`Watcher-sbom.json`) et une
-  provenance SLSA (`Watcher-Setup.intoto.jsonl`). Ces artefacts permettent de vérifier l'intégrité du binaire et d'auditer
-  la liste des dépendances Python utilisées lors du build.
+  attestation SLSA (`Watcher-Setup.intoto.jsonl`). Ces artefacts facilitent l'audit de la chaîne de compilation.
+
+## Accès à la documentation publiée
+
+Lorsque le workflow GitHub Actions **Deploy MkDocs site** est exécuté sur la branche `main`, la version statique la plus
+récente est disponible à l'adresse : `https://<github-username>.github.io/Watcher/` (remplacez `<github-username>` par
+votre compte ou organisation GitHub).
+
+!!! info "URL personnalisée"
+    Si un domaine personnalisé est configuré, mettez à jour le champ `site_url` dans `mkdocs.yml` et ajoutez un fichier
+    `CNAME` dans `docs/` pour refléter la nouvelle adresse.
 
 ## Prévisualiser la documentation localement
 
@@ -36,5 +50,5 @@ pip install -r requirements-dev.txt
 mkdocs serve
 ```
 
-La commande `mkdocs serve` démarre un serveur de développement à `http://127.0.0.1:8000` avec rechargement
-à chaud des pages lorsque les fichiers Markdown sont modifiés.
+La commande `mkdocs serve` démarre un serveur de développement à `http://127.0.0.1:8000` avec rechargement à chaud des
+pages lorsque les fichiers Markdown sont modifiés.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,7 +1,8 @@
 # Modèle de menaces
 
-Cette analyse synthétise les actifs critiques de Watcher, les vecteurs d'attaque plausibles et les
-contre-mesures disponibles. Elle complète la charte publiée dans [ETHICS.md](ethics.md).
+Cette analyse synthétise les actifs critiques de Watcher, les vecteurs d'attaque plausibles et les contrôles
+opérationnels disponibles. Elle complète la charte publiée dans [ETHICS.md](ethics.md) et s'appuie sur les diagrammes
+Mermaid/PlantUML rendus nativement par MkDocs Material.
 
 ## Actifs protégés
 
@@ -12,7 +13,7 @@ contre-mesures disponibles. Elle complète la charte publiée dans [ETHICS.md](e
 | Chaîne d'exécution | Scripts Python, plugins et automatisations. | Moyenne |
 | Journal d'audit | Traces JSON (`watcher.log`) et historiques d'évaluations. | Moyenne |
 
-## Cartographie des risques
+## Cartographie des risques (Mermaid)
 
 ```mermaid
 flowchart LR
@@ -53,8 +54,8 @@ flowchart LR
     T4 --> C4
 ```
 
-Ce diagramme relie chaque actif aux principaux vecteurs d'attaque puis aux contrôles mis en place. Il sert de
-référence rapide pour vérifier que chaque risque bénéficie d'au moins une mitigation.
+Ce diagramme relie chaque actif aux principaux vecteurs d'attaque puis aux contrôles mis en place. Il sert de référence
+rapide pour vérifier que chaque risque bénéficie d'au moins une mitigation.
 
 ## Surfaces d'attaque
 
@@ -65,17 +66,15 @@ référence rapide pour vérifier que chaque risque bénéficie d'au moins une m
 
 ## Mesures de mitigation
 
-- **Isolation des dépendances** : utilisation d'environnements virtuels (`.venv/`) et contrôle des versions
-  via `requirements*.txt`.
-- **Revue de code** : hooks `pre-commit`, linting (Ruff), analyse statique (mypy) et audits de sécurité
-  (Bandit, Semgrep) exécutés par Nox et CI.
+- **Isolation des dépendances** : environnements virtuels (`.venv/`) et contrôle des versions via `requirements*.txt`.
+- **Revue de code** : hooks `pre-commit`, linting (Ruff), analyse statique (mypy) et audits de sécurité (Bandit, Semgrep)
+  exécutés par Nox et la CI.
 - **Surveillance** : journalisation JSON centralisée et rotation configurable pour tracer chaque action.
-- **Gouvernance des données** : DVC impose un suivi précis des jeux de données et facilite les vérifications
-  d'intégrité.
-- **Contrôles utilisateurs** : la charte [ETHICS.md](ethics.md) rappelle les bonnes pratiques de gestion des
-  retours et des données sensibles.
+- **Gouvernance des données** : DVC impose un suivi précis des jeux de données et facilite les vérifications d'intégrité.
+- **Contrôles utilisateurs** : la charte [ETHICS.md](ethics.md) rappelle les bonnes pratiques de gestion des retours et des
+  données sensibles.
 
-## Séquence de réponse à incident
+## Réponse à incident (PlantUML)
 
 ```plantuml
 @startuml
@@ -99,15 +98,14 @@ FollowUp -> Detection : Mise à jour des seuils
 @enduml
 ```
 
-Cette séquence illustre la boucle de réponse opérationnelle : les journaux déclenchent la détection, une analyse
-évalue l'impact, la remédiation applique les correctifs puis le suivi met à jour la surveillance pour éviter la
-récurrence.
+Cette séquence illustre la boucle de réponse opérationnelle : les journaux déclenchent la détection, l'analyse évalue
+l'impact, la remédiation applique les correctifs puis le suivi ajuste la surveillance pour éviter la récurrence.
 
 ## Recommandations opérationnelles
 
 !!! warning "Limiter la surface réseau"
-    Le projet est conçu pour fonctionner hors ligne. Désactiver ou auditer toute communication externe
-    ajoutée par des plugins tiers.
+    Le projet est conçu pour fonctionner hors ligne. Désactiver ou auditer toute communication externe ajoutée par des
+    plugins tiers.
 
 !!! note "Scénarios d'incident"
     - Maintenir des sauvegardes chiffrées de la mémoire vectorielle et des datasets.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: "Documentation technique et opérationnelle de l'atelier Watch
 site_url: "https://<github-username>.github.io/Watcher/"
 repo_url: "https://github.com/<github-username>/Watcher"
 edit_uri: "edit/main/docs/"
+strict: true
 
 theme:
   name: material
@@ -61,6 +62,12 @@ markdown_extensions:
 
 plugins:
   - search
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/<github-username>/Watcher
+      name: Dépôt GitHub Watcher
 
 nav:
   - Accueil: index.md


### PR DESCRIPTION
## Summary
- enable MkDocs strict mode, keep Material configuration and expose the GitHub repository in the footer
- rewrite the index, architecture and threat-model pages with structured sections and Mermaid/PlantUML diagrams
- document how to activate the GitHub Pages publication flow in the README

## Testing
- `mkdocs build --strict` *(fails: mkdocs unavailable in the execution environment; installing via pip is blocked by the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68cf029133a4832080134e4ebb41c5bf