### PR TITLE
Add signed Windows release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,16 @@ jobs:
       - name: Package installer archive
         shell: pwsh
         run: |
-          $archive = "dist/Watcher-Setup.zip"
-          if (Test-Path $archive) {
-            Remove-Item $archive
+          $source = Join-Path 'dist' 'Watcher'
+          if (-not (Test-Path $source)) {
+            throw "Expected PyInstaller output '$source' was not found."
           }
-          Compress-Archive -Path "dist/Watcher/*" -DestinationPath $archive
+          $exe = Join-Path $source 'Watcher.exe'
+          if (-not (Test-Path $exe)) {
+            throw "Executable '$exe' is missing from the PyInstaller directory."
+          }
+          $archive = Join-Path 'dist' 'Watcher-Setup.zip'
+          Compress-Archive -Path $source -DestinationPath $archive -Force
 
       - name: Sign release artifact
         uses: sigstore/gh-action@v2.1.1

--- a/README.md
+++ b/README.md
@@ -26,12 +26,41 @@ Chaque tag SemVer (`vMAJOR.MINOR.PATCH`) déclenche le workflow [`release.yml`](
 un installeur Windows signé, un SBOM CycloneDX et une attestation de provenance SLSA niveau 3.
 
 - `Watcher-Setup.zip` : archive contenant l'installeur généré par PyInstaller.
-- `Watcher-Setup.zip.sigstore` : bundle Sigstore pour vérifier la signature du binaire (`sigstore verify --bundle ...`).
+- `Watcher-Setup.zip.sigstore` : bundle Sigstore pour vérifier la signature du binaire (`sigstore verify identity --bundle ...`).
 - `Watcher-sbom.json` : inventaire CycloneDX des dépendances Python installées lors du build (`cyclonedx-bom` / `cyclonedx-py`).
 - `Watcher-Setup.intoto.jsonl` : provenance SLSA générée par [`slsa-github-generator`](https://github.com/slsa-framework/slsa-github-generator).
 
 Ces fichiers sont publiés en tant qu'artefacts de release. Téléchargez le SBOM pour auditer les composants et la provenance
 `*.intoto.jsonl` pour tracer la chaîne de build ou alimenter un vérificateur SLSA.
+
+### Installer l'installeur Windows signé
+
+1. Téléchargez `Watcher-Setup.zip` ainsi que `Watcher-Setup.zip.sigstore` depuis la page GitHub Releases
+   correspondant au tag SemVer (`vMAJOR.MINOR.PATCH`) que vous souhaitez déployer.
+2. Installez le CLI [Sigstore](https://www.sigstore.dev/) si nécessaire :
+
+   ```bash
+   pip install sigstore
+   ```
+
+3. Vérifiez la signature à l'aide du bundle publié par le workflow `release.yml` :
+
+   ```powershell
+   sigstore verify identity `
+     --bundle Watcher-Setup.zip.sigstore `
+     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" `
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com `
+     Watcher-Setup.zip
+   ```
+
+   Remplacez `<owner>` par l'organisation ou l'utilisateur GitHub hébergeant ce dépôt et `<tag>` par la version téléchargée.
+   La commande échoue si la signature ne provient pas du workflow officiel exécuté sur GitHub Actions.
+4. Extrayez l'archive (clic droit → *Extraire tout...* ou `Expand-Archive` sous PowerShell) puis lancez `Watcher.exe`.
+   Conservez le dossier d'extraction tel quel : il contient la configuration (`config/`), les prompts LLM et les fichiers
+   auxiliaires (`LICENSE`, `example.env`) nécessaires à l'exécutable.
+
+Le bundle Sigstore fournit également un horodatage de transparence et peut être vérifié hors-ligne grâce au
+[`rekor-cli`](https://github.com/sigstore/rekor) si vous devez archiver la preuve de signature.
 
 ## Benchmarks
 

--- a/packaging/watcher.spec
+++ b/packaging/watcher.spec
@@ -8,11 +8,19 @@ block_cipher = None
 
 project_root = pathlib.Path(__file__).resolve().parent.parent
 
-datas = [('app/plugins.toml', 'app')]
+datas = [("app/plugins.toml", "app")]
+for extra in ("LICENSE", "example.env"):
+    candidate = project_root / extra
+    if candidate.exists():
+        datas.append((str(candidate), "."))
 datas += collect_data_files(
     "config",
-    includes=["*.toml", "*.yml", "*.json"],
+    includes=["*.toml", "*.yml", "*.yaml", "*.json"],
 )
+prompt_dir = project_root / "app" / "llm" / "prompts"
+if prompt_dir.exists():
+    for prompt in prompt_dir.glob("*.md"):
+        datas.append((str(prompt), "app/llm/prompts"))
 
 
 a = Analysis(


### PR DESCRIPTION
## Summary
- enrich the PyInstaller spec to bundle configuration assets, prompts and auxiliary files alongside the executable
- harden the Windows release workflow by validating the PyInstaller output before compressing it and shipping a deterministic archive
- document how to download, verify and install the signed Watcher Windows bundle with Sigstore

## Testing
- pytest *(fails: existing suite contains 23 known failures unrelated to the packaging workflow)*

------
https://chatgpt.com/codex/tasks/task_e_68cf029116b883209d708d285422f1af