### PR TITLE
Add Windows launcher smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Validate Windows installer
         if: runner.os == 'Windows'
         shell: pwsh
-        run: pwsh ./installer.ps1 -SkipOllama
+        run: ./installer.ps1 -SkipOllama
 
       - name: Run micro benchmarks
         if: runner.os == 'Linux'
@@ -75,7 +75,7 @@ jobs:
           $job = Start-Job -ScriptBlock {
             param($path)
             $env:DISPLAY = ""
-            pwsh -NoLogo -NoProfile -File $path
+            & $path
           } -ArgumentList $script
 
           try {

--- a/QA.md
+++ b/QA.md
@@ -19,10 +19,10 @@
 
 ## Continuous Integration
 
-* The Windows job invokes `pwsh ./installer.ps1 -SkipOllama` to validate that the PowerShell installer
-  succeeds without the Ollama models.
-* The same job launches `pwsh ./run.ps1` with an empty `DISPLAY` variable to emulate headless mode. Any
-  startup failure or premature exit fails the build.
+* The Windows job invokes `./installer.ps1 -SkipOllama` to validate that the PowerShell installer succeeds
+  without the Ollama models.
+* Immediately afterwards the workflow launches `./run.ps1` with an empty `DISPLAY` variable to emulate
+  headless mode. Any startup failure or premature exit fails the build.
 
 ## Static Analysis
 


### PR DESCRIPTION
## Summary
- run the Windows CI leg through `./installer.ps1 -SkipOllama`
- smoke test `./run.ps1` in headless mode and surface failures
- document the headless verification in QA notes

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cf029231b08320831bb3d42113c4d3