### PR TITLE
Configure DVC dataset pipeline with validation stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,8 +326,11 @@ jeu de données linéaire utilisé par `train.py` :
 - `prepare-data` lit `datasets/raw/simple_linear.csv`, applique les paramètres
   définis dans `params.yaml` (graine, taille d'échantillon) et génère
   `datasets/processed/simple_linear.csv`.
-- `validate-data` enchaîne trois scripts de validation (`scripts/validate_*`)
-  pour vérifier le schéma, la taille et le hachage du fichier produit.
+- `validate-data` utilise `foreach` pour produire trois sous-étapes
+  (`validate-data@schema`, `validate-data@size`, `validate-data@hash`).
+  Chacune exécute un script dédié dans `scripts/validate_*.py` pour
+  vérifier respectivement le schéma, la taille et le hachage du fichier
+  produit.
 
 Les hyperparamètres d'entraînement ainsi que les contraintes de validation sont
 centralisés dans `params.yaml` (syntaxe JSON valide YAML pour éviter d'ajouter
@@ -341,8 +344,8 @@ dvc repro validate-data
 Un remote S3 nommé `storage` est configuré dans `.dvc/config` (URL
 `s3://watcher-artifacts`). Renseignez vos identifiants AWS via les variables
 d'environnement standard (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,
-éventuellement `AWS_SESSION_TOKEN`) ou un profil configuré, puis synchronisez
-les artefacts DVC avec :
+éventuellement `AWS_SESSION_TOKEN` ou `AWS_PROFILE`) puis synchronisez les
+artefacts DVC avec :
 
 ```bash
 # envoyer les données préparées sur le bucket
@@ -357,6 +360,17 @@ remote :
 ```bash
 dvc remote modify storage url s3://votre-bucket
 ```
+
+Pour cibler un autre fournisseur, créez un remote dédié et rendez-le
+par défaut. Exemple avec Azure Blob Storage :
+
+```bash
+dvc remote add -d azure azure://mon-container/datasets
+dvc remote modify azure connection_string "DefaultEndpointsProtocol=..."
+```
+
+Consultez la [documentation DVC](https://dvc.org/doc/command-reference/remote)
+pour les paramètres spécifiques (S3, Azure, GCS, etc.).
 
 ### Collecte
 

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,5 +1,6 @@
 stages:
   prepare-data:
+    desc: "Nettoie le dataset brut et génère la version préparée."
     cmd: python scripts/prepare_data.py --input datasets/raw/simple_linear.csv --output datasets/processed/simple_linear.csv --params params.yaml
     deps:
       - datasets/raw/simple_linear.csv
@@ -11,19 +12,19 @@ stages:
     outs:
       - datasets/processed/simple_linear.csv
   validate-data:
-    cmd: |
-      set -e
-      python scripts/validate_schema.py --file datasets/processed/simple_linear.csv --params params.yaml --dataset-key simple_linear
-      python scripts/validate_size.py --file datasets/processed/simple_linear.csv --params params.yaml --dataset-key simple_linear
-      python scripts/validate_hash.py --file datasets/processed/simple_linear.csv --params params.yaml --dataset-key simple_linear
-    deps:
-      - datasets/processed/simple_linear.csv
-      - scripts/common.py
-      - scripts/validate_hash.py
-      - scripts/validate_schema.py
-      - scripts/validate_size.py
-    params:
-      - validate.simple_linear.columns
-      - validate.simple_linear.min_rows
-      - validate.simple_linear.expected_size
-      - validate.simple_linear.expected_hash
+    desc: "Valide le fichier préparé via trois contrôles indépendants."
+    foreach:
+      - schema
+      - size
+      - hash
+    do:
+      cmd: python scripts/validate_${item}.py --file datasets/processed/simple_linear.csv --params params.yaml --dataset-key simple_linear
+      deps:
+        - datasets/processed/simple_linear.csv
+        - scripts/common.py
+        - scripts/validate_${item}.py
+      params:
+        - validate.simple_linear.columns
+        - validate.simple_linear.min_rows
+        - validate.simple_linear.expected_size
+        - validate.simple_linear.expected_hash


### PR DESCRIPTION
## Summary
- restructure the `validate-data` stage to use a foreach block that runs each validation script
- document the validation sub-stages and remote configuration steps (S3/Azure) in the README

## Testing
- python scripts/validate_schema.py --file datasets/processed/simple_linear.csv --params params.yaml --dataset-key simple_linear
- python scripts/validate_size.py --file datasets/processed/simple_linear.csv --params params.yaml --dataset-key simple_linear
- python scripts/validate_hash.py --file datasets/processed/simple_linear.csv --params params.yaml --dataset-key simple_linear

------
https://chatgpt.com/codex/tasks/task_e_68cf028f517483209a1fab29ab3c66d3