### PR TITLE
Update auto-merge required labels

### DIFF
--- a/.github/auto_merge.yml
+++ b/.github/auto_merge.yml
@@ -1,6 +1,8 @@
 auto-merge:
   method: merge
   required-labels:
-    - status:auto-merge
+    - status:queued-for-merge
+    - status:maintainer-approved
+    - status:qa-approved
   blocking-labels:
     - status:blocked


### PR DESCRIPTION
## Summary
- require merge queue entries to have maintainer, QA, and queued labels before merging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf0719d8bc8320af62a73b5965a622