### PR TITLE
Ensure offline mode skips embedding requests

### DIFF
--- a/app/cli.py
+++ b/app/cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Sequence
 
 from config import get_settings
+from app.core.engine import Engine
 from app.core.reproducibility import set_seed
 from app.tools import plugins
 
@@ -69,6 +70,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     plugin_sub = plugin_parser.add_subparsers(dest="plugin_command", required=True)
     plugin_sub.add_parser("list", help="List available plugins")
 
+    mode_parser = sub.add_parser(
+        "mode",
+        help="Basculer le mode d'intelligence entre online et offline",
+    )
+    mode_parser.add_argument(
+        "mode",
+        choices=("offline", "online"),
+        help="Mode cible: 'offline' désactive les appels réseaux, 'online' les réactive.",
+    )
+
     args = parser.parse_args(argv)
 
     set_seed(args.seed)
@@ -76,6 +87,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     if args.command == "plugin" and args.plugin_command == "list":
         for plugin in _iter_plugins():
             print(plugin.name)
+        return 0
+
+    if args.command == "mode":
+        target = str(args.mode).lower()
+        offline = target == "offline"
+        settings.intelligence.mode = "offline" if offline else "online"
+        engine = Engine()
+        engine.set_offline(offline)
+        print(f"Mode intelligence défini sur {settings.intelligence.mode}")
         return 0
 
     parser.error("unknown command")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,42 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import logging
 import sys
 from pathlib import Path
 from types import ModuleType
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def configure_logging() -> None:
+    """Reset logging configuration so caplog captures expected records."""
+
+    root = logging.getLogger()
+    original_handlers = list(root.handlers)
+    original_level = root.level
+    logger_states: dict[logging.Logger, tuple[bool, int]] = {}
+    for existing in logging.root.manager.loggerDict.values():
+        if isinstance(existing, logging.Logger):
+            logger_states[existing] = (existing.disabled, existing.level)
+    for handler in original_handlers:
+        root.removeHandler(handler)
+    logging.basicConfig(level=logging.INFO)
+    for existing in logger_states:
+        existing.disabled = False
+        existing.setLevel(logging.NOTSET)
+    try:
+        yield
+    finally:
+        for handler in list(root.handlers):
+            root.removeHandler(handler)
+        for handler in original_handlers:
+            root.addHandler(handler)
+        root.setLevel(original_level)
+        for logger_obj, (disabled, level) in logger_states.items():
+            logger_obj.disabled = disabled
+            logger_obj.setLevel(level)
 
 
 @pytest.fixture

--- a/tests/test_data_pipeline.py
+++ b/tests/test_data_pipeline.py
@@ -104,6 +104,7 @@ def test_feedback_batch_loading_benchmark(tmp_path):
     """Compare naive feedback loading with batched iteration."""
 
     mem = Memory(tmp_path / "mem.db")
+    mem.set_offline(False)
     for i in range(1000):
         mem.add_feedback("k", f"p{i}", f"a{i}", float(i))
 

--- a/tests/test_engine_chat.py
+++ b/tests/test_engine_chat.py
@@ -20,6 +20,7 @@ def test_chat_saves_distinct_kinds(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    eng.mem.set_offline(False)
     eng.client = DummyClient()
     eng.critic = Critic()
 
@@ -45,6 +46,7 @@ def test_chat_includes_retrieved_terms(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    eng.mem.set_offline(False)
     eng.critic = Critic()
 
     def fake_search(self, query: str, top_k: int = 8):
@@ -82,6 +84,7 @@ def test_chat_suggests_details_without_llm(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    eng.mem.set_offline(False)
     eng.client = DummyClient()
     eng.critic = Critic()
 
@@ -114,6 +117,7 @@ def test_chat_uses_cache_for_identical_prompts(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    eng.mem.set_offline(False)
     eng.client = DummyClient()
     eng.critic = Critic()
 
@@ -143,6 +147,7 @@ def test_chat_evicts_least_recent(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    eng.mem.set_offline(False)
     eng.client = DummyClient()
     eng.critic = Critic()
     eng._cache_size = 2

--- a/tests/test_engine_feedback.py
+++ b/tests/test_engine_feedback.py
@@ -7,6 +7,7 @@ from app.core.memory import Memory
 def _make_engine(tmp_path):
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    eng.mem.set_offline(False)
     eng.last_prompt = "question"
     eng.last_answer = "answer"
     return eng

--- a/tests/test_engine_offline.py
+++ b/tests/test_engine_offline.py
@@ -1,0 +1,33 @@
+"""Regression tests for the engine offline mode integration."""
+
+from types import SimpleNamespace
+
+from config import get_settings
+
+from app.core.engine import Engine
+from app.core.memory import Memory
+from app.utils import np
+
+
+def test_engine_offline_skips_embedding_calls(monkeypatch, tmp_path):
+    calls = {"count": 0}
+
+    def fake_embed(texts, model=None, host=None):  # noqa: ARG001
+        calls["count"] += 1
+        return [np.ones(1, dtype=np.float32)]
+
+    monkeypatch.setattr("app.tools.embeddings.embed_ollama", fake_embed)
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+
+    engine = Engine.__new__(Engine)
+    engine.settings = get_settings()
+    engine.mem = Memory(tmp_path / "mem.db")
+    engine.client = SimpleNamespace(set_offline=lambda _offline: None)
+
+    engine.set_offline(True)
+    engine.mem.add("note", "bonjour")
+
+    vec = engine.mem._embed("salut")
+
+    assert calls["count"] == 0
+    assert np.array_equal(vec, np.zeros(1, dtype=np.float32))

--- a/tests/test_learner_context.py
+++ b/tests/test_learner_context.py
@@ -20,6 +20,7 @@ def _setup_engine(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    eng.mem.set_offline(False)
     eng.base = tmp_path
     eng.prepare_data = lambda: "data"
 

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -22,6 +22,7 @@ def _setup_engine(tmp_path, monkeypatch, calls):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    eng.mem.set_offline(False)
     eng.base = tmp_path
     eng.prepare_data = lambda: "data"
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -14,6 +14,7 @@ def test_add_and_search(tmp_path, monkeypatch):
     monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
     db_path = tmp_path / "mem.db"
     mem = Memory(db_path)
+    mem.set_offline(False)
     mem.add("note", "salut")
 
     with sqlite3.connect(db_path) as con:
@@ -37,6 +38,7 @@ def test_search_embedding_error(tmp_path, monkeypatch):
     monkeypatch.setattr("app.core.memory.embed_ollama", good_embed)
     db_path = tmp_path / "mem.db"
     mem = Memory(db_path)
+    mem.set_offline(False)
     mem.add("note", "bonjour")
 
     def bad_embed(texts, model="nomic-embed-text"):
@@ -56,6 +58,7 @@ def test_search_respects_threshold(tmp_path, monkeypatch):
     fake_embed.calls = 0
     monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
     mem = Memory(tmp_path / "mem.db")
+    mem.set_offline(False)
     mem.add("note", "salut")
     with pytest.raises(ValueError):
         mem.search("salut", threshold=0.5)
@@ -71,6 +74,7 @@ def test_search_threshold_checks_top_score(tmp_path, monkeypatch):
 
     monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
     mem = Memory(tmp_path / "mem.db")
+    mem.set_offline(False)
     mem.add("note", "good")
     mem.add("note", "bad")
 
@@ -97,6 +101,7 @@ def test_sqlcipher_configuration_executes_key_pragma(tmp_path, monkeypatch):
     monkeypatch.setenv("WATCHER_MEMORY_SQLCIPHER_PASSWORD", "pa'ss")
 
     mem = Memory(tmp_path / "mem.db")
+    mem.set_offline(False)
     mem._sqlcipher_available = True
     mem._sqlcipher_enabled = True
     mem._sqlcipher_key_sql = "PRAGMA key = 'pa''ss'"
@@ -139,6 +144,7 @@ def test_connection_pragmas_applied(tmp_path, monkeypatch):
 
     monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
     mem = Memory(tmp_path / "mem.db")
+    mem.set_offline(False)
 
     with mem._connect() as con:
         journal_mode = con.execute("PRAGMA journal_mode").fetchone()[0]
@@ -153,6 +159,7 @@ def test_connection_pragmas_applied(tmp_path, monkeypatch):
 def test_ensure_fts5_detects_compile_option(tmp_path, monkeypatch):
     monkeypatch.setattr(Memory, "_run_migrations", lambda self: None)
     mem = Memory(tmp_path / "mem.db")
+    mem.set_offline(False)
     mem._fts5_checked = False
     mem._fts5_available = False
     mem._fts5_requires_extension = False
@@ -170,6 +177,7 @@ def test_ensure_fts5_detects_compile_option(tmp_path, monkeypatch):
 def test_ensure_fts5_loads_extension(tmp_path, monkeypatch):
     monkeypatch.setattr(Memory, "_run_migrations", lambda self: None)
     mem = Memory(tmp_path / "mem.db")
+    mem.set_offline(False)
     mem._fts5_checked = False
     mem._fts5_available = False
     mem._fts5_requires_extension = False

--- a/tests/test_memory_summary.py
+++ b/tests/test_memory_summary.py
@@ -11,6 +11,7 @@ def test_summarize_limits_items(tmp_path, monkeypatch):
     monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
     db_path = tmp_path / "mem.db"
     mem = Memory(db_path)
+    mem.set_offline(False)
     max_items = 5
     for i in range(max_items + 3):
         mem.add("note", f"msg {i}")

--- a/tests/test_prompt_sanitization.py
+++ b/tests/test_prompt_sanitization.py
@@ -25,6 +25,7 @@ def test_engine_chat_rejects_command(tmp_path, monkeypatch) -> None:
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    eng.mem.set_offline(False)
     eng.client = DummyClient()
     eng.critic = Critic()
 

--- a/tests/test_reasoning_chain.py
+++ b/tests/test_reasoning_chain.py
@@ -23,6 +23,7 @@ def test_chat_records_reasoning(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    eng.mem.set_offline(False)
     eng.client = DummyClient()
     eng.critic = Critic()
 

--- a/tests/test_trace_logging.py
+++ b/tests/test_trace_logging.py
@@ -19,6 +19,7 @@ def test_trace_stored_in_memory(tmp_path, monkeypatch):
 
     eng = Engine.__new__(Engine)
     eng.mem = Memory(tmp_path / "mem.db")
+    eng.mem.set_offline(False)
     eng.client = DummyClient()
     eng.critic = Critic()
 


### PR DESCRIPTION
## Summary
- add an offline flag to `Memory`, expose `set_offline`, and return a cached zero vector when embedding while offline
- propagate offline state across `Engine` and the CLI so settings, the client, and memory stay in sync
- add regression coverage for the offline behaviour and reset logging between tests to keep `caplog` usable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf0f3060b883208aed637b45ccbe86