### PR TITLE
Add offline mode toggle to LLM client

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -101,6 +101,12 @@ class Client:
         self.host = host or llm_cfg.host
         self.ctx = ctx if ctx is not None else llm_cfg.ctx
         self.fallback_phrase = fallback_phrase or llm_cfg.fallback_phrase
+        self._offline = False
+
+    def set_offline(self, offline: bool) -> None:
+        """Enable or disable offline mode for the client."""
+
+        self._offline = bool(offline)
 
     def generate(self, prompt: str, *, separator: str = "") -> tuple[str, str]:
         """Return a response and trace for *prompt*.
@@ -116,6 +122,10 @@ class Client:
         """
 
         trace: list[str] = []
+        if self._offline:
+            trace.extend(["offline", "fallback"])
+            return f"{self.fallback_phrase}: {prompt}", " -> ".join(trace)
+
         try:  # pragma: no cover - network path
             responses: list[str] = []
             for idx, chunk in enumerate(chunk_prompt(prompt)):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+
+from app.core.engine import Engine
 from app.llm.client import Client
 
 
@@ -13,3 +16,51 @@ def test_client_custom_fallback() -> None:
     answer, trace = client.generate("hi")
     assert answer == "Offline: hi"
     assert "fallback" in trace
+
+
+def test_engine_set_offline_toggles_client(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_generate_ollama(prompt: str, *, host: str, model: str) -> str:
+        calls.append(prompt)
+        return f"generated:{prompt}"
+
+    monkeypatch.setattr(
+        "app.llm.client.generate_ollama", fake_generate_ollama, raising=True
+    )
+
+    class DummyMem:
+        def __init__(self) -> None:
+            self.offline: bool | None = None
+
+        def set_offline(self, offline: bool) -> None:
+            self.offline = bool(offline)
+
+    engine = object.__new__(Engine)
+    engine.client = Client()
+    engine.mem = DummyMem()
+    engine.settings = SimpleNamespace(intelligence=SimpleNamespace(mode="online"))
+    engine._offline = False
+
+    offline_prompt = "bonjour"
+    engine.set_offline(True)
+    assert engine.settings.intelligence.mode == "offline"
+    assert engine.client._offline is True
+    assert engine.mem.offline is True
+
+    offline_answer, offline_trace = engine.client.generate(offline_prompt)
+    assert offline_answer == f"Echo: {offline_prompt}"
+    assert offline_trace.split(" -> ") == ["offline", "fallback"]
+    assert calls == []
+
+    online_prompt = "hola"
+    engine.set_offline(False)
+    assert engine.settings.intelligence.mode == "online"
+    assert engine.client._offline is False
+    assert engine.mem.offline is False
+
+    online_answer, online_trace = engine.client.generate(online_prompt)
+    assert online_answer == f"generated:{online_prompt}"
+    assert "ollama:0" in online_trace.split(" -> ")
+    assert online_trace.split(" -> ")[-1] == "success"
+    assert calls == [online_prompt]


### PR DESCRIPTION
## Summary
- add an offline flag and setter to the LLM client so it can skip network calls
- record offline traces and rely on the fallback response when offline
- extend client tests with Engine coverage to ensure offline toggles prevent and restore network usage

## Testing
- pytest tests/test_client.py

------
https://chatgpt.com/codex/tasks/task_e_68cf19102ed0832085ee67b3fa492490