### PR TITLE
Prepare release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Added
+- Rien pour le moment.
+
+## [v0.4.0] - 2025-09-20
+
+### Added
 - Documentation de la feuille de route et du journal de bord.
 - Chargement en batch des retours mémoire et benchmark associé.
 - Cache chat responses.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 Atelier local d'IA de programmation autonome (offline par défaut).
 Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurité.
 
+## Version
+
+La dernière version stable est **v0.4.0** (tag `v0.4.0`, publiée le 20 septembre 2025). Consultez le
+[CHANGELOG](CHANGELOG.md) pour le détail des nouveautés et correctifs.
+
 ## Documentation
 
 La documentation technique est générée avec [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)


### PR DESCRIPTION
## Summary
- record the v0.4.0 release in the top-level changelog
- highlight v0.4.0 as the latest stable version in the README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cf1f173bd88320b3fd7997f69df989