### PR TITLE
Add OpenSSF Scorecard gate and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,44 @@ env:
   TORCH_DETERMINISTIC: "1"
 
 jobs:
+  scorecard:
+    name: Scorecard gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          results_file: scorecard-results.json
+          results_format: json
+          publish_results: false
+
+      - name: Enforce minimum score
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          results = json.loads(Path("scorecard-results.json").read_text())
+          score = results.get("score")
+
+          print(f"OpenSSF Scorecard: {score}")
+          if score is None:
+            raise SystemExit("Unable to read Scorecard score from scorecard-results.json")
+
+          if score < 7:
+            raise SystemExit("OpenSSF Scorecard score below policy threshold (7)")
+          PY
+
   quality:
     name: Quality checks
+    needs: scorecard
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,42 @@
+name: OpenSSF Scorecard
+
+on:
+  schedule:
+    - cron: '17 3 * * 1'
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  security-events: write
+  id-token: write
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run OpenSSF Scorecard
+        uses: ossf/scorecard-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: ${{ github.event_name != 'pull_request' }}
+
+      - name: Upload Scorecard artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: scorecard-results.sarif

--- a/QA.md
+++ b/QA.md
@@ -19,6 +19,9 @@
 
 ## Continuous Integration
 
+* Le job `Scorecard gate` rejoue l'analyse OpenSSF Scorecard pour chaque Pull Request via
+  `ossf/scorecard-action@v2`. La CI échoue dès que le score global descend sous `7` afin de
+  bloquer la fusion tant que les recommandations critiques ne sont pas appliquées.
 * The Windows job invokes `./installer.ps1 -SkipOllama` to validate that the PowerShell installer succeeds
   without the Ollama models.
 * Immediately afterwards the workflow launches `./run.ps1` with an empty `DISPLAY` variable to emulate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Watcher
 
 ![Benchmark status badge](metrics/performance_badge.svg)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/<owner>/Watcher/badge)](https://securityscorecards.dev/viewer/?uri=github.com/<owner>/Watcher)
 
 Atelier local d'IA de programmation autonome (offline par défaut).
 Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurité.
@@ -21,6 +22,20 @@ mkdocs serve
 
 Le workflow GitHub Actions [`deploy-docs.yml`](.github/workflows/deploy-docs.yml) construit le site avec `mkdocs build --strict`
 avant de le publier sur l'environnement **GitHub Pages** à chaque push sur `main`.
+
+## Sécurité et qualité automatisées
+
+Le badge OpenSSF Scorecard reflète en continu l'état de la posture de sécurité du dépôt
+(`.github/workflows/scorecard.yml`). Il est généré à partir de l'API publique
+<https://api.securityscorecards.dev/projects/github.com/<owner>/Watcher> et renvoie vers le
+rapport détaillé sur <https://securityscorecards.dev>. Un run planifié hebdomadaire publie les
+résultats sur le tableau de bord OpenSSF, tandis que chaque Pull Request bénéficie d'une analyse
+à jour dans GitHub Actions.
+
+La CI inclut désormais un garde-fou `Scorecard gate` dans [`ci.yml`](.github/workflows/ci.yml)
+qui rejoue l'analyse Scorecard à chaque Pull Request. Le job échoue si le score global
+redescend sous `7`, empêchant ainsi le reste du pipeline et la fusion tant que les bonnes
+pratiques identifiées par Scorecard ne sont pas rétablies.
 
 ## Releases, SBOM et provenance
 


### PR DESCRIPTION
## Summary
- add a dedicated OpenSSF Scorecard workflow that runs on pull requests and a weekly schedule
- enforce a Scorecard quality gate in the main CI when the overall score drops below 7
- document the new badge and quality gate in the README and QA guidelines

## Testing
- not run (workflow and documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cf1f3b132c8320b46179fbdbcf2967