### PR TITLE
chore: configure dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@ packaging/                @WatcherOrg/app-core
 # scope:ops — Automatisation, CI/CD et outillage développeur
 .github/workflows/        @WatcherOrg/release-engineering
 .github/auto_merge.yml    @WatcherOrg/release-engineering
+.github/dependabot.yml    @WatcherOrg/release-engineering
 automation-playbook.sh    @WatcherOrg/release-engineering
 auto_flow.sh              @WatcherOrg/release-engineering
 noxfile.py                @WatcherOrg/release-engineering

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    requirements:
+      - "requirements.txt"
+      - "requirements-dev.txt"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "WatcherOrg/release-engineering"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "WatcherOrg/release-engineering"

--- a/QA.md
+++ b/QA.md
@@ -10,6 +10,22 @@
    retirera après revue. Une fois la CI verte, seul un mainteneur pose
    `status:ready-to-merge` pour déclencher la fusion automatique.
 
+## PR Dependabot
+
+* Dependabot ouvre des PR hebdomadaires pour `requirements.txt`, `requirements-dev.txt`
+  et les workflows GitHub Actions. Il ne garde que 5 PR Python et 3 PR Actions
+  ouvertes simultanément afin de limiter le bruit.
+* Chaque PR est automatiquement affectée à l'équipe `@WatcherOrg/release-engineering`
+  (CODEOWNERS). Elle vérifie la matrice CI complète (`make check` localement si
+  nécessaire) avant d'approuver.
+* Si une mise à jour casse la compatibilité, répondre avec `@dependabot close`
+  en ouvrant un ticket de suivi. Pour les correctifs critiques, demander une
+  mise à jour dédiée via `@dependabot recreate` après avoir fusionné les
+  correctifs bloquants.
+* Déclencher `@dependabot rebase` lorsque la branche est en retard ou que la CI
+  échoue pour cause de conflits. Fusionner en **Squash & merge** une fois la
+  revue validée et la CI verte.
+
 ## Manual Verification
 
 1. Launch the GUI with `python -m app.ui.main`.


### PR DESCRIPTION
## Summary
- add a Dependabot configuration for Python requirements and GitHub Actions with weekly checks and capped concurrent PRs
- ensure the release engineering team is code owner for the Dependabot manifest
- document the triage and merge policy for automated dependency PRs

## Testing
- not run (documentation and configuration changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cf1f3cd2808320a3c5f415a8bef0cf