### PR TITLE
Add Docker packaging and publishing workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# VCS metadata
+.git
+.gitignore
+
+# CI and GitHub configuration
+.github
+
+# Python cache and build artifacts
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+*.whl
+*.egg-info/
+*.dist-info/
+
+# Virtual environments and tooling caches
+.venv/
+.nox/
+.pytest_cache/
+.mypy_cache/
+.cache/
+.tox/
+.pdm-build/
+
+# Build outputs
+build/
+dist/
+*.log
+
+# Documentation and local assets not required at runtime
+docs/
+metrics/
+
+# Development containers and DVC metadata
+.devcontainer/
+.dvc/
+
+# Tests not needed inside the runtime image
+tests/
+
+# Miscellaneous
+datasets/.gitignore
+*.env
+*.example
+*.bak

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,50 @@
+name: Docker image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    name: Build and publish image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/watcher
+          tags: |
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=tag,pattern=v*
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt ./
+RUN python -m pip install --upgrade pip \
+    && pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENTRYPOINT ["python", "-m", "app.cli"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -169,6 +169,50 @@ et mettez à jour la configuration d'authentification associée.
 
 Les fichiers d'environnement (`*.env`), les journaux (`*.log`) et les environnements virtuels (`.venv/`) sont ignorés par Git afin d'éviter la mise en version de données sensibles ou temporaires.
 
+## Exécution via Docker
+
+Une image container officielle est construite par le workflow [`docker.yml`](.github/workflows/docker.yml)
+et publiée sur le registre GitHub Container Registry sous `ghcr.io/<owner>/watcher`.
+
+### Utiliser l'image publiée
+
+Les points de montage suivants permettent de persister les fichiers générés par Watcher entre deux
+exécutions :
+
+- `/app/data` : base de données principale (`WATCHER_DATABASE__URL`).
+- `/app/memory` : cache vectoriel et fichiers de mémoire (`memory/mem.db`).
+- `/app/logs` : journaux d'exécution.
+- `/app/config` *(optionnel)* : configuration TOML et fichiers `plugins.toml` personnalisés.
+
+```bash
+docker run --rm -it \
+  -v watcher-data:/app/data \
+  -v watcher-memory:/app/memory \
+  -v watcher-logs:/app/logs \
+  ghcr.io/<owner>/watcher:latest --help
+```
+
+Copiez le dossier `config/` du dépôt si vous souhaitez le personnaliser avant de le monter en lecture
+(`-v "$(pwd)/config:/app/config:ro"`).  Les variables d'environnement peuvent être fournies avec
+`--env-file` (par exemple `--env-file ./example.env`).
+
+Pour exécuter une commande CLI, passez-la directement après l'image :
+
+```bash
+docker run --rm -it ghcr.io/<owner>/watcher:latest plugin list
+```
+
+### Construire l'image en local
+
+Si vous ne souhaitez pas attendre la publication GitHub Actions, construisez et testez l'image avec Docker :
+
+```bash
+docker build -t watcher:local .
+docker run --rm -it watcher:local mode offline
+```
+
+Les volumes présentés ci-dessus fonctionnent également avec l'image locale (`watcher:local`).
+
 ## Environnement de développement
 
 Un dossier `.devcontainer/` est fourni pour disposer d'un environnement prêt à l'emploi


### PR DESCRIPTION
## Summary
- add a production Dockerfile that installs runtime requirements and exposes the watcher CLI entrypoint
- exclude development artifacts from the container build context via .dockerignore
- add a GitHub Actions workflow that builds and publishes ghcr.io/<owner>/watcher on pushes and tags
- document how to run Watcher through Docker, including persistent volumes and local builds

## Testing
- not run (documentation and configuration changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cf1f44f43483209db1a3d4fccabe39