### PR TITLE
Configure packaging and publishing pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,72 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build distributions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build backend
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build sdist and wheel
+        run: python -m build --wheel --sdist
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+          if-no-files-found: error
+
+  publish-testpypi:
+    name: Publish to TestPyPI
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Upload package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist
+          skip-existing: true
+
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: publish-testpypi
+    environment: pypi
+    steps:
+      - name: Download distributions
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Upload package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: dist
+          skip-existing: true

--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ Ces fichiers sont publiés en tant qu'artefacts de release. Téléchargez le SBO
 Le bundle Sigstore fournit également un horodatage de transparence et peut être vérifié hors-ligne grâce au
 [`rekor-cli`](https://github.com/sigstore/rekor) si vous devez archiver la preuve de signature.
 
+## Installation via pipx ou pip
+
+Pour installer la CLI `watcher` depuis un dépôt PyPI, privilégiez `pipx` qui isole automatiquement
+les dépendances dans un environnement dédié :
+
+```bash
+pipx install watcher
+```
+
+La commande `pipx upgrade watcher` mettra ensuite à jour l'application lorsqu'un nouveau tag
+SemVer est publié. Si vous préférez utiliser `pip`, créez ou activez un environnement virtuel
+et installez le package directement :
+
+```bash
+python -m pip install watcher
+```
+
+Cette installation apporte la commande `watcher` et l'ensemble des fichiers de configuration
+décrits dans ce dépôt. L'installeur Windows signé reste disponible en option via les releases
+GitHub (voir section précédente) pour les environnements qui privilégient un exécutable autonome.
+
 ## Benchmarks
 
 Le script `python -m app.core.benchmark run` exécute quatre scénarios
@@ -133,7 +154,7 @@ Si vous devez utiliser un autre fournisseur (Azure Blob Storage, Google Cloud,
 etc.), ajustez l'URL du remote via `dvc remote modify storage url <nouvelle-url>`
 et mettez à jour la configuration d'authentification associée.
 
-## Installation
+## Installation depuis les sources
 
 1. Cloner ce dépôt.
 2. Créer et activer un environnement Python 3.12 :

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,14 @@ Bienvenue dans l'espace de référence du projet **Watcher**, l'atelier local d'
 Cette documentation complète le README en décrivant la structure logicielle, les mesures de sécurité et le
 mode d'exploitation de la plate-forme.
 
+## Installer Watcher
+
+- **pipx** : `pipx install watcher` déploie la CLI dans un environnement isolé et facilite les mises à jour
+  (`pipx upgrade watcher`).
+- **pip** : `python -m pip install watcher` installe le package dans l'environnement virtuel actif.
+- **Windows** : un installeur signé reste proposé via les releases GitHub pour ceux qui préfèrent un
+  exécutable autonome (voir la procédure détaillée dans le README).
+
 ## Parcours recommandé
 
 1. Comprendre la [vue d'ensemble de l'architecture](architecture.md) pour visualiser le dialogue entre

--- a/noxfile.py
+++ b/noxfile.py
@@ -74,5 +74,6 @@ def tests(session: nox.Session) -> None:
 @nox.session(python=PYTHON_VERSIONS)
 def build(session: nox.Session) -> None:
     """Build the project wheel and source distribution."""
-    install_project(session, "build")
-    session.run("python", "-m", "build")
+    session.install("--upgrade", "pip")
+    session.install("--constraint", "requirements-dev.txt", "build")
+    session.run("python", "-m", "build", "--wheel", "--sdist")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,60 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "watcher"
+version = "0.1.0"
+description = "Atelier local d'IA de programmation autonome (offline par défaut)."
+readme = "README.md"
+license = "MIT"
+requires-python = ">=3.11"
+authors = [{ name = "Watcher contributors" }]
+keywords = ["agents", "automation", "llm", "offline"]
+license-files = ["LICENSE"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "alembic>=1.13,<2.0",
+    "beautifulsoup4>=4.12,<5.0",
+    "httpx>=0.27,<1.0",
+    "numpy>=1.26,<3.0",
+    "psutil>=5.9,<6.0",
+    "pydantic>=2.8,<3.0",
+    "pydantic-settings>=2.4,<3.0",
+    "rich>=13.7,<14.0",
+    "sentence-transformers>=2.2,<3.0",
+    "sqlalchemy>=2.0,<3.0",
+]
+
+[project.scripts]
+watcher = "app.cli:main"
+
+[project.urls]
+Documentation = "https://<github-username>.github.io/Watcher/"
+Source = "https://github.com/<github-username>/Watcher"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["app*", "config*"]
+
+[tool.setuptools.package-data]
+"app" = ["plugins.toml"]
+"config" = ["*.toml", "*.yml", "*.json"]
+
 [tool.black]
 line-length = 88
 target-version = ["py312"]
 
 [tool.ruff]
 line-length = 88
-
-[tool.setuptools]
-include-package-data = true
-
-[tool.setuptools.package-data]
-"app" = ["plugins.toml"]
-


### PR DESCRIPTION
## Summary
- define the core project metadata in `pyproject.toml`, including dependencies, CLI entrypoint, and package data declarations
- document pipx/pip based installation in the README and docs while keeping the Windows installer procedure, and refresh the nox build session to use constrained `python -m build`
- add a tag-triggered publish workflow that builds distributions and pushes them to TestPyPI then the protected PyPI environment

## Testing
- `python -m build` *(fails: build module unavailable in the execution environment)*
- `python - <<'PY' ...` *(passes: used `setuptools.build_meta` directly to build sdist and wheel while `build` module is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68cf1f4566548320a4d1f25cc23cb930