### PR TITLE
Add contribution governance documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Code de conduite des contributeurs
+
+## Notre engagement
+
+Afin de favoriser un environnement ouvert et accueillant, nous nous engageons à faire de la participation à Watcher une
+expérience exempte de harcèlement pour tous, quel que soit l'âge, la corpulence, le handicap, l'apparence physique, le
+statut marital, l'identité ou l'expression de genre, l'expérience, la nationalité, la race, la religion ou l'identité et
+l'orientation sexuelle.
+
+Nous adoptons les principes du [Contributor Covenant](https://www.contributor-covenant.org/), adaptés à notre contexte pour
+clarifier les attentes spécifiques au projet et les canaux d'escalade.
+
+## Nos standards
+
+Exemples de comportements qui contribuent à créer un environnement positif :
+
+- faire preuve d'empathie et de bienveillance envers les autres personnes ;
+- respecter les opinions, points de vue et expériences divergentes ;
+- accepter les critiques constructives avec professionnalisme ;
+- se concentrer sur ce qui est le mieux pour la communauté et pour les utilisateur·rices ;
+- aider les nouveaux arrivants à comprendre les processus techniques (DVC, Nox, scripts d'assurance qualité) ;
+- signaler promptement les risques de sécurité ou de confidentialité découverts dans le projet.
+
+Exemples de comportements inacceptables de la part des participants :
+
+- l'utilisation d'un langage ou d'images sexualisés et toute attention sexuelle indésirable ;
+- le trolling, les commentaires insultants ou dégradants, les attaques personnelles ou politiques ;
+- le harcèlement public ou privé ;
+- la publication d'informations privées d'autrui sans consentement explicite (doxing) ;
+- toute autre conduite qui pourrait raisonnablement être considérée comme inappropriée dans un environnement
+  professionnel ;
+- l'introduction volontaire de vulnérabilités, de dépendances malveillantes ou de fuites de secrets.
+
+## Notre responsabilité
+
+Les mainteneurs sont chargés de clarifier les standards de comportement acceptable et sont attendus pour appliquer ce code de
+conduite de manière appropriée et équitable. Ils ont le droit et la responsabilité de supprimer, modifier ou rejeter des
+commentaires, commits, code, issues ou autres contributions qui ne sont pas alignés avec ce code.
+
+Les mainteneurs peuvent temporairement ou définitivement bannir tout contributeur dont le comportement est jugé
+inapproprié, menaçant, offensant ou nuisible.
+
+## Portée
+
+Ce code de conduite s'applique dans tous les espaces du projet, qu'ils soient en ligne ou en personne, et s'applique également
+lorsque quelqu'un représente officiellement le projet ou sa communauté. Les exemples de représentation incluent l'utilisation
+d'une adresse e-mail officielle du projet, la publication via un compte social officiel ou l'intervention en tant que délégué
+lors d'un événement en ligne ou hors ligne.
+
+## Application et escalade
+
+En cas de comportement abusif, harcelant ou autrement inacceptable, signalez le problème aux mainteneurs via l'adresse
+<maintainers@watcher.local>. Pour les incidents liés à la sécurité ou à la confidentialité des données, vous pouvez également
+contacter directement l'équipe sécurité à <security@watcher.local>. Fournissez autant d'informations que possible (liens,
+captures d'écran, journal des événements) afin de faciliter l'enquête.
+
+Une fois l'incident reçu :
+
+1. **Accusé de réception** — vous recevrez une réponse dans les trois jours ouvrés confirmant la bonne prise en compte du
+   signalement.
+2. **Analyse** — au moins deux mainteneurs examinent les faits, peuvent demander des informations complémentaires et déterminent
+   les mesures correctives.
+3. **Décision** — les mesures possibles comprennent un avertissement privé, une suspension temporaire de participation, la
+   révocation d'accès ou l'interdiction définitive, selon la gravité de l'incident.
+4. **Suivi** — les mesures retenues sont documentées et communiquées aux parties impliquées. Les incidents impliquant des
+   menaces physiques ou juridiques peuvent être escaladés auprès des autorités compétentes.
+
+Les mainteneurs sont tenus à la confidentialité concernant les informations fournies par les plaignants. Les signalements abusifs
+ou de mauvaise foi seront rejetés.
+
+## Attribution
+
+Ce code de conduite est adapté de la version 2.1 du [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+Pour obtenir les réponses aux questions courantes sur ce code de conduite, consultez la FAQ du Contributor Covenant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contribuer à Watcher
+
+Merci de votre intérêt pour l'amélioration de Watcher ! Ce guide détaille les attentes du projet, la préparation de votre
+environnement et la politique de revue/merge appliquée par l'équipe de maintenance.
+
+## Respecter le code de conduite
+
+Toutes les contributions doivent respecter le [Code de conduite](CODE_OF_CONDUCT.md). Signalez immédiatement tout comportement
+inapproprié aux mainteneurs.
+
+## Préparer son environnement
+
+- **Python 3.12** : créez un environnement virtuel dédié (`python -m venv .venv`).
+- **Dépendances projet** : installez les requirements de base et de développement :
+  ```bash
+  pip install -r requirements.txt
+  pip install -r requirements-dev.txt
+  ```
+- **Nox** : l'ensemble des linters, tests, vérifications de sécurité et build passe par [Nox](https://nox.thea.codes/). Installez-le
+  globalement ou dans votre venv (`pip install nox`). Les commandes utilisées par la CI sont :
+  ```bash
+  nox -s lint typecheck security tests build
+  ```
+- **DVC** : Watcher versionne des artefacts de données via [DVC](https://dvc.org/). Installez `dvc` (par exemple `pip install "dvc[s3]"`)
+  puis synchronisez les données nécessaires :
+  ```bash
+  dvc pull
+  ```
+  Le pipeline `dvc repro` orchestre la préparation (`scripts/prepare_data.py`) et la validation (`scripts/validate_schema.py`,
+  `scripts/validate_size.py`, `scripts/validate_hash.py`). Assurez-vous que ces étapes restent reproductibles et committez les
+  fichiers `.dvc` et `dvc.lock` mis à jour si besoin.
+- **Scripts utilitaires** : les commandes `python -m app.core.benchmark run` et `python -m app.core.benchmark check --update-badge`
+  sont utilisées pour surveiller les performances et rafraîchir le badge `metrics/performance_badge.svg`. Lancez-les en cas de
+  modifications susceptibles d'impacter les temps d'exécution.
+- **Hooks pre-commit** : activez les hooks fournis (`pre-commit install`) pour aligner vos contributions sur les formats attendus.
+
+## Processus de développement
+
+1. **Créer une branche** : travaillez sur une branche dérivée de `main` pour chaque contribution.
+2. **Synchroniser les données** : si votre changement affecte la pipeline DVC, mettez à jour les artefacts (`dvc repro`) et commitez
+   les fichiers suivis (`*.dvc`, `dvc.lock`, `metrics/…`).
+3. **Exécuter la suite Nox** : vérifiez localement que `nox -s lint typecheck security tests build` passe avant d'ouvrir la PR.
+4. **Mettre à jour la documentation** : adaptez `README.md`, `docs/` ou les guides associés pour décrire les nouvelles capacités ou
+   les breaking changes.
+5. **Rédiger un changelog** : ajoutez une entrée dans `CHANGELOG.md` si la modification est visible pour l'utilisateur final.
+
+## Politique de merge et des pull requests
+
+- **Template obligatoire** : utilisez le modèle de PR par défaut et fournissez un contexte clair (motivation, tests, impact).
+- **Vérifications automatisées** : une PR n'est éligible à la fusion que si tous les checks GitHub (Nox, DVC, benchmarks, lint)
+  sont verts. Les échecs doivent être résolus ou justifiés.
+- **Revue par les CODEOWNERS** : au moins un membre `@WatcherOrg/maintainers` (ou l'équipe `scope:*` concernée définie dans
+  `.github/CODEOWNERS`) doit approuver.
+- **Automerge contrôlé** : après approbation et succès de la CI, un mainteneur applique le label `status:ready-to-merge`. Le workflow
+  `.github/auto_merge.yml` fusionne ensuite automatiquement la PR. N'ajoutez pas ce label vous-même.
+- **Conflits et escalade** : en cas de désaccord technique ou de comportement inapproprié pendant la revue, contactez les
+  mainteneurs via `maintainers@watcher.local`. Les sujets liés à la sécurité doivent être escaladés à `security@watcher.local`.
+- **Backports** : les correctifs critiques peuvent être cherry-pickés vers les branches de maintenance après validation expresse d'un
+  mainteneur.
+
+## Questions fréquentes
+
+- **Comment signaler un bug ?** Ouvrez une issue via le template `Bug report`. Fournissez les étapes de reproduction, les logs
+  pertinents et la version utilisée.
+- **Comment proposer une nouvelle fonctionnalité ?** Utilisez le template `Feature request` et expliquez comment la fonctionnalité
+  s'intègre aux objectifs de Watcher et à l'expérience utilisateur.
+- **Qui contacter en cas de doute ?** Consultez `docs/merge-policy.md` pour connaître la gouvernance détaillée des labels et
+  contactez `@WatcherOrg/maintainers` sur GitHub ou par e-mail en cas de question.
+
+Merci de contribuer à un atelier d'IA de qualité, transparent et sécurisé !

--- a/README.md
+++ b/README.md
@@ -318,6 +318,10 @@ non pertinents.
 
 ## Gouvernance des contributions
 
+Les attentes pour les contributeurs et les canaux d'escalade sont décrites dans le [Code de conduite](CODE_OF_CONDUCT.md).
+Pour préparer votre environnement, exécuter les scripts nécessaires (Nox, DVC, benchmarks) et comprendre la politique de
+review/merge, consultez le guide [CONTRIBUTING.md](CONTRIBUTING.md).
+
 - Les formulaires présents dans `.github/ISSUE_TEMPLATE/` ajoutent
   systématiquement `status:needs-triage` ainsi qu'un label `type:*`
   (`type:bug`, `type:feature`, `type:discussion`).


### PR DESCRIPTION
## Summary
- add a Contributor Covenant based code of conduct with escalation channels for maintainers and security
- document contribution prerequisites, tooling (Nox, DVC, benchmarks) and merge policy in CONTRIBUTING.md
- link the README governance section to the new contribution and conduct guides

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cf1f4880588320839a03c0f17ff3a9