### PR TITLE
Move license configuration to setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ line-length = 88
 
 [tool.setuptools]
 include-package-data = true
+license-files = ["LICENSE"]
 
 [tool.setuptools.package-data]
 "app" = ["plugins.toml"]


### PR DESCRIPTION
## Summary
- configure setuptools to include the LICENSE file

## Testing
- python -m build --wheel --sdist *(fails: No module named build)*

------
https://chatgpt.com/codex/tasks/task_e_68cf241d561883209aa411686ce040ac