### PR TITLE
Add packaging metadata and Python distributions to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,51 @@ env:
   TORCH_DETERMINISTIC: "1"
 
 jobs:
+  build-python-distributions:
+    name: Build Python distributions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Validate SemVer tag
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_NAME}" != v[0-9]*.[0-9]*.[0-9]* ]]; then
+            echo "Release tag '${GITHUB_REF_NAME}' must match vMAJOR.MINOR.PATCH" >&2
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - name: Install build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+
+      - name: Build wheel and sdist
+        run: python -m build
+
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-python-distributions
+          if-no-files-found: error
+          path: |
+            dist/*.whl
+            dist/*.tar.gz
+
   build-windows-installer:
     name: Build and sign Windows installer
     runs-on: windows-latest
@@ -281,6 +326,7 @@ jobs:
   publish-release:
     name: Publish GitHub release
     needs:
+      - build-python-distributions
       - build-windows-installer
       - build-unix-executables
       - generate-provenance
@@ -322,5 +368,7 @@ jobs:
             dist/Watcher-linux-sbom.json
             dist/Watcher-macos-x86_64.zip
             dist/Watcher-macos-sbom.json
+            dist/watcher-*.whl
+            dist/watcher-*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,41 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "watcher"
+version = "0.4.0"
+description = "Atelier local d'IA de programmation autonome (offline par défaut)."
+readme = "README.md"
+requires-python = ">=3.12"
+license = { file = "LICENSE" }
+authors = [{ name = "Watcher contributors" }]
+dependencies = [
+    "httpx==0.27.0",
+    "rich==13.7.1",
+    "beautifulsoup4==4.12.2",
+    "sentence-transformers==2.2.2",
+    "pydantic==2.8.2",
+    "pydantic-settings==2.4.0",
+    "SQLAlchemy==2.0.32",
+    "alembic==1.13.2",
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+]
+
+[project.scripts]
+watcher = "app.cli:main"
+
+[tool.setuptools.packages.find]
+include = ["app*", "config*"]
+
 [tool.black]
 line-length = 88
 target-version = ["py312"]
@@ -11,4 +49,5 @@ license-files = ["LICENSE"]
 
 [tool.setuptools.package-data]
 "app" = ["plugins.toml"]
+"config" = ["*.toml", "*.yml", "*.json"]
 


### PR DESCRIPTION
## Summary
- add a PEP 621 `[project]` definition with runtime dependencies and CLI entry point
- declare the setuptools build backend and include both `app` and `config` packages with their data files
- extend the release workflow to build wheel/sdist artifacts alongside the existing installers

## Testing
- `nox -s build` *(fails: `nox` is not available in the execution environment and installing it via pip is blocked by the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68cf383d37308320837e0b65a965e694