### PR TITLE
Handle HTTPS hosts for Ollama embeddings

### DIFF
--- a/app/tools/embeddings.py
+++ b/app/tools/embeddings.py
@@ -49,11 +49,20 @@ def embed_ollama(
     host = host or memory_cfg.embed_host
 
     parsed = urlparse(host if "://" in host else f"http://{host}")
+    scheme = (parsed.scheme or "http").lower()
+    if scheme == "https":
+        conn_cls = http.client.HTTPSConnection
+        default_port = 443
+    else:
+        conn_cls = http.client.HTTPConnection
+        default_port = 11434
 
     conn = None
     try:
-        conn = http.client.HTTPConnection(
-            parsed.hostname or "127.0.0.1", parsed.port or 11434, timeout=30
+        conn = conn_cls(
+            parsed.hostname or "127.0.0.1",
+            parsed.port or default_port,
+            timeout=30,
         )
         payload = json.dumps({"model": model, "input": texts})
         conn.request(

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -45,6 +45,23 @@ def test_embed_ollama_host_argument(monkeypatch):
     assert called == {"host": "example.com", "port": 1234}
 
 
+def test_embed_ollama_https_host(monkeypatch):
+    called = {}
+
+    def bad_http_conn(*args, **kwargs):
+        raise AssertionError("HTTPConnection should not be used for HTTPS hosts")
+
+    def bad_https_conn(host, port, *args, **kwargs):
+        called["host"] = host
+        called["port"] = port
+        raise OSError("fail")
+
+    monkeypatch.setattr("http.client.HTTPConnection", bad_http_conn)
+    monkeypatch.setattr("http.client.HTTPSConnection", bad_https_conn)
+    embed_ollama(["hi"], host="https://secure.example.com")
+    assert called == {"host": "secure.example.com", "port": 443}
+
+
 def test_embed_ollama_host_from_config(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- select the appropriate HTTP(S) connection and default port for Ollama embedding hosts
- add coverage ensuring HTTPS hosts use `http.client.HTTPSConnection`

## Testing
- pytest tests/test_embeddings.py

------
https://chatgpt.com/codex/tasks/task_e_68cfcfc1607c832082e4fb12a621ab91