### PR TITLE
Handle HTTPS Ollama hosts

### DIFF
--- a/app/llm/client.py
+++ b/app/llm/client.py
@@ -34,8 +34,16 @@ def generate_ollama(prompt: str, *, host: str, model: str) -> str:
     """
 
     parsed = urlparse(host if "://" in host else f"http://{host}")
-    conn = http.client.HTTPConnection(
-        parsed.hostname or "127.0.0.1", parsed.port or 11434, timeout=30
+    scheme = parsed.scheme or "http"
+    if scheme == "https":
+        connection_cls = http.client.HTTPSConnection
+        default_port = 443
+    else:
+        connection_cls = http.client.HTTPConnection
+        default_port = 11434
+
+    conn = connection_cls(
+        parsed.hostname or "127.0.0.1", parsed.port or default_port, timeout=30
     )
     try:  # pragma: no cover - network path
         payload = json.dumps({"model": model, "prompt": prompt})


### PR DESCRIPTION
## Summary
- select the appropriate HTTP(S) connection class based on the configured host scheme
- default HTTPS hosts to port 443 while preserving existing defaults for other schemes
- add a unit test ensuring HTTPS hosts use HTTPSConnection when generating completions

## Testing
- pytest tests/test_client.py

------
https://chatgpt.com/codex/tasks/task_e_68cfcfc3f9c88320bad25aafc3cb361c