### PR TITLE
ci: sign Docker images with cosign

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 jobs:
   build-and-push:
@@ -48,3 +49,38 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: mode=max
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign published images
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          mkdir -p cosign-bundles
+          tags="${TAGS//,/ }"
+          for image in $tags; do
+            if [ -n "$image" ]; then
+              sanitized=$(echo "$image" | tr '/:' '__')
+              cosign sign --yes --keyless --bundle "cosign-bundles/${sanitized}.sigstore" "$image"
+            fi
+          done
+
+      - name: Upload Cosign bundles artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cosign-bundles
+          path: cosign-bundles
+
+      - name: Attach bundles to GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" cosign-bundles/*.sigstore --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            echo "No GitHub Release found for tag $tag, skipping upload."
+          fi

--- a/README.md
+++ b/README.md
@@ -241,6 +241,36 @@ Les fichiers d'environnement (`*.env`), les journaux (`*.log`) et les environnem
 
 Une image container officielle est construite par le workflow [`docker.yml`](.github/workflows/docker.yml)
 et publiée sur le registre GitHub Container Registry sous `ghcr.io/<owner>/watcher`.
+Les images publiées sont taguées `latest` (branche `main`) et avec chaque version SemVer (`vX.Y.Z`).
+
+```bash
+docker pull ghcr.io/<owner>/watcher:v1.2.3
+```
+
+Les signatures [Sigstore](https://www.sigstore.dev/) sont publiées pour chaque tag sous la forme de
+bundles `*.sigstore` (artefacts du workflow et assets des pages GitHub Releases). Vérifiez une image
+avec `cosign` :
+
+```bash
+cosign verify \
+  --bundle watcher_v1.2.3.sigstore \
+  --certificate-identity-regexp "https://github.com/<owner>/Watcher/.github/workflows/docker.yml@.*" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/<owner>/watcher:v1.2.3
+```
+
+Les attestations de provenance associées peuvent être vérifiées avec :
+
+```bash
+cosign verify-attestation \
+  --type slsaprovenance \
+  --certificate-identity-regexp "https://github.com/<owner>/Watcher/.github/workflows/docker.yml@.*" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/<owner>/watcher:v1.2.3
+```
+
+Les signatures permettent également de valider le tag `latest` si vous préférez suivre la branche
+principale (`--bundle watcher_latest.sigstore`).
 
 ### Utiliser l'image publiée
 


### PR DESCRIPTION
## Summary
- enable keyless cosign signing for published Docker images and export bundle files
- upload cosign bundles as workflow artifacts and attach them to GitHub releases
- document image tags and cosign verification commands in the Docker usage section of the README

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cfd06124cc8320a36254cf6773e775