### PR TITLE
Add citation metadata and documentation guidance

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+title: Watcher
+abstract: |
+  Watcher est un atelier local d'IA de programmation autonome, hors-ligne par défaut,
+  combinant mémoire vectorielle, curriculum adaptatif, benchmarks A/B et garde-fous de
+  sécurité.
+authors:
+  - name: Watcher contributors
+identifiers:
+  - type: url
+    value: https://github.com/<owner>/Watcher/releases/tag/v0.4.0
+    description: Version v0.4.0 publiée le 20 septembre 2025
+repository-code: https://github.com/<owner>/Watcher
+version: 0.4.0

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurit
 La dernière version stable est **v0.4.0** (tag `v0.4.0`, publiée le 20 septembre 2025). Consultez le
 [CHANGELOG](CHANGELOG.md) pour le détail des nouveautés et correctifs.
 
+## Citer Watcher
+
+Merci de citer ce dépôt lorsque vous réutilisez son code, ses jeux de données ou sa
+documentation. Les métadonnées officielles de citation sont fournies dans
+[`CITATION.cff`](CITATION.cff) et peuvent être exportées dans différents formats à
+l'aide de [`cffconvert`](https://github.com/citation-file-format/cff-converter-python) :
+
+```bash
+pip install cffconvert
+cffconvert --validate --format bibtex --outfile watcher.bib
+```
+
 ## Documentation
 
 La documentation technique est générée avec [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)

--- a/docs/merge-policy.md
+++ b/docs/merge-policy.md
@@ -5,6 +5,11 @@ workflows GitHub sont utilisés pour assurer un cycle de contribution
 cohérent. Il complète les informations générales du `README.md` et les
 check-lists qualité documentées dans `QA.md`.
 
+> 📌 **Rappel citation** : lors de la préparation d'une release ou d'une
+> contribution majeure, vérifiez que la version publiée et le fichier
+> `CITATION.cff` sont alignés avec le `pyproject.toml` et le `CHANGELOG.md` afin
+> que les équipes externes puissent citer correctement le projet.
+
 ## Typologie des labels
 
 Trois familles de labels sont utilisées pour classifier les issues et les


### PR DESCRIPTION
## Summary
- add a CITATION.cff file with release v0.4.0 metadata aligned with the changelog
- document how to cite Watcher in the README using cffconvert
- remind maintainers in the governance guide to keep citation data in sync with releases

## Testing
- mkdocs build --strict *(fails: mkdocs command not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd06affd483208b4b3565e33af660