### PR TITLE
Add container SBOM generation and release artifact

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,12 +39,44 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=tag,pattern=v*
 
-      - name: Build and push
+      - name: Build image
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          push: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Download Syft
+        uses: anchore/sbom-action/download-syft@v0
+
+      - name: Generate container SBOM
+        id: generate-sbom
+        run: |
+          set -euo pipefail
+          PRIMARY_TAG=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)
+          if [ -z "$PRIMARY_TAG" ]; then
+            echo "No image tag was generated" >&2
+            exit 1
+          fi
+          syft "$PRIMARY_TAG" -o cyclonedx-json > Watcher-container-sbom.cdx.json
+          echo "sbom-file=Watcher-container-sbom.cdx.json" >> "$GITHUB_OUTPUT"
+
+      - name: Upload container SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Watcher-container-sbom
+          if-no-files-found: error
+          path: ${{ steps.generate-sbom.outputs.sbom-file }}
+
+      - name: Push image
+        run: |
+          set -euo pipefail
+          while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              docker image push "$tag"
+            fi
+          done < <(printf '%s\n' "${{ steps.meta.outputs.tags }}")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,6 +340,16 @@ jobs:
           path: dist
           merge-multiple: true
 
+      - name: Download container image SBOM
+        if: github.ref_type == 'tag'
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          workflow: docker.yml
+          workflow_conclusion: success
+          name: Watcher-container-sbom
+          tag: ${{ github.ref_name }}
+          path: dist
+
       - name: Normalize provenance filename
         run: |
           set -euo pipefail
@@ -368,6 +378,7 @@ jobs:
             dist/Watcher-linux-sbom.json
             dist/Watcher-macos-x86_64.zip
             dist/Watcher-macos-sbom.json
+            dist/Watcher-container-sbom.cdx.json
             dist/watcher-*.whl
             dist/watcher-*.tar.gz
         env:


### PR DESCRIPTION
## Summary
- run Syft in the Docker workflow to produce a CycloneDX SBOM before pushing the image
- upload the container SBOM as a workflow artifact and publish it with the rest of the release assets

## Testing
- no tests (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68cfd05f10b4832094efcb01767458ba