### PR TITLE
docs: ajouter la vérification de provenance et un guide hors-ligne

### DIFF
--- a/docs/offline_guide.md
+++ b/docs/offline_guide.md
@@ -1,0 +1,150 @@
+# Exploitation en environnement air-gap
+
+Ce guide décrit la préparation et l'exploitation de Watcher dans un réseau isolé (air-gap).
+L'objectif est de transférer un kit complet — exécutables, dépendances Python, SBOM et
+attestations — depuis une zone connectée vers une enclave déconnectée, tout en conservant les
+contrôles d'intégrité.
+
+## 1. Préparer le kit hors-ligne sur une machine connectée
+
+1. **Téléchargez les artefacts de release** depuis GitHub pour le tag ciblé :
+
+   ```bash
+   mkdir -p ~/watcher-offline-kit/artifacts
+   cd ~/watcher-offline-kit/artifacts
+   gh release download <tag> --repo <owner>/Watcher
+   ```
+
+   Ce répertoire doit contenir au minimum :
+
+   - `Watcher-Setup.zip`, `Watcher-linux-x86_64.tar.gz`, `Watcher-macos-x86_64.zip`.
+   - Les SBOM (`Watcher-*.json`).
+   - L'attestation SLSA (`Watcher-Setup.intoto.jsonl`).
+   - Les bundles Sigstore (`*.sigstore`) et les `sha256sum`.
+
+   Le CLI `gh` facilite le téléchargement groupé ; à défaut, récupérez les mêmes fichiers via
+   l'interface web ou `curl -L -O`.
+
+2. **Constituez un miroir PyPI minimal** contenant les dépendances Python nécessaires :
+
+   ```bash
+   cd ~/watcher-offline-kit
+   python -m venv venv
+   source venv/bin/activate
+   pip install --upgrade pip wheel
+   pip download -r /workspace/Watcher/requirements.txt --dest ./pypi-mirror
+   pip download -r /workspace/Watcher/requirements-dev.txt --dest ./pypi-mirror
+   deactivate
+   ```
+
+   Le dossier `pypi-mirror/` pourra être copié tel quel dans l'enclave et utilisé avec
+   `pip install --no-index --find-links ./pypi-mirror`.
+
+3. **Sauvegardez la configuration et les prompts** qui accompagnent le binaire :
+
+   ```bash
+   rsync -av --progress /workspace/Watcher/config ~/watcher-offline-kit/
+   rsync -av --progress /workspace/Watcher/example.env ~/watcher-offline-kit/
+   rsync -av --progress /workspace/Watcher/requirements*.txt ~/watcher-offline-kit/
+   ```
+
+4. **Archivez le tout** pour faciliter le transfert physique (clé USB, disque chiffré) :
+
+   ```bash
+   tar -czf watcher-offline-kit.tgz -C ~/watcher-offline-kit .
+   ```
+
+## 2. Vérifier les artefacts sans connexion
+
+Dans l'environnement air-gap, recopiez l'archive et exécutez les contrôles suivants avant toute
+installation :
+
+```bash
+mkdir -p ~/watcher
+cd ~/watcher
+tar -xzf /mnt/usb/watcher-offline-kit.tgz
+```
+
+1. **Empreintes SHA256** :
+
+   ```bash
+   sha256sum --check sha256sums.txt
+   ```
+
+2. **Signatures Sigstore** (fonctionnent hors-ligne grâce aux bundles) :
+
+   ```bash
+   sigstore verify identity \
+     --bundle artifacts/Watcher-Setup.zip.sigstore \
+     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     artifacts/Watcher-Setup.zip
+   ```
+
+3. **Attestation SLSA** :
+
+   ```bash
+   cosign verify-attestation \
+     --type slsaprovenance \
+     --bundle artifacts/Watcher-Setup.intoto.jsonl.sigstore \
+     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     artifacts/Watcher-Setup.intoto.jsonl | jq '.subject'
+   ```
+
+4. **SBOM CycloneDX** :
+
+   ```bash
+   cosign verify-attestation \
+     --type cyclonedx \
+     --bundle artifacts/Watcher-sbom.json.sigstore \
+     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     artifacts/Watcher-sbom.json | jq '.predicate.metadata'
+   ```
+
+Conservez les journaux de ces commandes comme preuves d'intégrité et stockez-les avec les
+artefacts validés.
+
+## 3. Installer Watcher sans accès Internet
+
+1. **Installer les dépendances Python** depuis le miroir local :
+
+   ```bash
+   python3 -m venv watcher-venv
+   source watcher-venv/bin/activate
+   pip install --no-index --find-links ./pypi-mirror -r requirements.txt
+   ```
+
+2. **Déployer le binaire** correspondant à votre plateforme :
+
+   - Windows : décompressez `Watcher-Setup.zip` et copiez le dossier sur la machine cible.
+   - Linux : `tar -xzf Watcher-linux-x86_64.tar.gz -C /opt/watcher` puis `ln -sf /opt/watcher/Watcher /usr/local/bin/watcher`.
+   - macOS : `unzip Watcher-macos-x86_64.zip` et placez l'application dans `/Applications`.
+
+3. **Configurer l'environnement** :
+
+   - Dupliquez `example.env` en `.env` et renseignez les clés API locales.
+   - Mettez à jour les chemins de stockage dans `config/settings.yaml` pour pointer vers des
+     répertoires internes à l'enclave.
+   - Activez, si nécessaire, le mode `offline` dans la configuration afin de désactiver les
+     intégrations nécessitant Internet.
+
+## 4. Mettre à jour le kit hors-ligne
+
+- Planifiez un cycle de rafraîchissement (par exemple mensuel). Lorsqu'un nouveau tag est publié,
+  recréez le `watcher-offline-kit.tgz` avec les dernières dépendances, SBOM et attestations.
+- Utilisez `diff -ru` entre deux kits pour identifier rapidement les fichiers modifiés.
+- Conservez l'historique des kits sur un support chiffré et versionné pour pouvoir revenir à
+  une version antérieure en cas d'incident.
+
+## 5. Bonnes pratiques de sécurité
+
+- Transportez les supports physiques dans des sacs scellés et consignez chaque transfert.
+- Vérifiez la date de validité des certificats Sigstore : une alerte de révocation doit déclencher
+  un nouveau téléchargement dans la zone connectée.
+- Limitez l'accès au miroir PyPI local aux seules machines de confiance et nettoyez-le après
+  chaque mise à jour.
+
+En suivant ces étapes, Watcher peut être installé et maintenu dans une enclave totalement
+isolée tout en respectant les exigences de traçabilité et d'intégrité logicielle.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,0 +1,58 @@
+# Notes de version Watcher
+
+Cette page récapitule chaque tag SemVer publié pour Watcher. Elle complète le
+[`CHANGELOG`](CHANGELOG.md) en proposant une vue synthétique des fonctionnalités et en
+référençant les pages GitHub Releases correspondantes.
+
+## Synthèse des tags
+
+| Version | Date | Points clés | Lien GitHub Releases |
+| --- | --- | --- | --- |
+| *(à publier)* | — | Préparez la release initiale à partir de la section `Unreleased` du [CHANGELOG](CHANGELOG.md). | [Brouillons et releases](https://github.com/<github-username>/Watcher/releases) |
+
+!!! info "Mettre à jour dès la première release"
+    Remplacez la ligne ci-dessus par un bloc par version dès qu'un tag `vMAJOR.MINOR.PATCH`
+    est poussé :
+
+    ```markdown
+    ## v1.2.3 — 2025-10-07
+
+    - 🔒 Renforcement de la politique de signatures Sigstore.
+    - 🛠️ Nouveaux connecteurs de données.
+    - 📦 SBOM CycloneDX enrichi (classification des licences).
+
+    ➤ [Consulter la release GitHub](https://github.com/<github-username>/Watcher/releases/tag/v1.2.3)
+    ```
+
+## Processus de publication
+
+1. Créez un tag annoté sur la branche `main` :
+
+   ```bash
+   git tag -a vMAJOR.MINOR.PATCH -m "Watcher vMAJOR.MINOR.PATCH"
+   git push origin vMAJOR.MINOR.PATCH
+   ```
+
+2. Vérifiez sur GitHub que le workflow `release.yml` a bien généré :
+
+   - Les exécutables (`Watcher-Setup.zip`, `Watcher-linux-x86_64.tar.gz`, `Watcher-macos-x86_64.zip`).
+   - Les SBOM CycloneDX (`Watcher-*-sbom.json`).
+   - L'attestation SLSA (`Watcher-Setup.intoto.jsonl`).
+   - Les bundles Sigstore (`*.sigstore`).
+
+3. Complétez la description de la release avec :
+
+   - Un résumé des nouveautés (copié/collé de cette page et du CHANGELOG).
+   - Les instructions de vérification (`sigstore verify`, `cosign verify-attestation`).
+   - Les empreintes `sha256sum` pour chaque artefact.
+
+## Historiser les mises à jour
+
+- Ajoutez un bloc `## vX.Y.Z — YYYY-MM-DD` pour chaque tag publié, avec les points clés et les
+  liens pertinents (issues, PR, tickets internes).
+- Conservez une tonalité orientée produit : décrivez l'impact utilisateur, pas uniquement
+  les changements techniques.
+- Archivez un PDF de la release (fonction *Export release notes*) pour les besoins de conformité.
+
+Cette page sert de table d'orientation rapide pour savoir quelles fonctionnalités sont
+contenues dans chaque version officielle de Watcher.

--- a/docs/security_provenance.md
+++ b/docs/security_provenance.md
@@ -1,0 +1,140 @@
+# Vérification de la provenance et des artefacts
+
+La chaîne de compilation de Watcher repose sur les workflows GitHub Actions et les services
+Sigstore. Chaque release SemVer publie des exécutables, un SBOM CycloneDX par plateforme et
+une provenance SLSA (`*.intoto.jsonl`). Cette page décrit comment vérifier ces artefacts avant
+de les déployer en production.
+
+## Pré-requis
+
+Installez les utilitaires suivants sur une machine de validation connectée à Internet :
+
+- [sigstore](https://www.sigstore.dev/) pour vérifier les bundles de signatures (`*.sigstore`).
+- [cosign](https://docs.sigstore.dev/cosign/overview/) pour valider les attestations SLSA et
+  SBOM.
+- [`jq`](https://stedolan.github.io/jq/) ou un autre parseur JSON pour inspecter les métadonnées
+  retournées par `cosign`.
+
+```bash
+pipx install sigstore
+brew install cosign jq  # macOS
+sudo apt install cosign jq -y  # Debian/Ubuntu
+```
+
+Téléchargez ensuite, depuis la page GitHub Releases du tag visé, l'exécutable, le SBOM, la
+provenance SLSA et leurs bundles Sigstore associés. Exemple pour Windows :
+
+```text
+Watcher-Setup.zip
+Watcher-Setup.zip.sigstore
+Watcher-Setup.intoto.jsonl
+Watcher-Setup.intoto.jsonl.sigstore
+Watcher-sbom.json
+Watcher-sbom.json.sigstore
+```
+
+!!! tip "Utiliser les SHA256 publiés"
+    Chaque release expose également les empreintes `sha256sum` en tant qu'artefacts.
+    Téléchargez-les pour automatiser l'intégrité des fichiers transférés vers un réseau déconnecté.
+
+## Vérifier la signature Sigstore (`sigstore verify`)
+
+1. Calculez le hash du binaire pour vérifier qu'il correspond à l'empreinte publiée :
+
+   ```bash
+   sha256sum Watcher-Setup.zip
+   ```
+
+2. Vérifiez la signature du bundle Sigstore et la provenance GitHub Actions :
+
+   ```bash
+   sigstore verify identity \
+     --bundle Watcher-Setup.zip.sigstore \
+     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     Watcher-Setup.zip
+   ```
+
+   - Remplacez `<owner>` par l'organisation ou l'utilisateur GitHub hébergeant Watcher.
+   - Substituez `<tag>` par la version téléchargée (`vMAJOR.MINOR.PATCH`).
+   - La commande échoue si le bundle ne provient pas du workflow officiel `release.yml`.
+
+3. Répétez la vérification pour les archives Linux et macOS (`Watcher-linux-x86_64.tar.gz`,
+   `Watcher-macos-x86_64.zip`) en adaptant le nom du fichier et du bundle.
+
+!!! success "Automatiser la validation"
+    Intégrez ces commandes dans un script CI interne pour refuser tout artefact dont la
+    signature Sigstore est absente ou invalide.
+
+## Vérifier l'attestation SLSA (`cosign verify-attestation`)
+
+1. Exécutez la vérification cryptographique du fichier de provenance :
+
+   ```bash
+   cosign verify-attestation \
+     --type slsaprovenance \
+     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     --bundle Watcher-Setup.intoto.jsonl.sigstore \
+     Watcher-Setup.intoto.jsonl | jq '.'
+   ```
+
+2. Contrôlez la section `subject` du JSON retourné : le digest SHA256 doit correspondre au
+   binaire validé précédemment (`Watcher-Setup.zip`).
+3. Inspectez également les champs `builder.id` et `invocation.environment.githubWorkflowRef`
+   pour confirmer que le workflow `release.yml` a produit l'artefact.
+
+Pour une vérification approfondie, vous pouvez croiser cette attestation avec
+[`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier) et exporter un rapport PDF
+pour vos audits internes.
+
+## Vérifier le SBOM CycloneDX
+
+Les SBOM sont publiés sous forme de fichiers JSON signés avec Sigstore. Deux étapes sont
+recommandées :
+
+1. Vérifiez la signature du SBOM à l'aide de son bundle Sigstore :
+
+   ```bash
+   sigstore verify identity \
+     --bundle Watcher-sbom.json.sigstore \
+     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     Watcher-sbom.json
+   ```
+
+2. Validez le lien entre le SBOM et l'artefact grâce à `cosign verify-attestation` avec le type
+   `cyclonedx` :
+
+   ```bash
+   cosign verify-attestation \
+     --type cyclonedx \
+     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     --bundle Watcher-sbom.json.sigstore \
+     Watcher-sbom.json | jq '.predicate' | less
+   ```
+
+   Le champ `predicate.metadata.component.externalRefs` doit pointer vers l'artefact (binaire,
+   image ou archive) auquel le SBOM se rapporte.
+
+3. Analysez enfin le contenu du SBOM :
+
+   ```bash
+   jq '.components[] | {name, version, licenses}' Watcher-sbom.json
+   ```
+
+   Utilisez `grype Watcher-sbom.json` ou un autre scanner pour générer un rapport de
+   vulnérabilités basé sur la nomenclature CycloneDX.
+
+## Intégrer les contrôles dans votre pipeline
+
+- Stockez les bundles Sigstore et les attestions SLSA aux côtés des exécutables dans vos
+  coffres-forts d'artefacts.
+- Ajoutez un job de validation qui rejoue les commandes ci-dessus avant chaque mise en
+  production.
+- Archivez les journaux `sigstore`/`cosign` signés pour constituer un dossier de conformité
+  (ISO 27001, SecNumCloud, etc.).
+
+En combinant la vérification Sigstore, les attestations SLSA et l'analyse du SBOM CycloneDX,
+vous obtenez une traçabilité complète de la chaîne de build Watcher.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,7 +79,11 @@ nav:
           - 2025-09-19: journal/2025-09-19.md
   - Sécurité et conformité:
       - Modèle de menaces: threat-model.md
+      - Vérification des artefacts: security_provenance.md
       - Charte éthique: ethics.md
+  - Gestion des releases:
+      - Notes de version: release_notes.md
+      - Guide hors-ligne: offline_guide.md
   - Exploitation:
       - Conventions de logging: logging.md
       - Feuille de route: ROADMAP.md


### PR DESCRIPTION
## Summary
- documenter la vérification des signatures, attestations SLSA et SBOM avec sigstore et cosign
- créer une page de notes de version avec le processus de publication et les liens GitHub Releases
- fournir un guide d'exploitation en environnement air-gap et intégrer les nouvelles pages dans la navigation MkDocs

## Testing
- `mkdocs build --strict` *(impossible : mkdocs non disponible et installation bloquée par le proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd06babe08320848ebb023a2be2f6