### PR TITLE
Add Hypothesis property-based tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,12 +389,17 @@ Watcher s'appuie désormais sur [Nox](https://nox.thea.codes/) pour unifier les
 linters, l'analyse statique, les tests et la construction du package :
 
 ```bash
-nox -s lint typecheck security tests
+nox -s lint typecheck security tests hypothesis
 ```
 
 Les sessions peuvent également être exécutées individuellement (`nox -s lint`,
-`nox -s tests`, etc.) et une étape `nox -s build` génère les artefacts wheel et
-sdist.
+`nox -s tests`, `nox -s hypothesis`, etc.) et une étape `nox -s build` génère les
+artefacts wheel et sdist.
+
+La session `hypothesis` exécute les tests property-based (`pytest -q
+tests/property`) avec le plugin Hypothesis activé. Pour les lancer sans Nox, il
+suffit d'installer les dépendances de développement puis de lancer directement
+`pytest -q tests/property`.
 
 Pour automatiser les corrections, la cible `make format` applique Ruff (lint
 et formattage) puis Black, et `make check` délègue dorénavant à Nox.

--- a/noxfile.py
+++ b/noxfile.py
@@ -19,7 +19,7 @@ SOURCE_DIRECTORIES = (
 SBOM_PATH = Path("dist/Watcher-sbom.json")
 SBOM_DIRECTORY = SBOM_PATH.parent
 
-nox.options.sessions = ("lint", "typecheck", "tests", "build", "security")
+nox.options.sessions = ("lint", "typecheck", "tests", "hypothesis", "build", "security")
 nox.options.reuse_existing_virtualenvs = True
 
 
@@ -116,6 +116,13 @@ def tests(session: nox.Session) -> None:
     """Run the unit test suite."""
     install_project(session)
     session.run("pytest", "-q")
+
+
+@nox.session(python=PYTHON_VERSIONS)
+def hypothesis(session: nox.Session) -> None:
+    """Run property-based tests with Hypothesis."""
+    install_project(session)
+    session.run("pytest", "-q", "tests/property")
 
 
 @nox.session(python=PYTHON_VERSIONS)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,8 @@ nox==2024.4.15
 pip-audit==2.7.3
 pre-commit==3.8.0
 pytest==8.3.2
+hypothesis==6.115.3
+hypothesis[cli]==6.115.3
 ruff==0.6.9
 semgrep==1.91.0
 mkdocs==1.6.0

--- a/tests/property/test_memory_properties.py
+++ b/tests/property/test_memory_properties.py
@@ -1,0 +1,114 @@
+"""Property-based tests for :mod:`app.core.memory`."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from app.core.memory import Memory
+from app.utils import np
+
+
+PRINTABLE_TEXT = st.text(
+    alphabet=st.characters(min_codepoint=32, max_codepoint=126, blacklist_characters=["\n"]),
+    min_size=1,
+    max_size=40,
+)
+
+
+def _fake_embedding(text: str) -> np.ndarray:
+    """Return a deterministic embedding vector for ``text``."""
+
+    length = (len(text) % 5) + 1
+    return np.arange(length, dtype=np.float32)
+
+
+@given(st.lists(PRINTABLE_TEXT, min_size=1, max_size=5))
+@settings(max_examples=25, deadline=None)
+def test_add_persists_embedding_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, texts: list[str]
+) -> None:
+    """Adding items should store embeddings with the expected dimensionality."""
+
+    def fake_embed(texts_to_embed: list[str], model: str = "nomic-embed-text"):
+        return [_fake_embedding(text) for text in texts_to_embed]
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+
+    db_path = tmp_path / "memory.db"
+    memory = Memory(db_path)
+    memory.set_offline(False)
+
+    for text in texts:
+        memory.add("note", text)
+
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute(
+            "SELECT text, vec FROM items WHERE kind=? ORDER BY ts ASC",
+            ("note",),
+        ).fetchall()
+
+    assert len(rows) == len(texts)
+    for stored_text, blob in rows:
+        vector = np.frombuffer(blob, dtype=np.float32)
+        expected = _fake_embedding(stored_text)
+        assert vector.shape == expected.shape
+        assert vector.dtype == np.float32
+
+
+@given(
+    st.lists(PRINTABLE_TEXT, min_size=1, max_size=10),
+    st.integers(min_value=1, max_value=5),
+)
+@settings(max_examples=25, deadline=None)
+def test_summarize_limits_history_and_is_idempotent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    texts: list[str],
+    max_items: int,
+) -> None:
+    """Summaries keep history bounded and stable across repeated calls."""
+
+    def fake_embed(texts_to_embed: list[str], model: str = "nomic-embed-text"):
+        return [_fake_embedding(text) for text in texts_to_embed]
+
+    monkeypatch.setattr("app.core.memory.embed_ollama", fake_embed)
+
+    db_path = tmp_path / "memory.db"
+    memory = Memory(db_path)
+    memory.set_offline(False)
+
+    for text in texts:
+        memory.add("kind", text)
+
+    memory.summarize("kind", max_items)
+
+    with sqlite3.connect(db_path) as connection:
+        rows = connection.execute(
+            "SELECT text, ts FROM items WHERE kind=? ORDER BY ts ASC",
+            ("kind",),
+        ).fetchall()
+
+    if len(texts) <= max_items:
+        assert [text for text, _ in rows] == texts
+    else:
+        assert len(rows) == max_items
+        oldest_count = len(texts) - max_items + 1
+        expected_summary = " ".join(texts[:oldest_count])
+        if len(expected_summary) > 200:
+            expected_summary = expected_summary[:197] + "..."
+        summary_text = rows[-1][0]
+        assert summary_text == expected_summary
+
+    memory.summarize("kind", max_items)
+
+    with sqlite3.connect(db_path) as connection:
+        rows_again = connection.execute(
+            "SELECT text, ts FROM items WHERE kind=? ORDER BY ts ASC",
+            ("kind",),
+        ).fetchall()
+
+    assert rows_again == rows

--- a/tests/property/test_planner_properties.py
+++ b/tests/property/test_planner_properties.py
@@ -1,0 +1,97 @@
+"""Property-based tests for :mod:`app.core.planner`."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from app.core.planner import Planner
+
+
+PRINTABLE_TEXT = st.text(
+    alphabet=st.characters(min_codepoint=32, max_codepoint=126, blacklist_characters=["\n"]),
+    min_size=1,
+    max_size=40,
+)
+
+OPTIONAL_SECTION = st.one_of(
+    st.none(),
+    st.lists(PRINTABLE_TEXT, max_size=4),
+    st.lists(PRINTABLE_TEXT, max_size=4).map(tuple),
+)
+
+
+def _expected_section_lines(section: str, values: Iterable[str] | None) -> list[str]:
+    sequence = list(values) if values is not None else []
+    if not sequence:
+        return [f"{section}: []"]
+    lines = [f"{section}:"]
+    lines.extend(f"  - {value}" for value in sequence)
+    return lines
+
+
+@given(
+    objective=PRINTABLE_TEXT.filter(lambda s: s.strip()),
+    inputs=OPTIONAL_SECTION,
+    outputs=OPTIONAL_SECTION,
+    constraints=OPTIONAL_SECTION,
+    deliverables=OPTIONAL_SECTION,
+    success=OPTIONAL_SECTION,
+    platform=PRINTABLE_TEXT,
+    license_name=PRINTABLE_TEXT,
+)
+@settings(max_examples=50, deadline=None)
+def test_briefing_structure(
+    objective: str,
+    inputs: Iterable[str] | None,
+    outputs: Iterable[str] | None,
+    constraints: Iterable[str] | None,
+    deliverables: Iterable[str] | None,
+    success: Iterable[str] | None,
+    platform: str,
+    license_name: str,
+) -> None:
+    """Generated briefings preserve the expected ordering and content."""
+
+    planner = Planner()
+    result = planner.briefing(
+        objective,
+        inputs=inputs,
+        outputs=outputs,
+        platform=platform,
+        constraints=constraints,
+        license_name=license_name,
+        deliverables=deliverables,
+        success=success,
+    )
+
+    lines = result.splitlines()
+
+    expected_lines: list[str] = [f"objectif: {objective}"]
+    expected_lines += _expected_section_lines("entrees", inputs)
+    expected_lines += _expected_section_lines("sorties", outputs)
+    expected_lines.append("taches:")
+    expected_lines.extend(["  - analyser", "  - implementer", "  - tester"])
+    expected_lines.append(f"plateforme: {platform}")
+    expected_lines += _expected_section_lines("contraintes", constraints)
+    expected_lines.append(f"licence: {license_name}")
+    expected_lines += _expected_section_lines("livrables", deliverables)
+    expected_lines += _expected_section_lines("critere_succes", success)
+
+    assert lines == expected_lines
+
+
+@given(st.text())
+@settings(max_examples=20, deadline=None)
+def test_briefing_rejects_blank_objectives(objective: str) -> None:
+    """Blank objectives should trigger a validation error."""
+
+    planner = Planner()
+
+    if objective.strip():
+        planner.briefing(objective)
+    else:
+        with pytest.raises(ValueError):
+            planner.briefing(objective)


### PR DESCRIPTION
## Summary
- add Hypothesis (including CLI extras) to the development requirements and expose a dedicated Nox session for property-based runs
- cover memory summarisation/embedding invariants and planner briefing structure with Hypothesis-based tests
- document how to execute the new `nox -s hypothesis` workflow in the README

## Testing
- pytest tests/property -q *(fails: Hypothesis not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cfd06a51888320aaa3fa7cec19c52f