### PR TITLE
Make release artifacts reproducible

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   PYTHONHASHSEED: "42"
+  PYINSTALLER_CONFIG_DIR: ".pyinstaller"
   WATCHER_TRAINING__SEED: "42"
   CUBLAS_WORKSPACE_CONFIG: ":4096:8"
   TORCH_DETERMINISTIC: "1"
@@ -40,6 +41,50 @@ jobs:
           cache-dependency-path: |
             requirements.txt
             requirements-dev.txt
+
+      - name: Configure reproducible build metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+import os
+import pathlib
+import subprocess
+
+workspace = pathlib.Path(os.environ["GITHUB_WORKSPACE"])
+(workspace / ".pyinstaller").mkdir(parents=True, exist_ok=True)
+
+ref_candidates = []
+ref = os.environ.get("GITHUB_REF")
+if ref:
+    ref_candidates.append(ref)
+ref_name = os.environ.get("GITHUB_REF_NAME")
+if ref_name:
+    ref_candidates.append(f"refs/tags/{ref_name}")
+ref_candidates.append("HEAD")
+
+epoch = None
+for candidate in ref_candidates:
+    try:
+        value = subprocess.check_output([
+            "git",
+            "log",
+            "-1",
+            "--format=%ct",
+            candidate,
+        ], text=True).strip()
+    except subprocess.CalledProcessError:
+        continue
+    if value:
+        epoch = value
+        break
+
+if epoch is None:
+    raise SystemExit("Unable to determine SOURCE_DATE_EPOCH")
+
+with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
+    fh.write(f"SOURCE_DATE_EPOCH={epoch}\n")
+PY
 
       - name: Install build dependencies
         run: |
@@ -88,6 +133,50 @@ jobs:
             requirements.txt
             requirements-dev.txt
 
+      - name: Configure reproducible build metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+import os
+import pathlib
+import subprocess
+
+workspace = pathlib.Path(os.environ["GITHUB_WORKSPACE"])
+(workspace / ".pyinstaller").mkdir(parents=True, exist_ok=True)
+
+ref_candidates = []
+ref = os.environ.get("GITHUB_REF")
+if ref:
+    ref_candidates.append(ref)
+ref_name = os.environ.get("GITHUB_REF_NAME")
+if ref_name:
+    ref_candidates.append(f"refs/tags/{ref_name}")
+ref_candidates.append("HEAD")
+
+epoch = None
+for candidate in ref_candidates:
+    try:
+        value = subprocess.check_output([
+            "git",
+            "log",
+            "-1",
+            "--format=%ct",
+            candidate,
+        ], text=True).strip()
+    except subprocess.CalledProcessError:
+        continue
+    if value:
+        epoch = value
+        break
+
+if epoch is None:
+    raise SystemExit("Unable to determine SOURCE_DATE_EPOCH")
+
+with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
+    fh.write(f"SOURCE_DATE_EPOCH={epoch}\n")
+PY
+
       - name: Install build dependencies
         shell: pwsh
         run: |
@@ -122,6 +211,10 @@ jobs:
           }
           $archive = Join-Path 'dist' 'Watcher-Setup.zip'
           Compress-Archive -Path $source -DestinationPath $archive -Force
+
+      - name: Normalize installer archive metadata
+        shell: pwsh
+        run: python scripts/normalize_zip_metadata.py dist/Watcher-Setup.zip
 
       - name: Sign release artifact
         uses: sigstore/gh-action@v2.1.1
@@ -198,6 +291,50 @@ jobs:
             requirements.txt
             requirements-dev.txt
 
+      - name: Configure reproducible build metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+import os
+import pathlib
+import subprocess
+
+workspace = pathlib.Path(os.environ["GITHUB_WORKSPACE"])
+(workspace / ".pyinstaller").mkdir(parents=True, exist_ok=True)
+
+ref_candidates = []
+ref = os.environ.get("GITHUB_REF")
+if ref:
+    ref_candidates.append(ref)
+ref_name = os.environ.get("GITHUB_REF_NAME")
+if ref_name:
+    ref_candidates.append(f"refs/tags/{ref_name}")
+ref_candidates.append("HEAD")
+
+epoch = None
+for candidate in ref_candidates:
+    try:
+        value = subprocess.check_output([
+            "git",
+            "log",
+            "-1",
+            "--format=%ct",
+            candidate,
+        ], text=True).strip()
+    except subprocess.CalledProcessError:
+        continue
+    if value:
+        epoch = value
+        break
+
+if epoch is None:
+    raise SystemExit("Unable to determine SOURCE_DATE_EPOCH")
+
+with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
+    fh.write(f"SOURCE_DATE_EPOCH={epoch}\n")
+PY
+
       - name: Install build dependencies
         shell: bash
         run: |
@@ -253,7 +390,12 @@ jobs:
           ARCHIVE="dist/${{ matrix.archive-name }}"
           case "${{ matrix.os }}" in
             ubuntu-latest)
-              tar -czf "$ARCHIVE" -C dist Watcher
+              tar --sort=name \
+                --mtime="@${SOURCE_DATE_EPOCH}" \
+                --owner=0 \
+                --group=0 \
+                --numeric-owner \
+                -czf "$ARCHIVE" -C dist Watcher
               ;;
             macos-latest)
               ditto -c -k --sequesterRsrc --keepParent "$DIST_DIR" "$ARCHIVE"
@@ -264,6 +406,17 @@ jobs:
               ;;
           esac
           echo "ARCHIVE_FILE=$ARCHIVE" >> "$GITHUB_ENV"
+
+      - name: Normalize archive metadata
+        if: endsWith(matrix.archive-name, '.zip')
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${ARCHIVE_FILE:-}" ]; then
+            echo "ARCHIVE_FILE is not defined" >&2
+            exit 1
+          fi
+          python scripts/normalize_zip_metadata.py "$ARCHIVE_FILE"
 
       - name: Store notarization credentials
         if: matrix.os == 'macos-latest' && env.APPLE_NOTARIZE_APPLE_ID != '' && env.APPLE_NOTARIZE_TEAM_ID != '' && env.APPLE_NOTARIZE_PASSWORD != ''
@@ -349,6 +502,12 @@ jobs:
             exit 1
           fi
           mv "$PROVENANCE" dist/Watcher-Setup.intoto.jsonl
+
+      - name: Verify Windows provenance
+        uses: slsa-framework/slsa-verifier/actions/verify-artifact@v2.4.2
+        with:
+          provenance-path: dist/Watcher-Setup.intoto.jsonl
+          artifact-path: dist/Watcher-Setup.zip
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__/
 # Virtual environments
 .venv/
 .tools/
+.pyinstaller/
 
 # Environment variables
 *.env

--- a/packaging/watcher.spec
+++ b/packaging/watcher.spec
@@ -1,5 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import os
 import pathlib
 
 from PyInstaller.utils.hooks import collect_data_files
@@ -12,7 +13,8 @@ datas = [("app/plugins.toml", "app")]
 for extra in ("LICENSE", "example.env"):
     candidate = project_root / extra
     if candidate.exists():
-        datas.append((str(candidate), "."))
+        datas.append((extra, "."))
+
 datas += collect_data_files(
     "config",
     includes=["*.toml", "*.yml", "*.yaml", "*.json"],
@@ -20,7 +22,31 @@ datas += collect_data_files(
 prompt_dir = project_root / "app" / "llm" / "prompts"
 if prompt_dir.exists():
     for prompt in prompt_dir.glob("*.md"):
-        datas.append((str(prompt), "app/llm/prompts"))
+        datas.append((prompt.relative_to(project_root).as_posix(), "app/llm/prompts"))
+
+
+def _normalize_data_entries(entries):
+    normalized = []
+    for source, target in entries:
+        src_path = pathlib.Path(source)
+        if not src_path.is_absolute():
+            src_path = project_root / src_path
+        src_path = src_path.resolve()
+        try:
+            relative = src_path.relative_to(project_root)
+            src_value = relative.as_posix()
+        except ValueError:
+            src_value = src_path.as_posix()
+        normalized.append((src_value, target))
+    return sorted(normalized)
+
+
+datas = _normalize_data_entries(datas)
+
+# Ensure PyInstaller does not rely on user specific cache paths when available.
+pyinstaller_config_dir = os.environ.get("PYINSTALLER_CONFIG_DIR")
+if pyinstaller_config_dir:
+    pathlib.Path(pyinstaller_config_dir).mkdir(parents=True, exist_ok=True)
 
 
 a = Analysis(
@@ -48,7 +74,7 @@ exe = EXE(
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,
-    upx=True,
+    upx=False,
     console=True,
     disable_windowed_traceback=False,
     argv_emulation=False,
@@ -63,7 +89,7 @@ coll = COLLECT(
     a.zipfiles,
     a.datas,
     strip=False,
-    upx=True,
+    upx=False,
     upx_exclude=[],
     name='Watcher',
 )

--- a/scripts/normalize_zip_metadata.py
+++ b/scripts/normalize_zip_metadata.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Normalize timestamp metadata in ZIP archives.
+
+This helper rewrites the ZIP entries with deterministic timestamps and updates
+the archive comment so reproducible builds can rely on ``SOURCE_DATE_EPOCH``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import shutil
+import tempfile
+import time
+import zipfile
+
+
+def _parse_epoch(value: str) -> int:
+    try:
+        epoch = int(value)
+    except ValueError as exc:  # pragma: no cover - defensive programming
+        raise argparse.ArgumentTypeError("epoch must be an integer") from exc
+    if epoch < 0:
+        raise argparse.ArgumentTypeError("epoch must be positive")
+    return epoch
+
+
+def _normalized_zipinfo(info: zipfile.ZipInfo, date_time: tuple[int, int, int, int, int, int]) -> zipfile.ZipInfo:
+    new_info = zipfile.ZipInfo(info.filename)
+    new_info.date_time = date_time
+    new_info.compress_type = info.compress_type
+    new_info.comment = b""
+    new_info.extra = info.extra
+    new_info.flag_bits = info.flag_bits
+    new_info.create_system = info.create_system
+    new_info.create_version = info.create_version
+    new_info.extract_version = info.extract_version
+    new_info.external_attr = info.external_attr
+    new_info.internal_attr = info.internal_attr
+    new_info.volume = getattr(info, "volume", 0)
+    if hasattr(info, "_compresslevel") and info._compresslevel is not None:  # pragma: no cover - CPython specific
+        new_info._compresslevel = info._compresslevel
+    return new_info
+
+
+def normalize_zip(archive: pathlib.Path, epoch: int) -> None:
+    if not archive.exists():
+        raise FileNotFoundError(f"Archive '{archive}' not found")
+
+    normalized_dir = tempfile.mkdtemp(prefix="zip-normalize-")
+    normalized_path = pathlib.Path(normalized_dir, archive.name)
+
+    gm_time = time.gmtime(epoch)
+    normalized_time = (
+        gm_time.tm_year,
+        gm_time.tm_mon,
+        gm_time.tm_mday,
+        gm_time.tm_hour,
+        gm_time.tm_min,
+        gm_time.tm_sec,
+    )
+
+    with zipfile.ZipFile(archive, "r") as source, zipfile.ZipFile(
+        normalized_path,
+        "w",
+    ) as dest:
+        for info in sorted(source.infolist(), key=lambda item: item.filename):
+            data = source.read(info.filename)
+            new_info = _normalized_zipinfo(info, normalized_time)
+            dest.writestr(new_info, data)
+
+        dest.comment = str(epoch).encode("ascii")
+
+    shutil.move(str(normalized_path), archive)
+    shutil.rmtree(normalized_dir)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=pathlib.Path, help="Path to the ZIP archive to normalize")
+    parser.add_argument(
+        "--epoch",
+        type=_parse_epoch,
+        default=None,
+        help="UNIX timestamp to use (defaults to SOURCE_DATE_EPOCH)",
+    )
+    args = parser.parse_args()
+
+    epoch_env = os.environ.get("SOURCE_DATE_EPOCH")
+    epoch = args.epoch if args.epoch is not None else _parse_epoch(epoch_env) if epoch_env else None
+    if epoch is None:
+        raise SystemExit("SOURCE_DATE_EPOCH is not defined")
+
+    normalize_zip(args.archive, epoch)
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    main()


### PR DESCRIPTION
## Summary
- export SOURCE_DATE_EPOCH, reuse deterministic PyInstaller config paths, and normalize archives during each release build
- harden the PyInstaller spec by normalizing collected data paths and disabling UPX
- add a post-build helper that rewrites ZIP metadata and verify the Windows provenance before publishing

## Testing
- `python -m compileall scripts/normalize_zip_metadata.py`


------
https://chatgpt.com/codex/tasks/task_e_68cfd0626c008320b693b66e5adddf6d