### PR TITLE
Improve release and container workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   contents: read
   packages: write
+  id-token: write
 
 jobs:
   build-and-push:
@@ -39,29 +40,37 @@ jobs:
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=tag,pattern=v*
 
-      - name: Build image
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3.5.0
+
+      - name: Build and push image
+        id: build
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: false
-          load: true
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Determine image reference
+      - name: Set image digest reference
         id: image-ref
         run: |
-          first_tag=$(echo "${{ steps.meta.outputs.tags }}" | head -n 1)
-          echo "IMAGE_REF=$first_tag" >> $GITHUB_ENV
-          echo "value=$first_tag" >> $GITHUB_OUTPUT
+          set -euo pipefail
+          if [ -z "${{ steps.build.outputs.digest }}" ]; then
+            echo "Image digest missing" >&2
+            exit 1
+          fi
+          image_digest="ghcr.io/${{ github.repository_owner }}/watcher@${{ steps.build.outputs.digest }}"
+          echo "IMAGE_DIGEST_REF=$image_digest" >> "$GITHUB_ENV"
+          printf 'value=%s\n' "$image_digest" >> "$GITHUB_OUTPUT"
 
       - name: Scan image with Trivy
         id: trivy-scan
         uses: aquasecurity/trivy-action@v0.24.0
         with:
-          image-ref: ${{ env.IMAGE_REF }}
+          image-ref: ${{ env.IMAGE_DIGEST_REF }}
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: 'HIGH,CRITICAL'
@@ -75,11 +84,33 @@ jobs:
           path: trivy-results.sarif
           if-no-files-found: warn
 
-      - name: Push image
+      - name: Generate CycloneDX SBOM
+        id: sbom
+        uses: anchore/sbom-action@v0
+        with:
+          image: ${{ env.IMAGE_DIGEST_REF }}
+          format: cyclonedx-json
+          output-file: watcher-image-sbom.cdx.json
+          artifact-name: watcher-image-sbom
+
+      - name: Sign published images
         if: success()
         run: |
+          set -euo pipefail
+          mkdir -p sigstore
           while IFS= read -r tag; do
-            if [ -n "$tag" ]; then
-              docker push "$tag"
+            if [ -z "$tag" ]; then
+              continue
             fi
+            safe_name=$(echo "$tag" | sed 's#[/:]#__#g')
+            bundle="sigstore/${safe_name}.sigstore"
+            cosign sign --yes --output-bundle "$bundle" "$tag"
           done <<< "${{ steps.meta.outputs.tags }}"
+
+      - name: Upload signature bundles
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cosign-bundles
+          path: sigstore/*.sigstore
+          if-no-files-found: warn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,10 +89,27 @@ PY
       - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build
+          python -m pip install build pip-audit
 
       - name: Build wheel and sdist
         run: python -m build
+
+      - name: Run pip-audit
+        run: |
+          mkdir -p dist
+          pip-audit \
+            --strict \
+            --format json \
+            --output dist/pip-audit-report.json \
+            -r requirements.txt \
+            -r requirements-dev.txt
+
+      - name: Upload pip-audit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-pip-audit
+          if-no-files-found: error
+          path: dist/pip-audit-report.json
 
       - name: Upload distributions
         uses: actions/upload-artifact@v4
@@ -529,5 +546,6 @@ PY
             dist/Watcher-macos-sbom.json
             dist/watcher-*.whl
             dist/watcher-*.tar.gz
+            dist/pip-audit-report.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,9 @@ Les forks, versions communautaires modifiées ou binaires reconstruits par des t
 
 ## Signaler une vulnérabilité
 
-Merci de privilégier des canaux privés pour tout signalement de vulnérabilité afin de limiter le risque d'exploitation avant qu'un correctif ne soit disponible. Utilisez l'un des moyens suivants :
+Merci de privilégier des canaux privés pour tout signalement de vulnérabilité afin de limiter le risque d'exploitation avant qu'un correctif ne soit disponible. Utilisez en priorité le bouton **Report a vulnerability** de l'onglet *Security* du dépôt GitHub, qui ouvre le formulaire de signalement privé intégré.
+
+Si ce canal n'est pas accessible, vous pouvez utiliser l'un des moyens suivants :
 
 - 📧 **Email chiffré PGP** : security@watcher.dev — clé publique : https://watcher.dev/security/pgp.asc (empreinte `8A20 5D9E 3A1B F236 B179  5AA0 E2F0 3F1B 9D0F 4A17`).
 - 🛡️ **Formulaire privé** : https://watcher.dev/security/report.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,8 +37,8 @@ mode d'exploitation de la plate-forme.
 ## Accès à la documentation publiée
 
 Lorsque le workflow GitHub Actions **Deploy MkDocs site** est exécuté sur la branche `main`, la version statique la plus
-récente est disponible à l'adresse : `https://<github-username>.github.io/Watcher/` (remplacez `<github-username>` par
-votre compte ou organisation GitHub).
+récente est accessible via l'environnement **github-pages** du dépôt. Ouvrez l'onglet **Deployments → github-pages** puis
+cliquez sur « View deployment » pour consulter le site public.
 
 !!! info "URL personnalisée"
     Si un domaine personnalisé est configuré, mettez à jour le champ `site_url` dans `mkdocs.yml` et ajoutez un fichier

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: "Watcher"
 site_description: "Documentation technique et opérationnelle de l'atelier Watcher"
-site_url: "https://<github-username>.github.io/Watcher/"
-repo_url: "https://github.com/<github-username>/Watcher"
+site_url: !ENV ["WATCHER_DOCS_URL", ""]
+repo_url: !ENV ["WATCHER_REPO_URL", ""]
 edit_uri: "edit/main/docs/"
 strict: true
 


### PR DESCRIPTION
## Summary
- document how to access the published MkDocs site and remove the placeholder GitHub Pages URL from the docs
- harden the Docker workflow by pushing with Buildx, scanning the pushed digest, generating a CycloneDX SBOM, and exporting cosign bundles
- run pip-audit as part of the release workflow so the report ships with every tagged release, and document the new artifact
- point the security policy to GitHub private vulnerability reporting as the primary intake channel and allow overriding MkDocs URLs via env vars

## Testing
- not run (unable to install `nox` because the execution environment blocks outbound network access)


------
https://chatgpt.com/codex/tasks/task_e_68cfdad036548320ae2ce2a58c89a861