### PR TITLE
Documenter le blocage réseau dans la configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,15 @@
+# Configuration
+
+La configuration de Watcher repose sur un tronc commun défini dans `config/settings.toml` et des "profils" facultatifs chargés dynamiquement en fonction de l'environnement. Les valeurs peuvent être redéfinies via des variables d'environnement préfixées par `WATCHER_`.
+
+## Profils et instrumentation
+
+Le tableau ci-dessous récapitule les principaux interrupteurs liés aux profils et à l'instrumentation.
+
+| Élément | Variable(s) | Valeurs attendues | Effet | Valeur par défaut |
+| --- | --- | --- | --- | --- |
+| Sélection de profil | `WATCHER_ENV`, `WATCHER_PROFILE` | Nom de profil (`dev`, `prod`, `staging`…) | Charge `config/settings.<profil>.toml` s'il existe ; sinon le profil est ignoré. | *(aucune)* |
+| Traçage HTTP détaillé | `WATCHER_DEV__TRACE_REQUESTS` | Booléen (`true`/`false`) | Lorsque `true`, les requêtes HTTP émises par l'application sont journalisées en détail pour faciliter le debugging. | `false` |
+| Blocage réseau sandbox | `WATCHER_BLOCK_NETWORK` | `"0"` (désactivé), `"1"` (activé) | Injecté par `app.core.sandbox.run` et le lanceur de plugins. Seule la valeur `"1"` active le blocage réseau ; toute autre valeur laisse l'accès réseau autorisé. | `"0"` |
+
+Les profils permettent d'adapter rapidement les limites ou le niveau de verbosité selon l'environnement d'exécution. Les commutateurs d'instrumentation garantissent quant à eux un cadre d'observabilité cohérent (traçabilité, réseau) quelle que soit la manière de lancer Watcher (processus principal, sandbox ou plugin).


### PR DESCRIPTION
## Summary
- documente la page de configuration avec les principaux commutateurs de profil et d'instrumentation
- précise que seule la valeur "1" active l'option de blocage réseau `WATCHER_BLOCK_NETWORK`

## Testing
- no tests (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d0110609e483209db4aec067e8da29