### PR TITLE
Allow configuring Python versions via WATCHER_NOX_PYTHON

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,36 @@ env:
   TRIVY_CACHE_DIR: .trivy
 
 jobs:
+  determine-python:
+    name: Determine Python versions
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.python-versions.outputs.matrix }}
+    steps:
+      - name: Resolve matrix
+        id: python-versions
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          raw = os.environ.get("WATCHER_NOX_PYTHON")
+          versions = [
+              fragment.strip()
+              for fragment in re.split(r"[,\s]+", raw or "")
+              if fragment and fragment.strip()
+          ]
+          if not versions:
+              versions = ["3.12"]
+
+          output = Path(os.environ["GITHUB_OUTPUT"])
+          with output.open("a", encoding="utf-8") as file:
+              file.write(f"matrix={json.dumps(versions)}\n")
+          PY
+
   scorecard:
     name: Scorecard gate
     runs-on: ubuntu-latest
@@ -51,13 +81,15 @@ jobs:
 
   quality:
     name: Quality checks
-    needs: scorecard
+    needs:
+      - scorecard
+      - determine-python
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.12"]
+        python-version: ${{ fromJSON(needs.determine-python.outputs.matrix) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,3 +13,7 @@ Le tableau ci-dessous récapitule les principaux interrupteurs liés aux profils
 | Blocage réseau sandbox | `WATCHER_BLOCK_NETWORK` | `"0"` (désactivé), `"1"` (activé) | Injecté par `app.core.sandbox.run` et le lanceur de plugins. Seule la valeur `"1"` active le blocage réseau ; toute autre valeur laisse l'accès réseau autorisé. | `"0"` |
 
 Les profils permettent d'adapter rapidement les limites ou le niveau de verbosité selon l'environnement d'exécution. Les commutateurs d'instrumentation garantissent quant à eux un cadre d'observabilité cohérent (traçabilité, réseau) quelle que soit la manière de lancer Watcher (processus principal, sandbox ou plugin).
+
+## Qualité et automatisation
+
+Les sessions Nox et la matrice Python du pipeline CI respectent la variable d'environnement `WATCHER_NOX_PYTHON`. Elle accepte une liste de versions séparées par des virgules et/ou des espaces (par exemple `"3.10, 3.11 3.12"`). Lorsque la variable est absente ou ne contient aucune version, la valeur par défaut reste `3.12`.

--- a/noxfile.py
+++ b/noxfile.py
@@ -3,12 +3,35 @@
 from __future__ import annotations
 
 import os
+import re
+from collections.abc import Iterable
 from pathlib import Path
 
 import nox
 from nox.command import CommandFailed
 
-PYTHON_VERSIONS = ["3.12"]
+DEFAULT_PYTHON_VERSIONS = ("3.12",)
+
+
+def _parse_python_versions(
+    value: str | None, default: Iterable[str] = DEFAULT_PYTHON_VERSIONS
+) -> list[str]:
+    """Return a list of Python versions from a comma/space separated string."""
+
+    if value is None:
+        return list(default)
+
+    parts = [fragment.strip() for fragment in re.split(r"[,\s]+", value) if fragment.strip()]
+    return parts or list(default)
+
+
+def get_python_versions() -> list[str]:
+    """Resolve the Python versions to use for Nox sessions."""
+
+    return _parse_python_versions(os.environ.get("WATCHER_NOX_PYTHON"))
+
+
+PYTHON_VERSIONS = get_python_versions()
 SOURCE_DIRECTORIES = (
     "app",
     "config",

--- a/tests/test_noxfile_python_versions.py
+++ b/tests/test_noxfile_python_versions.py
@@ -1,0 +1,57 @@
+"""Regression tests for the WATCHER_NOX_PYTHON parsing helper."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+try:
+    import nox  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - exercised when nox is unavailable
+    nox = types.ModuleType("nox")
+
+    def session(*args: object, **kwargs: object):
+        def decorator(function):
+            return function
+
+        return decorator
+
+    nox.session = session  # type: ignore[attr-defined]
+    nox.options = types.SimpleNamespace(sessions=(), reuse_existing_virtualenvs=False)  # type: ignore[attr-defined]
+    sys.modules["nox"] = nox
+
+    command_module = types.ModuleType("nox.command")
+
+    class CommandFailed(RuntimeError):
+        pass
+
+    command_module.CommandFailed = CommandFailed  # type: ignore[attr-defined]
+    sys.modules["nox.command"] = command_module
+
+import noxfile
+
+
+def test_parse_python_versions_defaults_when_missing() -> None:
+    assert noxfile._parse_python_versions(None) == ["3.12"]
+
+
+def test_parse_python_versions_accepts_commas_and_whitespace() -> None:
+    value = "3.10, 3.11\n3.12"
+    assert noxfile._parse_python_versions(value) == ["3.10", "3.11", "3.12"]
+
+
+def test_parse_python_versions_discards_empty_tokens() -> None:
+    value = "  \t , ,  "
+    assert noxfile._parse_python_versions(value) == ["3.12"]
+
+
+def test_get_python_versions_uses_environment(monkeypatch) -> None:
+    monkeypatch.setenv("WATCHER_NOX_PYTHON", "3.11,3.9 3.10")
+    importlib.reload(noxfile)
+    try:
+        assert noxfile.get_python_versions() == ["3.11", "3.9", "3.10"]
+        assert noxfile.PYTHON_VERSIONS == ["3.11", "3.9", "3.10"]
+    finally:
+        monkeypatch.delenv("WATCHER_NOX_PYTHON", raising=False)
+        importlib.reload(noxfile)


### PR DESCRIPTION
## Summary
- resolve the Python versions used by Nox from the WATCHER_NOX_PYTHON environment variable with a safe default
- drive the CI matrix from the same parsing logic and document the expected format
- add unit tests covering the parser to guard against regressions

## Testing
- pytest tests/test_noxfile_python_versions.py

------
https://chatgpt.com/codex/tasks/task_e_68d02a19ac588320a2a01e4e1d3cd2bb