### PR TITLE
Document v0.4.0 release outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@
 ## [v0.4.0] - 2025-09-20
 
 ### Added
-- Documentation de la feuille de route et du journal de bord.
-- Chargement en batch des retours mémoire et benchmark associé.
-- Cache chat responses.
+- Property tests with numpy-stub compatible embeddings (#375).
+
+### Changed
+- Allow configuring Python versions for Nox and CI (#378).
+- Improve release and container workflows (#368).
+
+### Documentation
+- Documenter le blocage réseau dans la configuration (#376).
 
 ## [2025-09-14]
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurit
 
 ## Version
 
-La dernière version stable est **v0.4.0** (tag `v0.4.0`, publiée le 20 septembre 2025). Consultez le
+La dernière version stable est **v0.4.0** (tag `v0.4.0`, publiée le 20 septembre 2025). Téléchargez-la
+depuis [GitHub Releases](https://github.com/<owner>/Watcher/releases/tag/v0.4.0) et consultez le
 [CHANGELOG](CHANGELOG.md) pour le détail des nouveautés et correctifs.
 
 ## Citer Watcher
@@ -62,15 +63,17 @@ des exécutables Windows, Linux et macOS, un SBOM CycloneDX par plateforme et un
 
 ### Artefacts publiés
 
-- `Watcher-Setup.zip` : archive PyInstaller Windows signée et empaquetée.
-- `Watcher-Setup.zip.sigstore` : bundle Sigstore pour vérifier la signature du binaire Windows (`sigstore verify identity --bundle ...`).
-- `Watcher-sbom.json` : inventaire CycloneDX des dépendances installées pendant le build Windows (`cyclonedx-bom` / `cyclonedx-py`).
-- `Watcher-linux-x86_64.tar.gz` : tarball PyInstaller contenant le binaire autonome Linux.
-- `Watcher-linux-sbom.json` : SBOM CycloneDX généré lors du build Linux.
-- `Watcher-macos-x86_64.zip` : archive PyInstaller macOS signée (si certificat configuré) et soumise à la notarisation Apple lorsque les secrets sont fournis.
-- `Watcher-macos-sbom.json` : SBOM CycloneDX généré lors du build macOS.
-- `Watcher-Setup.intoto.jsonl` : provenance SLSA générée par [`slsa-github-generator`](https://github.com/slsa-framework/slsa-github-generator).
-- `pip-audit-report.json` : rapport JSON de l'analyse `pip-audit` exécutée sur `requirements.txt` et `requirements-dev.txt`.
+| Fichier | Description |
+| --- | --- |
+| [`Watcher-Setup.zip`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-Setup.zip) | Archive PyInstaller Windows signée et empaquetée. |
+| [`Watcher-Setup.zip.sigstore`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-Setup.zip.sigstore) | Bundle Sigstore pour vérifier la signature du binaire Windows (`sigstore verify identity --bundle ...`). |
+| [`Watcher-sbom.json`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-sbom.json) | Inventaire CycloneDX des dépendances installées pendant le build Windows (`cyclonedx-bom` / `cyclonedx-py`). |
+| [`Watcher-linux-x86_64.tar.gz`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-linux-x86_64.tar.gz) | Tarball PyInstaller contenant le binaire autonome Linux. |
+| [`Watcher-linux-sbom.json`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-linux-sbom.json) | SBOM CycloneDX généré lors du build Linux. |
+| [`Watcher-macos-x86_64.zip`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-macos-x86_64.zip) | Archive PyInstaller macOS signée (si certificat configuré) et soumise à la notarisation Apple lorsque les secrets sont fournis. |
+| [`Watcher-macos-sbom.json`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-macos-sbom.json) | SBOM CycloneDX généré lors du build macOS. |
+| [`Watcher-Setup.intoto.jsonl`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-Setup.intoto.jsonl) | Provenance SLSA générée par [`slsa-github-generator`](https://github.com/slsa-framework/slsa-github-generator). |
+| [`pip-audit-report.json`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/pip-audit-report.json) | Rapport JSON de l'analyse `pip-audit` exécutée sur `requirements.txt` et `requirements-dev.txt`. |
 
 Ces fichiers sont publiés en tant qu'artefacts de release. Téléchargez le SBOM correspondant pour auditer les composants de la
 plateforme visée et conservez la provenance `*.intoto.jsonl` pour tracer la chaîne de build ou alimenter un vérificateur SLSA.

--- a/docs/offline_guide.md
+++ b/docs/offline_guide.md
@@ -7,7 +7,7 @@ contrôles d'intégrité.
 
 ## 1. Préparer le kit hors-ligne sur une machine connectée
 
-1. **Téléchargez les artefacts de release** depuis GitHub pour le tag ciblé :
+1. **Téléchargez les artefacts de release** depuis GitHub pour le tag ciblé (par exemple [v0.4.0](https://github.com/<owner>/Watcher/releases/tag/v0.4.0)) :
 
    ```bash
    mkdir -p ~/watcher-offline-kit/artifacts

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -8,21 +8,20 @@ référençant les pages GitHub Releases correspondantes.
 
 | Version | Date | Points clés | Lien GitHub Releases |
 | --- | --- | --- | --- |
-| *(à publier)* | — | Préparez la release initiale à partir de la section `Unreleased` du [CHANGELOG](CHANGELOG.md). | [Brouillons et releases](https://github.com/<github-username>/Watcher/releases) |
+| v0.4.0 | 20 septembre 2025 | - Configurer les versions Python ciblées par Nox et CI.<br>- Ajouter des property tests compatibles numpy-stub.<br>- Améliorer les workflows de release et de conteneurisation. | [Consulter la release v0.4.0](https://github.com/<owner>/Watcher/releases/tag/v0.4.0) |
 
-!!! info "Mettre à jour dès la première release"
-    Remplacez la ligne ci-dessus par un bloc par version dès qu'un tag `vMAJOR.MINOR.PATCH`
-    est poussé :
+!!! info "Suivre les prochaines versions"
+    Ajoutez une nouvelle ligne à ce tableau et un bloc dédié dès qu'un tag `vMAJOR.MINOR.PATCH`
+    est poussé.
 
-    ```markdown
-    ## v1.2.3 — 2025-10-07
+## v0.4.0 — 2025-09-20
 
-    - 🔒 Renforcement de la politique de signatures Sigstore.
-    - 🛠️ Nouveaux connecteurs de données.
-    - 📦 SBOM CycloneDX enrichi (classification des licences).
+- 🛠️ Configuration explicite des versions Python ciblées par Nox et par la CI.
+- ✅ Ajout de property tests compatibles avec les stubs numpy.
+- 🚀 Optimisations des workflows de release et de build de conteneurs.
+- 📚 Documentation du blocage réseau dans la configuration par défaut.
 
-    ➤ [Consulter la release GitHub](https://github.com/<github-username>/Watcher/releases/tag/v1.2.3)
-    ```
+➤ [Consulter la release GitHub](https://github.com/<owner>/Watcher/releases/tag/v0.4.0)
 
 ## Processus de publication
 


### PR DESCRIPTION
## Summary
- update the v0.4.0 changelog entry with the features shipped in the release
- link the README and offline deployment guide directly to the v0.4.0 release assets
- publish the v0.4.0 summary in the release notes overview

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d02dbaf8008320b6cb786d6ef117c0