### PR TITLE
docs: add release verification guidance for v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurit
 
 ## Version
 
-La dernière version stable est **v0.4.0** (tag `v0.4.0`, publiée le 20 septembre 2025). Téléchargez-la
-depuis [GitHub Releases](https://github.com/<owner>/Watcher/releases/tag/v0.4.0) et consultez le
-[CHANGELOG](CHANGELOG.md) pour le détail des nouveautés et correctifs.
+La dernière version stable est **v0.4.0** (tag `v0.4.0`, publiée le 20 septembre 2025).
+
+- 📦 Téléchargement direct : [https://github.com/<owner>/Watcher/releases/tag/v0.4.0](https://github.com/<owner>/Watcher/releases/tag/v0.4.0)
+- 🗒️ Notes complètes : voir le [CHANGELOG](CHANGELOG.md) et la [page de notes de version](docs/release_notes.md).
+- ✅ Instructions de vérification (signatures, provenance, empreintes) : détaillées ci-dessous pour chaque
+  artefact publié.
 
 ## Citer Watcher
 
@@ -72,8 +75,47 @@ des exécutables Windows, Linux et macOS, un SBOM CycloneDX par plateforme et un
 | [`Watcher-linux-sbom.json`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-linux-sbom.json) | SBOM CycloneDX généré lors du build Linux. |
 | [`Watcher-macos-x86_64.zip`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-macos-x86_64.zip) | Archive PyInstaller macOS signée (si certificat configuré) et soumise à la notarisation Apple lorsque les secrets sont fournis. |
 | [`Watcher-macos-sbom.json`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-macos-sbom.json) | SBOM CycloneDX généré lors du build macOS. |
-| [`Watcher-Setup.intoto.jsonl`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-Setup.intoto.jsonl) | Provenance SLSA générée par [`slsa-github-generator`](https://github.com/slsa-framework/slsa-github-generator). |
+| [`Watcher-Setup.intoto.jsonl`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-Setup.intoto.jsonl) | Provenance SLSA générée par [`slsa-github-generator`](https://github.com/slsa-framework/slsa-github-generator) (atteste la supply chain du binaire Windows). |
+| `watcher-*.whl` / `watcher-*.tar.gz` | Paquets Python (wheel + source) publiés dans la section *Assets* (installables via `pip`). |
 | [`pip-audit-report.json`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/pip-audit-report.json) | Rapport JSON de l'analyse `pip-audit` exécutée sur `requirements.txt` et `requirements-dev.txt`. |
+
+### Vérifier les artefacts publiés
+
+Avant toute installation, validez l'authenticité et l'intégrité des binaires téléchargés depuis la
+release `v0.4.0` :
+
+```bash
+# 1. Télécharger tous les fichiers nécessaires (binaire + SBOM + provenance)
+RELEASE="https://github.com/<owner>/Watcher/releases/download/v0.4.0"
+wget "$RELEASE/Watcher-Setup.zip" \
+     "$RELEASE/Watcher-Setup.zip.sigstore" \
+     "$RELEASE/Watcher-Setup.intoto.jsonl" \
+     "$RELEASE/Watcher-sbom.json"
+
+# 2. Vérifier la signature Sigstore (Windows)
+sigstore verify identity \
+  --bundle Watcher-Setup.zip.sigstore \
+  --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/v0.4.0" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  Watcher-Setup.zip
+
+# 3. Vérifier la provenance SLSA (attestation supply chain)
+slsa-verifier verify-artifact \
+  --provenance Watcher-Setup.intoto.jsonl \
+  --source-uri github.com/<owner>/Watcher \
+  --source-tag v0.4.0 \
+  Watcher-Setup.zip
+
+# 4. Calculer/valider les empreintes
+sha256sum Watcher-Setup.zip Watcher-linux-x86_64.tar.gz Watcher-macos-x86_64.zip
+```
+
+- Pour Linux/macOS, comparez le `sha256sum` obtenu avec les empreintes publiées dans la release.
+- Les SBOM (`Watcher-*-sbom.json`) peuvent être explorés avec `jq`, importés dans un scanner CycloneDX ou
+  validés via `cyclonedx-py validate Watcher-sbom.json`.
+- Les distributions Python (`watcher-*.whl`, `watcher-*.tar.gz`) sont signées par la provenance GitHub
+  (workflow `release.yml`) et peuvent être installées via `pip install watcher-*.whl` après vérification des
+  `sha256sum`.
 
 Ces fichiers sont publiés en tant qu'artefacts de release. Téléchargez le SBOM correspondant pour auditer les composants de la
 plateforme visée et conservez la provenance `*.intoto.jsonl` pour tracer la chaîne de build ou alimenter un vérificateur SLSA.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -8,7 +8,7 @@ référençant les pages GitHub Releases correspondantes.
 
 | Version | Date | Points clés | Lien GitHub Releases |
 | --- | --- | --- | --- |
-| v0.4.0 | 20 septembre 2025 | - Configurer les versions Python ciblées par Nox et CI.<br>- Ajouter des property tests compatibles numpy-stub.<br>- Améliorer les workflows de release et de conteneurisation. | [Consulter la release v0.4.0](https://github.com/<owner>/Watcher/releases/tag/v0.4.0) |
+| v0.4.0 | 20 septembre 2025 | - Configurer les versions Python ciblées par Nox et CI.<br>- Ajouter des property tests compatibles numpy-stub.<br>- Améliorer les workflows de release et de conteneurisation. | [Release v0.4.0 (GitHub)](https://github.com/<owner>/Watcher/releases/tag/v0.4.0) |
 
 !!! info "Suivre les prochaines versions"
     Ajoutez une nouvelle ligne à ce tableau et un bloc dédié dès qu'un tag `vMAJOR.MINOR.PATCH`
@@ -22,6 +22,59 @@ référençant les pages GitHub Releases correspondantes.
 - 📚 Documentation du blocage réseau dans la configuration par défaut.
 
 ➤ [Consulter la release GitHub](https://github.com/<owner>/Watcher/releases/tag/v0.4.0)
+
+### Vérifier les artefacts de la release v0.4.0
+
+1. Téléchargez les binaires et métadonnées depuis la release officielle :
+
+   ```bash
+   RELEASE="https://github.com/<owner>/Watcher/releases/download/v0.4.0"
+   wget "$RELEASE/Watcher-Setup.zip" \
+        "$RELEASE/Watcher-Setup.zip.sigstore" \
+        "$RELEASE/Watcher-Setup.intoto.jsonl" \
+        "$RELEASE/Watcher-sbom.json" \
+        "$RELEASE/Watcher-linux-x86_64.tar.gz" \
+        "$RELEASE/Watcher-linux-sbom.json" \
+        "$RELEASE/Watcher-macos-x86_64.zip" \
+        "$RELEASE/Watcher-macos-sbom.json"
+   ```
+
+2. Vérifiez la signature Sigstore du binaire Windows :
+
+   ```bash
+   sigstore verify identity \
+     --bundle Watcher-Setup.zip.sigstore \
+     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/v0.4.0" \
+     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+     Watcher-Setup.zip
+   ```
+
+3. Vérifiez l'attestation de provenance SLSA :
+
+   ```bash
+   slsa-verifier verify-artifact \
+     --provenance Watcher-Setup.intoto.jsonl \
+     --source-uri github.com/<owner>/Watcher \
+     --source-tag v0.4.0 \
+     Watcher-Setup.zip
+   ```
+
+4. Contrôlez les empreintes `sha256sum` des binaires et comparez-les à celles publiées dans la release :
+
+   ```bash
+   sha256sum Watcher-Setup.zip \
+             Watcher-linux-x86_64.tar.gz \
+             Watcher-macos-x86_64.zip
+   ```
+
+5. Explorez les SBOM pour auditer les dépendances :
+
+   ```bash
+   cyclonedx-py validate Watcher-sbom.json
+   jq '.components[] | {name, version}' Watcher-linux-sbom.json | head
+   ```
+
+6. Archivez le rapport `pip-audit-report.json` et les distributions Python pour des installations offline.
 
 ## Processus de publication
 


### PR DESCRIPTION
## Summary
- link directly to the v0.4.0 release from the README version section and enumerate the published assets
- document step-by-step commands for verifying the Sigstore signature, SLSA provenance, checksums, and SBOMs
- mirror the release verification workflow in the documentation site so users can download and audit the published artefacts

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d032bd19a48320be7a0ea9e6086458