### PR TITLE
Update CI matrix defaults to supported Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
               if fragment and fragment.strip()
           ]
           if not versions:
-              versions = ["3.12"]
+              versions = ["3.10", "3.11", "3.12"]
 
           output = Path(os.environ["GITHUB_OUTPUT"])
           with output.open("a", encoding="utf-8") as file:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ qui rejoue l'analyse Scorecard à chaque Pull Request. Le job échoue si le scor
 redescend sous `7`, empêchant ainsi le reste du pipeline et la fusion tant que les bonnes
 pratiques identifiées par Scorecard ne sont pas rétablies.
 
+La matrice Python du même workflow est résolue par le job `determine-python`. En l'absence
+de variable `WATCHER_NOX_PYTHON`, il publie explicitement les versions supportées (`3.10`,
+`3.11`, `3.12`) afin que les jobs `quality` puissent s'exécuter sur Linux, macOS et Windows
+pour chaque interpréteur. Pour cibler un sous-ensemble lors d'un debug ou d'un backport,
+exportez `WATCHER_NOX_PYTHON="3.11"` (ou plusieurs valeurs séparées par des virgules) avant
+de lancer `nox` ou de déclencher le workflow manuellement ; la même logique s'applique aux
+exécutions locales via `noxfile.py`.
+
 ## Releases, SBOM et provenance
 
 Chaque tag SemVer (`vMAJOR.MINOR.PATCH`) déclenche le workflow [`release.yml`](.github/workflows/release.yml) qui produit

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,4 +16,4 @@ Les profils permettent d'adapter rapidement les limites ou le niveau de verbosit
 
 ## Qualité et automatisation
 
-Les sessions Nox et la matrice Python du pipeline CI respectent la variable d'environnement `WATCHER_NOX_PYTHON`. Elle accepte une liste de versions séparées par des virgules et/ou des espaces (par exemple `"3.10, 3.11 3.12"`). Lorsque la variable est absente ou ne contient aucune version, la valeur par défaut reste `3.12`.
+Les sessions Nox et la matrice Python du pipeline CI respectent la variable d'environnement `WATCHER_NOX_PYTHON`. Elle accepte une liste de versions séparées par des virgules et/ou des espaces (par exemple `"3.10, 3.11 3.12"`). Lorsque la variable est absente ou ne contient aucune version, la valeur par défaut couvre explicitement les interpréteurs pris en charge (`3.10`, `3.11` et `3.12`).

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import nox
 from nox.command import CommandFailed
 
-DEFAULT_PYTHON_VERSIONS = ("3.12",)
+DEFAULT_PYTHON_VERSIONS = ("3.10", "3.11", "3.12")
 
 
 def _parse_python_versions(


### PR DESCRIPTION
## Summary
- set the `determine-python` job to emit Python 3.10/3.11/3.12 when no override is provided
- align `DEFAULT_PYTHON_VERSIONS` in `noxfile.py` with the supported interpreter list
- document the supported Python matrix and how to override it in the CI and configuration docs

## Testing
- pip install -r requirements.txt (Python 3.10 venv) *(fails: PyPI access blocked by proxy)*
- pip install -r requirements.txt (Python 3.11 venv) *(fails: PyPI access blocked by proxy)*
- pip install -r requirements.txt (Python 3.12 venv) *(fails: PyPI access blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d032be96a48320824156ba4a6620c2