### PR TITLE
Add commitlint and release drafter automation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,55 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
+no-changes-template: 'Aucun changement notable dans cette itération.'
+exclude-labels:
+  - 'status:blocked'
+  - 'status:needs-triage'
+  - 'status:wip'
+categories:
+  - title: '🚀 Fonctionnalités'
+    labels:
+      - 'type:feature'
+  - title: '🐛 Corrections de bugs'
+    labels:
+      - 'type:bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'type:maintenance'
+  - title: '📚 Documentation'
+    labels:
+      - 'scope:docs'
+  - title: '🛠️ Plateforme & Ops'
+    labels:
+      - 'scope:ops'
+  - title: '🔐 Sécurité'
+    labels:
+      - 'scope:security'
+  - title: '🧪 Qualité & Tests'
+    labels:
+      - 'scope:quality'
+  - title: '🤖 ML & Données'
+    labels:
+      - 'scope:ml'
+replacers:
+  - search: '### 🚀 Fonctionnalités\n\n###'
+    replace: '### 🚀 Fonctionnalités\n'
+version-resolver:
+  major:
+    labels:
+      - 'release:major'
+  minor:
+    labels:
+      - 'release:minor'
+  patch:
+    labels:
+      - 'release:patch'
+  default: patch
+template: |
+  ## ✨ Nouveautés
+  $CHANGES
+
+  ## ✅ Procédure de publication
+  - Vérifier/mettre à jour les métadonnées (`pyproject.toml`, `CHANGELOG.md`, `CITATION.cff`).
+  - Publier la release sur GitHub pour déclencher le workflow `Release`.
+  - Communiquer la version aux équipes produit et documentation.

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,29 @@
+name: commitlint
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+  push:
+    branches:
+      - main
+
+jobs:
+  lint:
+    name: Validate Conventional Commits
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run commitlint
+        uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: commitlint.config.cjs

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,22 @@
+name: release-drafter
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update:
+    name: Update draft release notes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - name: Run Release Drafter
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,40 @@ inapproprié aux mainteneurs.
    les breaking changes.
 5. **Rédiger un changelog** : ajoutez une entrée dans `CHANGELOG.md` si la modification est visible pour l'utilisateur final.
 
+## Conventions de commit
+
+Watcher applique les [Conventional Commits](https://www.conventionalcommits.org/fr/v1.0.0/) et un workflow GitHub
+(`commitlint`) vérifie automatiquement que les commits et les titres de pull request respectent le format attendu.
+
+- **Structure** : `type(scope): description` (le scope est optionnel mais recommandé et doit rester aligné avec les labels
+  `scope:*`).
+- **Types autorisés** : `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`.
+- **Description** : à l'impératif, en français ou en anglais, sans majuscule initiale inutile ni point final.
+- **Corps/footer** : laissez une ligne vide avant le corps du message ; les références à des issues (`Fixes #123`) sont indiquées
+  dans le footer.
+
+Les commits mal formatés doivent être corrigés avant la merge (via `git commit --amend` ou `git rebase --autosquash`). Si votre
+PR contient plusieurs commits, ils doivent tous respecter cette convention.
+
+## Processus de release automatisé
+
+Les mainteneurs s'appuient sur [Release Drafter](https://github.com/release-drafter/release-drafter) et sur le workflow
+`.github/workflows/release-drafter.yml` pour préparer les notes de version.
+
+1. **Labelliser la PR** : chaque PR mergée sur `main` doit porter au moins un label `type:*` (catégorie du changelog) et un ou
+   plusieurs labels `scope:*`. Ajoutez `release:major`, `release:minor` ou `release:patch` si la modification requiert une version
+   spécifique ; à défaut la version `patch` est incrémentée.
+2. **Prévisualiser la release** : à chaque push sur `main`, Release Drafter met à jour le brouillon de release `vNEXT`. Vérifiez
+   que les entrées générées correspondent bien aux changements livrés.
+3. **Publier** : quand la version est prête, publiez le draft GitHub en choisissant le numéro SemVer (`vX.Y.Z`). Cette action
+   déclenche le workflow `.github/workflows/release.yml` qui construit les artefacts (packages, installeur Windows, audit de
+   sécurité) et publie les rapports.
+4. **Communication** : synchronisez `CHANGELOG.md`, `pyproject.toml` et `CITATION.cff` si nécessaire et informez les équipes
+   produit/documentation.
+
+> 💡 Les notes de release regroupent automatiquement les PR par catégorie (`type:*`, `scope:*`) et ignorent les entrées marquées
+> `status:blocked`, `status:needs-triage` ou `status:wip`.
+
 ## Politique de merge et des pull requests
 
 - **Template obligatoire** : utilisez le modèle de PR par défaut et fournissez un contexte clair (motivation, tests, impact).

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-leading-blank': [2, 'always'],
+    'footer-leading-blank': [2, 'always'],
+    'subject-case': [2, 'never', ['sentence-case', 'start-case', 'pascal-case', 'upper-case']],
+  },
+};

--- a/docs/merge-policy.md
+++ b/docs/merge-policy.md
@@ -102,3 +102,42 @@ assure que les équipes adéquates sont sollicitées. Quelques principes :
 Les modifications sensibles (sécurité, configuration, opérations) doivent
 rester en `status:blocked` tant que le plan d'action n'est pas validé par
 l'équipe responsable.
+
+## Conventions de commit et de changelog
+
+- **Commitlint** : le workflow `.github/workflows/commitlint.yml` applique les
+  [Conventional Commits](https://www.conventionalcommits.org/fr/v1.0.0/). Les
+  commits et titres de PR doivent respecter le format `type(scope): message`.
+  Les types autorisés sont `feat`, `fix`, `docs`, `style`, `refactor`, `perf`,
+  `test`, `build`, `ci`, `chore` et `revert`. Les scopes suivent les labels
+  `scope:*` décrits ci-dessus.
+- **Changelog automatisé** : Release Drafter regroupe les PR par catégories
+  (`type:*`, `scope:*`) et ignore celles marquées `status:blocked`,
+  `status:needs-triage` ou `status:wip`. Assurez-vous que la PR possède les
+  bons labels avant merge pour alimenter les sections « Fonctionnalités »,
+  « Corrections », « Maintenance », etc.
+- **Résolution de version** : ajoutez un label `release:major`,
+  `release:minor` ou `release:patch` lorsque la PR implique un changement
+  SemVer spécifique. Sans label explicite, l'incrément par défaut est de type
+  patch.
+
+## Publication automatisée
+
+Le workflow `.github/workflows/release-drafter.yml` met à jour le brouillon de
+release à chaque push sur `main`. Une fois la release validée par les
+mainteneurs :
+
+1. Ouvrez le draft généré par Release Drafter, vérifiez les sections et
+   finalisez le numéro de version (`vX.Y.Z`).
+2. Publiez la release GitHub : cela crée le tag et déclenche le workflow
+   `.github/workflows/release.yml` qui construit les artefacts et uploads
+   associés.
+3. Contrôlez que les artefacts publiés sont conformes, mettez à jour le
+   `CHANGELOG.md`, `pyproject.toml` et `CITATION.cff` si besoin, puis
+   communiquez la version aux équipes concernées.
+
+> ℹ️ Les workflows commitlint et release-drafter n'accordent que les
+> permissions minimales (`contents:read/pull-requests:read` pour commitlint,
+> `contents:write/pull-requests:read` pour Release Drafter) et n'interfèrent
+> pas avec l'automerge : ils opèrent sur des événements différents (`push` ou
+> `pull_request`) et ne modifient pas les labels `status:*`.


### PR DESCRIPTION
## Summary
- add a commitlint workflow and configuration to enforce Conventional Commits on PRs and direct pushes
- configure release-drafter to prepare changelog drafts grouped by project labels and version labels
- document the commit message requirements and automated release flow in the contributor guides

## Testing
- not run (workflow and documentation changes only)

------
https://chatgpt.com/codex/tasks/task_e_68d032bf86e48320b70a1e4974aff8ad