### PR TITLE
Guard DVC artifact checks for forked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,8 @@ jobs:
       - scorecard
       - determine-python
     runs-on: ${{ matrix.os }}
+    env:
+      DVC_CREDENTIALS_AVAILABLE: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -134,8 +136,18 @@ jobs:
         run: python scripts/install_cli_tools.py --install-dir ./.tools --add-to-path
 
       - name: Pull data artifacts
+        if: env.DVC_CREDENTIALS_AVAILABLE == 'true'
         run: dvc pull
         continue-on-error: true
+
+      - name: Verify data artifacts
+        if: env.DVC_CREDENTIALS_AVAILABLE == 'true'
+        run: dvc status
+
+      - name: Skip DVC artifact checks
+        if: env.DVC_CREDENTIALS_AVAILABLE != 'true'
+        run: >-
+          echo "::warning::Skipping DVC artifact pull and verification because AWS credentials are unavailable for forked pull requests."
 
       - name: Validate Windows installer
         if: runner.os == 'Windows'

--- a/QA.md
+++ b/QA.md
@@ -42,6 +42,8 @@
   without the Ollama models.
 * Immediately afterwards the workflow launches `./run.ps1` with an empty `DISPLAY` variable to emulate
   headless mode. Any startup failure or premature exit fails the build.
+* Forked pull requests skip the DVC artifact pull and verification steps because the AWS credentials are not
+  exposed to external runners. Maintainer branches still fail when artifacts are missing or corrupt.
 
 ## Static Analysis
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,3 +17,7 @@ Les profils permettent d'adapter rapidement les limites ou le niveau de verbosit
 ## Qualité et automatisation
 
 Les sessions Nox et la matrice Python du pipeline CI respectent la variable d'environnement `WATCHER_NOX_PYTHON`. Elle accepte une liste de versions séparées par des virgules et/ou des espaces (par exemple `"3.10, 3.11 3.12"`). Lorsque la variable est absente ou ne contient aucune version, la valeur par défaut couvre explicitement les interpréteurs pris en charge (`3.10`, `3.11` et `3.12`).
+
+Les pull requests provenant d'un fork n'ont pas accès aux identifiants AWS nécessaires au `dvc pull`. La CI journalise un
+avertissement et saute les étapes de récupération et de vérification des artefacts dans ce cas. Les branches internes
+continuent d'échouer si un artefact manque ou est corrompu.


### PR DESCRIPTION
## Summary
- only run the DVC pull and verification steps when AWS credentials are available to the workflow
- surface a warning explaining why forked pull requests skip the DVC artifact checks
- document that external contributors do not trigger the DVC integrity gate while internal branches still fail on missing data

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d046f08dd483209ff3e12b51912c40