### PR TITLE
ci: enforce dvc checks and document aws secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - determine-python
     runs-on: ${{ matrix.os }}
     env:
-      DVC_CREDENTIALS_AVAILABLE: ${{ secrets.AWS_ACCESS_KEY_ID != '' }}
+      DVC_CREDENTIALS_AVAILABLE: ${{ secrets.AWS_ACCESS_KEY_ID != '' && secrets.AWS_SECRET_ACCESS_KEY != '' && secrets.AWS_DEFAULT_REGION != '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -135,14 +135,21 @@ jobs:
       - name: Install security CLIs
         run: python scripts/install_cli_tools.py --install-dir ./.tools --add-to-path
 
+      - name: Configure AWS credentials
+        if: env.DVC_CREDENTIALS_AVAILABLE == 'true'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
       - name: Pull data artifacts
         if: env.DVC_CREDENTIALS_AVAILABLE == 'true'
         run: dvc pull
-        continue-on-error: true
 
       - name: Verify data artifacts
         if: env.DVC_CREDENTIALS_AVAILABLE == 'true'
-        run: dvc status
+        run: dvc status --cloud
 
       - name: Skip DVC artifact checks
         if: env.DVC_CREDENTIALS_AVAILABLE != 'true'

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,3 +21,18 @@ Les sessions Nox et la matrice Python du pipeline CI respectent la variable d'en
 Les pull requests provenant d'un fork n'ont pas accès aux identifiants AWS nécessaires au `dvc pull`. La CI journalise un
 avertissement et saute les étapes de récupération et de vérification des artefacts dans ce cas. Les branches internes
 continuent d'échouer si un artefact manque ou est corrompu.
+
+### Accès aux artefacts DVC
+
+Les branches protégées doivent disposer des secrets GitHub suivants afin que la CI accède au remote `s3://watcher-artifacts` :
+
+| Secret | Description |
+| --- | --- |
+| `AWS_ACCESS_KEY_ID` | Identifiant de la clé d'accès disposant des droits `GetObject`/`PutObject` sur le bucket `watcher-artifacts`. |
+| `AWS_SECRET_ACCESS_KEY` | Secret associé à la clé précédente. |
+| `AWS_DEFAULT_REGION` | Région AWS du bucket (par exemple `eu-west-1`). |
+| `AWS_SESSION_TOKEN` *(optionnel)* | Jeton temporaire pour des identifiants STS. Le laisser vide pour des clés longues durées. |
+
+Le workflow GitHub Actions configure automatiquement ces identifiants via `aws-actions/configure-aws-credentials@v4` avant de
+lancer `dvc pull`. Un `dvc status --cloud` systématique vérifie ensuite la parité entre le dépôt local et le remote. Tout échec
+sur ces étapes bloque la CI sur les branches des mainteneurs tant que les artefacts n'ont pas été corrigés ou régénérés.


### PR DESCRIPTION
## Summary
- configure AWS credentials in the CI workflow and fail on DVC pull/status issues
- document the GitHub secrets required to access the watcher-artifacts bucket
- explain how to recover or regenerate datasets when the DVC checks fail

## Testing
- not run (documentation and workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d052e157ec83209fe1056f40ad7586