### PR TITLE
fix: lower declared python floor to 3.10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ inapproprié aux mainteneurs.
 
 ## Préparer son environnement
 
-- **Python 3.12** : créez un environnement virtuel dédié (`python -m venv .venv`).
+- **Python 3.10 ou supérieur** : créez un environnement virtuel dédié (`python -m venv .venv`).
 - **Dépendances projet** : installez les requirements de base et de développement :
   ```bash
   pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ et mettez à jour la configuration d'authentification associée.
 ## Installation
 
 1. Cloner ce dépôt.
-2. Créer et activer un environnement Python 3.12 :
+2. Créer et activer un environnement Python 3.10 ou supérieur :
 
    ```bash
    python -m venv .venv
@@ -415,9 +415,10 @@ Les volumes présentés ci-dessus fonctionnent également avec l'image locale (`
 ## Environnement de développement
 
 Un dossier `.devcontainer/` est fourni pour disposer d'un environnement prêt à l'emploi
-dans VS Code ou GitHub Codespaces. Il utilise l'image Python 3.12 officielle,
-préconfigure les caches `pip` et `DVC` sur des volumes persistants et installe
-automatiquement les dépendances du projet ainsi que les hooks `pre-commit`.
+dans VS Code ou GitHub Codespaces. Il utilise l'image Python 3.12 officielle
+(le projet restant compatible à partir de Python 3.10), préconfigure les caches
+`pip` et `DVC` sur des volumes persistants et installe automatiquement les
+dépendances du projet ainsi que les hooks `pre-commit`.
 
 Pour ouvrir le projet dans un devcontainer :
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "watcher"
 version = "0.4.0"
 description = "Atelier local d'IA de programmation autonome (offline par défaut)."
 readme = "README.md"
-requires-python = ">=3.12"
+requires-python = ">=3.10"
 license = { file = "LICENSE" }
 authors = [{ name = "Watcher contributors" }]
 dependencies = [
@@ -27,6 +27,8 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
 


### PR DESCRIPTION
## Summary
- declare Python 3.10 as the minimum supported version in the packaging metadata
- document the relaxed Python requirement in the README and contributing guide

## Testing
- python -m build *(fails: No module named build in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d108474e6c8320bae0a87e41faa6af