### PR TITLE
doc: align release links with repository owner

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,7 +8,7 @@ authors:
   - name: Watcher contributors
 identifiers:
   - type: url
-    value: https://github.com/<owner>/Watcher/releases/tag/v0.4.0
+    value: https://github.com/francis18georges-png/Watcher/releases/tag/v0.4.0
     description: Version v0.4.0 publiée le 20 septembre 2025
-repository-code: https://github.com/<owner>/Watcher
+repository-code: https://github.com/francis18georges-png/Watcher
 version: 0.4.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Watcher
 
 ![Benchmark status badge](metrics/performance_badge.svg)
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/<owner>/Watcher/badge)](https://securityscorecards.dev/viewer/?uri=github.com/<owner>/Watcher)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/francis18georges-png/Watcher/badge)](https://securityscorecards.dev/viewer/?uri=github.com/francis18georges-png/Watcher)
 
 Atelier local d'IA de programmation autonome (offline par défaut).
 Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurité.
@@ -10,7 +10,7 @@ Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurit
 
 La dernière version stable est **v0.4.0** (tag `v0.4.0`, publiée le 20 septembre 2025).
 
-- 📦 Téléchargement direct : [https://github.com/<owner>/Watcher/releases/tag/v0.4.0](https://github.com/<owner>/Watcher/releases/tag/v0.4.0)
+- 📦 Téléchargement direct : [https://github.com/francis18georges-png/Watcher/releases/tag/v0.4.0](https://github.com/francis18georges-png/Watcher/releases/tag/v0.4.0)
 - 🗒️ Notes complètes : voir le [CHANGELOG](CHANGELOG.md) et la [page de notes de version](docs/release_notes.md).
 - ✅ Instructions de vérification (signatures, provenance, empreintes) : détaillées ci-dessous pour chaque
   artefact publié.
@@ -49,7 +49,7 @@ avant de le publier sur l'environnement **GitHub Pages** à chaque push sur `mai
 
 Le badge OpenSSF Scorecard reflète en continu l'état de la posture de sécurité du dépôt
 (`.github/workflows/scorecard.yml`). Il est généré à partir de l'API publique
-<https://api.securityscorecards.dev/projects/github.com/<owner>/Watcher> et renvoie vers le
+<https://api.securityscorecards.dev/projects/github.com/francis18georges-png/Watcher> et renvoie vers le
 rapport détaillé sur <https://securityscorecards.dev>. Un run planifié hebdomadaire publie les
 résultats sur le tableau de bord OpenSSF, tandis que chaque Pull Request bénéficie d'une analyse
 à jour dans GitHub Actions.
@@ -76,16 +76,16 @@ des exécutables Windows, Linux et macOS, un SBOM CycloneDX par plateforme et un
 
 | Fichier | Description |
 | --- | --- |
-| [`Watcher-Setup.zip`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-Setup.zip) | Archive PyInstaller Windows signée et empaquetée. |
-| [`Watcher-Setup.zip.sigstore`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-Setup.zip.sigstore) | Bundle Sigstore pour vérifier la signature du binaire Windows (`sigstore verify identity --bundle ...`). |
-| [`Watcher-sbom.json`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-sbom.json) | Inventaire CycloneDX des dépendances installées pendant le build Windows (`cyclonedx-bom` / `cyclonedx-py`). |
-| [`Watcher-linux-x86_64.tar.gz`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-linux-x86_64.tar.gz) | Tarball PyInstaller contenant le binaire autonome Linux. |
-| [`Watcher-linux-sbom.json`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-linux-sbom.json) | SBOM CycloneDX généré lors du build Linux. |
-| [`Watcher-macos-x86_64.zip`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-macos-x86_64.zip) | Archive PyInstaller macOS signée (si certificat configuré) et soumise à la notarisation Apple lorsque les secrets sont fournis. |
-| [`Watcher-macos-sbom.json`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-macos-sbom.json) | SBOM CycloneDX généré lors du build macOS. |
-| [`Watcher-Setup.intoto.jsonl`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/Watcher-Setup.intoto.jsonl) | Provenance SLSA générée par [`slsa-github-generator`](https://github.com/slsa-framework/slsa-github-generator) (atteste la supply chain du binaire Windows). |
+| [`Watcher-Setup.zip`](https://github.com/francis18georges-png/Watcher/releases/download/v0.4.0/Watcher-Setup.zip) | Archive PyInstaller Windows signée et empaquetée. |
+| [`Watcher-Setup.zip.sigstore`](https://github.com/francis18georges-png/Watcher/releases/download/v0.4.0/Watcher-Setup.zip.sigstore) | Bundle Sigstore pour vérifier la signature du binaire Windows (`sigstore verify identity --bundle ...`). |
+| [`Watcher-sbom.json`](https://github.com/francis18georges-png/Watcher/releases/download/v0.4.0/Watcher-sbom.json) | Inventaire CycloneDX des dépendances installées pendant le build Windows (`cyclonedx-bom` / `cyclonedx-py`). |
+| [`Watcher-linux-x86_64.tar.gz`](https://github.com/francis18georges-png/Watcher/releases/download/v0.4.0/Watcher-linux-x86_64.tar.gz) | Tarball PyInstaller contenant le binaire autonome Linux. |
+| [`Watcher-linux-sbom.json`](https://github.com/francis18georges-png/Watcher/releases/download/v0.4.0/Watcher-linux-sbom.json) | SBOM CycloneDX généré lors du build Linux. |
+| [`Watcher-macos-x86_64.zip`](https://github.com/francis18georges-png/Watcher/releases/download/v0.4.0/Watcher-macos-x86_64.zip) | Archive PyInstaller macOS signée (si certificat configuré) et soumise à la notarisation Apple lorsque les secrets sont fournis. |
+| [`Watcher-macos-sbom.json`](https://github.com/francis18georges-png/Watcher/releases/download/v0.4.0/Watcher-macos-sbom.json) | SBOM CycloneDX généré lors du build macOS. |
+| [`Watcher-Setup.intoto.jsonl`](https://github.com/francis18georges-png/Watcher/releases/download/v0.4.0/Watcher-Setup.intoto.jsonl) | Provenance SLSA générée par [`slsa-github-generator`](https://github.com/slsa-framework/slsa-github-generator) (atteste la supply chain du binaire Windows). |
 | `watcher-*.whl` / `watcher-*.tar.gz` | Paquets Python (wheel + source) publiés dans la section *Assets* (installables via `pip`). |
-| [`pip-audit-report.json`](https://github.com/<owner>/Watcher/releases/download/v0.4.0/pip-audit-report.json) | Rapport JSON de l'analyse `pip-audit` exécutée sur `requirements.txt` et `requirements-dev.txt`. |
+| [`pip-audit-report.json`](https://github.com/francis18georges-png/Watcher/releases/download/v0.4.0/pip-audit-report.json) | Rapport JSON de l'analyse `pip-audit` exécutée sur `requirements.txt` et `requirements-dev.txt`. |
 
 ### Vérifier les artefacts publiés
 
@@ -94,7 +94,7 @@ release `v0.4.0` :
 
 ```bash
 # 1. Télécharger tous les fichiers nécessaires (binaire + SBOM + provenance)
-RELEASE="https://github.com/<owner>/Watcher/releases/download/v0.4.0"
+RELEASE="https://github.com/francis18georges-png/Watcher/releases/download/v0.4.0"
 wget "$RELEASE/Watcher-Setup.zip" \
      "$RELEASE/Watcher-Setup.zip.sigstore" \
      "$RELEASE/Watcher-Setup.intoto.jsonl" \
@@ -103,14 +103,14 @@ wget "$RELEASE/Watcher-Setup.zip" \
 # 2. Vérifier la signature Sigstore (Windows)
 sigstore verify identity \
   --bundle Watcher-Setup.zip.sigstore \
-  --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/v0.4.0" \
+  --certificate-identity "https://github.com/francis18georges-png/Watcher/.github/workflows/release.yml@refs/tags/v0.4.0" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
   Watcher-Setup.zip
 
 # 3. Vérifier la provenance SLSA (attestation supply chain)
 slsa-verifier verify-artifact \
   --provenance Watcher-Setup.intoto.jsonl \
-  --source-uri github.com/<owner>/Watcher \
+  --source-uri github.com/francis18georges-png/Watcher \
   --source-tag v0.4.0 \
   Watcher-Setup.zip
 
@@ -143,12 +143,12 @@ plateforme visée et conservez la provenance `*.intoto.jsonl` pour tracer la cha
    ```powershell
    sigstore verify identity `
      --bundle Watcher-Setup.zip.sigstore `
-     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" `
+     --certificate-identity "https://github.com/francis18georges-png/Watcher/.github/workflows/release.yml@refs/tags/<tag>" `
      --certificate-oidc-issuer https://token.actions.githubusercontent.com `
      Watcher-Setup.zip
    ```
 
-   Remplacez `<owner>` par l'organisation ou l'utilisateur GitHub hébergeant ce dépôt et `<tag>` par la version téléchargée.
+   Remplacez `<tag>` par la version téléchargée. Si vous validez un fork, adaptez l'identité du certificat pour refléter votre dépôt ; pour la distribution officielle, l'identité doit rester `https://github.com/francis18georges-png/Watcher/.github/workflows/release.yml@refs/tags/<tag>`.
    La commande échoue si la signature ne provient pas du workflow officiel exécuté sur GitHub Actions.
 4. Extrayez l'archive (clic droit → *Extraire tout...* ou `Expand-Archive` sous PowerShell) puis lancez `Watcher.exe`.
    Conservez le dossier d'extraction tel quel : il contient la configuration (`config/`), les prompts LLM et les fichiers
@@ -307,7 +307,7 @@ Les fichiers d'environnement (`*.env`), les journaux (`*.log`) et les environnem
 ## Exécution via Docker
 
 Une image container officielle est construite par le workflow [`docker.yml`](.github/workflows/docker.yml)
-et publiée sur le registre GitHub Container Registry sous `ghcr.io/<owner>/watcher`.
+et publiée sur le registre GitHub Container Registry sous `ghcr.io/francis18georges-png/watcher`.
 
 ### Utiliser l'image publiée
 
@@ -324,7 +324,7 @@ docker run --rm -it \
   -v watcher-data:/app/data \
   -v watcher-memory:/app/memory \
   -v watcher-logs:/app/logs \
-  ghcr.io/<owner>/watcher:latest --help
+  ghcr.io/francis18georges-png/watcher:latest --help
 ```
 
 Copiez le dossier `config/` du dépôt si vous souhaitez le personnaliser avant de le monter en lecture
@@ -334,7 +334,7 @@ Copiez le dossier `config/` du dépôt si vous souhaitez le personnaliser avant 
 Pour exécuter une commande CLI, passez-la directement après l'image :
 
 ```bash
-docker run --rm -it ghcr.io/<owner>/watcher:latest plugin list
+docker run --rm -it ghcr.io/francis18georges-png/watcher:latest plugin list
 ```
 
 ### Vérifier les artefacts de signature, de provenance et les SBOM
@@ -342,8 +342,8 @@ docker run --rm -it ghcr.io/<owner>/watcher:latest plugin list
 Le workflow [`docker.yml`](.github/workflows/docker.yml) publie, en plus de l'image container,
 les artefacts suivants pour chaque exécution :
 
-- `cosign-bundles/ghcr.io__<owner>__watcher__<tag>.sigstore` : bundle Sigstore de la signature
-  keyless pour la référence `ghcr.io/<owner>/watcher:<tag>`.
+- `cosign-bundles/ghcr.io__francis18georges-png__watcher__<tag>.sigstore` : bundle Sigstore de la signature
+  keyless pour la référence `ghcr.io/francis18georges-png/watcher:<tag>`.
 - `watcher-image-provenance/watcher-image.intoto.jsonl` : attestation SLSA générée via
   [`slsa-github-generator`](https://github.com/slsa-framework/slsa-github-generator) et liée au digest
   publié par le job `Build and publish image`.
@@ -359,18 +359,18 @@ avec `cosign` :
 
 ```bash
 cosign verify \
-  --bundle ghcr.io__<owner>__watcher__<tag>.sigstore \
-  --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/docker.yml@refs/tags/<tag>" \
+  --bundle ghcr.io__francis18georges-png__watcher__<tag>.sigstore \
+  --certificate-identity "https://github.com/francis18georges-png/Watcher/.github/workflows/docker.yml@refs/tags/<tag>" \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  ghcr.io/<owner>/watcher@sha256:<digest>
+  ghcr.io/francis18georges-png/watcher@sha256:<digest>
 ```
 
 Remplacez `<tag>` par la version téléchargée (par exemple `v0.4.0`) et `<digest>` par l'empreinte
 SHA256 de l'image. Vous pouvez récupérer ce digest via `docker buildx imagetools inspect`
-(`docker buildx imagetools inspect ghcr.io/<owner>/watcher:<tag> --format '{{.Digest}}'`).
+(`docker buildx imagetools inspect ghcr.io/francis18georges-png/watcher:<tag> --format '{{.Digest}}'`).
 
 Pour les images construites depuis `main`, remplacez l'identité du certificat par
-`https://github.com/<owner>/Watcher/.github/workflows/docker.yml@refs/heads/main` et utilisez le
+`https://github.com/francis18georges-png/Watcher/.github/workflows/docker.yml@refs/heads/main` et utilisez le
 digest correspondant (affiché par `docker pull` ou `crane digest`).
 
 L'attestation SLSA permet de relier cryptographiquement ce digest au workflow GitHub Actions.
@@ -380,7 +380,7 @@ Téléchargez l'artefact `watcher-image-provenance` puis vérifiez-le avec
 ```bash
 slsa-verifier verify-image \
   --provenance watcher-image.intoto.jsonl \
-  ghcr.io/<owner>/watcher@sha256:<digest>
+  ghcr.io/francis18georges-png/watcher@sha256:<digest>
 ```
 
 Vous pouvez également inspecter le fichier pour contrôler manuellement les champs `builder.id` et

--- a/docs/offline_guide.md
+++ b/docs/offline_guide.md
@@ -7,12 +7,12 @@ contrôles d'intégrité.
 
 ## 1. Préparer le kit hors-ligne sur une machine connectée
 
-1. **Téléchargez les artefacts de release** depuis GitHub pour le tag ciblé (par exemple [v0.4.0](https://github.com/<owner>/Watcher/releases/tag/v0.4.0)) :
+1. **Téléchargez les artefacts de release** depuis GitHub pour le tag ciblé (par exemple [v0.4.0](https://github.com/francis18georges-png/Watcher/releases/tag/v0.4.0)) :
 
    ```bash
    mkdir -p ~/watcher-offline-kit/artifacts
    cd ~/watcher-offline-kit/artifacts
-   gh release download <tag> --repo <owner>/Watcher
+   gh release download <tag> --repo francis18georges-png/Watcher
    ```
 
    Ce répertoire doit contenir au minimum :
@@ -76,7 +76,7 @@ tar -xzf /mnt/usb/watcher-offline-kit.tgz
    ```bash
    sigstore verify identity \
      --bundle artifacts/Watcher-Setup.zip.sigstore \
-     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-identity "https://github.com/francis18georges-png/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
      artifacts/Watcher-Setup.zip
    ```
@@ -87,7 +87,7 @@ tar -xzf /mnt/usb/watcher-offline-kit.tgz
    cosign verify-attestation \
      --type slsaprovenance \
      --bundle artifacts/Watcher-Setup.intoto.jsonl.sigstore \
-     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-identity "https://github.com/francis18georges-png/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
      artifacts/Watcher-Setup.intoto.jsonl | jq '.subject'
    ```
@@ -98,7 +98,7 @@ tar -xzf /mnt/usb/watcher-offline-kit.tgz
    cosign verify-attestation \
      --type cyclonedx \
      --bundle artifacts/Watcher-sbom.json.sigstore \
-     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-identity "https://github.com/francis18georges-png/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
      artifacts/Watcher-sbom.json | jq '.predicate.metadata'
    ```

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -8,7 +8,7 @@ référençant les pages GitHub Releases correspondantes.
 
 | Version | Date | Points clés | Lien GitHub Releases |
 | --- | --- | --- | --- |
-| v0.4.0 | 20 septembre 2025 | - Configurer les versions Python ciblées par Nox et CI.<br>- Ajouter des property tests compatibles numpy-stub.<br>- Améliorer les workflows de release et de conteneurisation. | [Release v0.4.0 (GitHub)](https://github.com/<owner>/Watcher/releases/tag/v0.4.0) |
+| v0.4.0 | 20 septembre 2025 | - Configurer les versions Python ciblées par Nox et CI.<br>- Ajouter des property tests compatibles numpy-stub.<br>- Améliorer les workflows de release et de conteneurisation. | [Release v0.4.0 (GitHub)](https://github.com/francis18georges-png/Watcher/releases/tag/v0.4.0) |
 
 !!! info "Suivre les prochaines versions"
     Ajoutez une nouvelle ligne à ce tableau et un bloc dédié dès qu'un tag `vMAJOR.MINOR.PATCH`
@@ -21,14 +21,14 @@ référençant les pages GitHub Releases correspondantes.
 - 🚀 Optimisations des workflows de release et de build de conteneurs.
 - 📚 Documentation du blocage réseau dans la configuration par défaut.
 
-➤ [Consulter la release GitHub](https://github.com/<owner>/Watcher/releases/tag/v0.4.0)
+➤ [Consulter la release GitHub](https://github.com/francis18georges-png/Watcher/releases/tag/v0.4.0)
 
 ### Vérifier les artefacts de la release v0.4.0
 
 1. Téléchargez les binaires et métadonnées depuis la release officielle :
 
    ```bash
-   RELEASE="https://github.com/<owner>/Watcher/releases/download/v0.4.0"
+   RELEASE="https://github.com/francis18georges-png/Watcher/releases/download/v0.4.0"
    wget "$RELEASE/Watcher-Setup.zip" \
         "$RELEASE/Watcher-Setup.zip.sigstore" \
         "$RELEASE/Watcher-Setup.intoto.jsonl" \
@@ -44,7 +44,7 @@ référençant les pages GitHub Releases correspondantes.
    ```bash
    sigstore verify identity \
      --bundle Watcher-Setup.zip.sigstore \
-     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/v0.4.0" \
+     --certificate-identity "https://github.com/francis18georges-png/Watcher/.github/workflows/release.yml@refs/tags/v0.4.0" \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
      Watcher-Setup.zip
    ```
@@ -54,7 +54,7 @@ référençant les pages GitHub Releases correspondantes.
    ```bash
    slsa-verifier verify-artifact \
      --provenance Watcher-Setup.intoto.jsonl \
-     --source-uri github.com/<owner>/Watcher \
+     --source-uri github.com/francis18georges-png/Watcher \
      --source-tag v0.4.0 \
      Watcher-Setup.zip
    ```

--- a/docs/security_provenance.md
+++ b/docs/security_provenance.md
@@ -52,13 +52,12 @@ Watcher-sbom.json.sigstore
    ```bash
    sigstore verify identity \
      --bundle Watcher-Setup.zip.sigstore \
-     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-identity "https://github.com/francis18georges-png/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
      Watcher-Setup.zip
    ```
 
-   - Remplacez `<owner>` par l'organisation ou l'utilisateur GitHub hébergeant Watcher.
-   - Substituez `<tag>` par la version téléchargée (`vMAJOR.MINOR.PATCH`).
+   - Substituez `<tag>` par la version téléchargée (`vMAJOR.MINOR.PATCH`). Pour un fork, adaptez l'URL `https://github.com/francis18georges-png/Watcher/...` à votre dépôt ; pour la distribution officielle, conservez l'identité `francis18georges-png`.
    - La commande échoue si le bundle ne provient pas du workflow officiel `release.yml`.
 
 3. Répétez la vérification pour les archives Linux et macOS (`Watcher-linux-x86_64.tar.gz`,
@@ -75,7 +74,7 @@ Watcher-sbom.json.sigstore
    ```bash
    cosign verify-attestation \
      --type slsaprovenance \
-     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-identity "https://github.com/francis18georges-png/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
      --bundle Watcher-Setup.intoto.jsonl.sigstore \
      Watcher-Setup.intoto.jsonl | jq '.'
@@ -100,7 +99,7 @@ recommandées pour les releases officielles :
    ```bash
    sigstore verify identity \
      --bundle Watcher-sbom.json.sigstore \
-     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-identity "https://github.com/francis18georges-png/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
      Watcher-sbom.json
    ```
@@ -111,7 +110,7 @@ recommandées pour les releases officielles :
    ```bash
    cosign verify-attestation \
      --type cyclonedx \
-     --certificate-identity "https://github.com/<owner>/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
+     --certificate-identity "https://github.com/francis18georges-png/Watcher/.github/workflows/release.yml@refs/tags/<tag>" \
      --certificate-oidc-issuer https://token.actions.githubusercontent.com \
      --bundle Watcher-sbom.json.sigstore \
      Watcher-sbom.json | jq '.predicate' | less
@@ -140,7 +139,7 @@ jq '.packages[] | {name, versionInfo, licenseDeclared}' sbom.spdx.json | head
 ```
 
 Vérifiez que le champ `documentNamespace` contient le digest SHA256 de l'image téléchargée et que
-les entrées `externalRefs` pointent bien vers `ghcr.io/<owner>/watcher@sha256:<digest>`.
+les entrées `externalRefs` pointent bien vers `ghcr.io/francis18georges-png/watcher@sha256:<digest>`.
 
 Pour conserver un lien de confiance, archivez ce SBOM avec le bundle de signature de l'image et
 l'attestation SLSA décrite ci-dessous.
@@ -157,7 +156,7 @@ avec [`slsa-github-generator`](https://github.com/slsa-framework/slsa-github-gen
    ```bash
    slsa-verifier verify-image \
      --provenance watcher-image.intoto.jsonl \
-     ghcr.io/<owner>/watcher@sha256:<digest>
+     ghcr.io/francis18georges-png/watcher@sha256:<digest>
    ```
 
    Le digest passé en argument doit correspondre à celui vérifié avec `cosign verify`.


### PR DESCRIPTION
## Summary
- replace the <owner> placeholder with francis18georges-png across the README and docs so release links resolve
- update CLI instructions (wget, sigstore, gh release, cosign) to reflect the official repository owner
- clarify guidance for forks when referencing certificate identities

## Testing
- ⚠️ `mkdocs build` *(fails: mkdocs is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d108466cb083208057e21edb2e59ad