### PR TITLE
Update documentation links for GitHub Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ cffconvert --validate --format bibtex --outfile watcher.bib
 ## Documentation
 
 La documentation technique est générée avec [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)
-et publiée via l'environnement **github-pages** du dépôt.
-Activez GitHub Pages dans les paramètres du dépôt (source : **GitHub Actions**) puis cliquez sur
-« View deployment » depuis l'onglet **Deployments → github-pages** pour accéder au site public généré
-par `deploy-docs.yml`.
+et publiée via l'environnement **github-pages** du dépôt. Consultez la dernière version compilée sur
+[https://francis18georges-png.github.io/Watcher/](https://francis18georges-png.github.io/Watcher/),
+déployée automatiquement par `deploy-docs.yml`.
 
 Pour la prévisualiser localement :
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,9 +36,10 @@ mode d'exploitation de la plate-forme.
 
 ## Accès à la documentation publiée
 
-Lorsque le workflow GitHub Actions **Deploy MkDocs site** est exécuté sur la branche `main`, la version statique la plus
-récente est accessible via l'environnement **github-pages** du dépôt. Ouvrez l'onglet **Deployments → github-pages** puis
-cliquez sur « View deployment » pour consulter le site public.
+La version statique la plus récente est accessible à l'adresse
+[https://francis18georges-png.github.io/Watcher/](https://francis18georges-png.github.io/Watcher/).
+Elle est déployée automatiquement par le workflow GitHub Actions **Deploy MkDocs site** sur l'environnement
+**github-pages** après chaque push sur `main`.
 
 !!! info "URL personnalisée"
     Si un domaine personnalisé est configuré, mettez à jour le champ `site_url` dans `mkdocs.yml` et ajoutez un fichier

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: "Watcher"
 site_description: "Documentation technique et opérationnelle de l'atelier Watcher"
-site_url: !ENV ["WATCHER_DOCS_URL", ""]
-repo_url: !ENV ["WATCHER_REPO_URL", ""]
+site_url: "https://francis18georges-png.github.io/Watcher/"
+repo_url: "https://github.com/francis18georges-png/Watcher"
 edit_uri: "edit/main/docs/"
 strict: true
 
@@ -66,7 +66,7 @@ plugins:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/<github-username>/Watcher
+      link: https://github.com/francis18georges-png/Watcher
       name: Dépôt GitHub Watcher
 
 nav:


### PR DESCRIPTION
## Summary
- link the README and documentation homepage directly to the published GitHub Pages site
- configure MkDocs with the public site and repository URLs so generated pages reference them correctly
- align the social link with the repository URL

## Testing
- ⚠️ `mkdocs build --strict` *(fails: mkdocs command unavailable in environment and pip install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d10f6e38b8832098cbd4714b385fab