### PR TITLE
Update GitHub link in MkDocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,7 @@ plugins:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/<github-username>/Watcher
+      link: https://github.com/francis18georges-png/Watcher
       name: Dépôt GitHub Watcher
 
 nav:


### PR DESCRIPTION
## Summary
- replace the placeholder GitHub repository link in the MkDocs configuration with the francis18georges-png account

## Testing
- mkdocs serve *(fails: mkdocs is not installed in the execution environment and pip installs are blocked by the proxy)*
- mkdocs build --strict *(fails: mkdocs is not installed in the execution environment and pip installs are blocked by the proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d10f6edb08832086ec0cda1a8b9d5c