### PR TITLE
chore(ci): tighten coverage gates

### DIFF
--- a/QA.md
+++ b/QA.md
@@ -38,6 +38,10 @@
 * Le job `Scorecard gate` rejoue l'analyse OpenSSF Scorecard pour chaque Pull Request via
   `ossf/scorecard-action@v2`. La CI échoue dès que le score global descend sous `7` afin de
   bloquer la fusion tant que les recommandations critiques ne sont pas appliquées.
+* Les jobs de tests exigent une couverture globale d'au moins `90 %` via
+  `pytest --cov-fail-under=90` exécuté dans la session Nox `tests`.
+* Le rapport de couverture différentiel doit rester à `100 %`. Le job `coverage` échoue si
+  `diff-cover` détecte une baisse (seuil configuré avec `DIFF_COVER_FAIL_UNDER=100`).
 * The Windows job invokes `./installer.ps1 -SkipOllama` to validate that the PowerShell installer succeeds
   without the Ollama models.
 * Immediately afterwards the workflow launches `./run.ps1` with an empty `DISPLAY` variable to emulate

--- a/noxfile.py
+++ b/noxfile.py
@@ -43,7 +43,7 @@ SOURCE_DIRECTORIES = (
 SBOM_PATH = Path("dist/Watcher-sbom.json")
 SBOM_DIRECTORY = SBOM_PATH.parent
 DEFAULT_COMPARE_BRANCH = "origin/main"
-DIFF_COVER_FAIL_UNDER = 80
+DIFF_COVER_FAIL_UNDER = 100
 
 nox.options.sessions = ("lint", "typecheck", "tests", "coverage", "build", "security")
 nox.options.reuse_existing_virtualenvs = True
@@ -141,7 +141,13 @@ def security(session: nox.Session) -> None:
 def tests(session: nox.Session) -> None:
     """Run the unit test suite."""
     install_project(session)
-    session.run("pytest", "--cov=app", "--cov=config", "--cov-report=xml")
+    session.run(
+        "pytest",
+        "--cov=app",
+        "--cov=config",
+        "--cov-report=xml",
+        "--cov-fail-under=90",
+    )
 
 
 @nox.session(python=PYTHON_VERSIONS)


### PR DESCRIPTION
## Summary
- raise the diff-cover failure threshold to 100 in the Nox configuration
- enforce a minimum 90% coverage when running pytest via the tests session
- document the new coverage expectations in the QA guide so CI behaviour is clear

## Testing
- not run (configuration updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d10f705f4083208f7f9cfa0150be7a