### PR TITLE
Enable multi-arch Docker image builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: image=moby/buildkit:rootless
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -52,10 +54,27 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Verify published image platforms
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          image="ghcr.io/${{ github.repository_owner }}/watcher:${tag}"
+          echo "Inspecting $image"
+          inspect_output=$(docker buildx imagetools inspect "$image")
+          printf '%s\n' "$inspect_output"
+          for platform in linux/amd64 linux/arm64; do
+            if ! grep -q "$platform" <<<"$inspect_output"; then
+              echo "Missing manifest for $platform" >&2
+              exit 1
+            fi
+          done
 
       - name: Set image digest reference
         id: image-ref


### PR DESCRIPTION
## Summary
- configure the Docker Buildx builder to use the rootless BuildKit image for multi-platform support
- build and push Docker images for linux/amd64 and linux/arm64
- verify on tag pushes that the published image exposes amd64 and arm64 manifests via `docker buildx imagetools inspect`

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d10f6fa9608320b3d26e55a84efc83