### PR TITLE
Add pytest-socket enforcement and offline network test

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,6 +11,7 @@ pip-audit==2.7.3
 pre-commit==3.8.0
 pytest==8.3.2
 pytest-cov==5.0.0
+pytest-socket==0.6.0
 ruff==0.6.9
 semgrep==1.91.0
 mkdocs==1.6.0


### PR DESCRIPTION
## Summary
- add pytest-socket to the development requirements and activate it during test collection with a local fallback when the dependency is unavailable
- ensure the offline engine suite verifies that network connections are blocked in offline mode

## Testing
- pytest tests/test_engine_offline.py

------
https://chatgpt.com/codex/tasks/task_e_68d10f7129008320a261e3717a2dc55c