### PR TITLE
Add actionlint and yamllint pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,12 @@ repos:
       - id: end-of-file-fixer
         name: Ensure text files end with a trailing newline
         types: [text]
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.1
+    hooks:
+      - id: actionlint
+        files: ^\.github/workflows/.*\.yml$
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint


### PR DESCRIPTION
## Summary
- add an actionlint hook to validate GitHub Actions workflows
- add yamllint to lint general YAML files

## Testing
- ⚠️ `pre-commit install && pre-commit run --all-files` *(fails: `pre-commit` package cannot be installed because outbound network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68deee2a822483209cd97aa030afe217