### PR TITLE
refactor: reuse script for SOURCE_DATE_EPOCH export

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,45 +46,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python - <<'PY'
-            import os
-            import pathlib
-            import subprocess
-
-            workspace = pathlib.Path(os.environ["GITHUB_WORKSPACE"])
-            (workspace / ".pyinstaller").mkdir(parents=True, exist_ok=True)
-
-            ref_candidates = []
-            ref = os.environ.get("GITHUB_REF")
-            if ref:
-                ref_candidates.append(ref)
-            ref_name = os.environ.get("GITHUB_REF_NAME")
-            if ref_name:
-                ref_candidates.append(f"refs/tags/{ref_name}")
-            ref_candidates.append("HEAD")
-
-            epoch = None
-            for candidate in ref_candidates:
-                try:
-                    value = subprocess.check_output([
-                        "git",
-                        "log",
-                        "-1",
-                        "--format=%ct",
-                        candidate,
-                    ], text=True).strip()
-                except subprocess.CalledProcessError:
-                    continue
-                if value:
-                    epoch = value
-                    break
-
-            if epoch is None:
-                raise SystemExit("Unable to determine SOURCE_DATE_EPOCH")
-
-            with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
-                fh.write(f"SOURCE_DATE_EPOCH={epoch}\n")
-PY
+          python scripts/export_source_date_epoch.py
 
       - name: Install build dependencies
         run: |
@@ -154,45 +116,7 @@ PY
         shell: bash
         run: |
           set -euo pipefail
-          python - <<'PY'
-            import os
-            import pathlib
-            import subprocess
-
-            workspace = pathlib.Path(os.environ["GITHUB_WORKSPACE"])
-            (workspace / ".pyinstaller").mkdir(parents=True, exist_ok=True)
-
-            ref_candidates = []
-            ref = os.environ.get("GITHUB_REF")
-            if ref:
-                ref_candidates.append(ref)
-            ref_name = os.environ.get("GITHUB_REF_NAME")
-            if ref_name:
-                ref_candidates.append(f"refs/tags/{ref_name}")
-            ref_candidates.append("HEAD")
-
-            epoch = None
-            for candidate in ref_candidates:
-                try:
-                    value = subprocess.check_output([
-                        "git",
-                        "log",
-                        "-1",
-                        "--format=%ct",
-                        candidate,
-                    ], text=True).strip()
-                except subprocess.CalledProcessError:
-                    continue
-                if value:
-                    epoch = value
-                    break
-
-            if epoch is None:
-                raise SystemExit("Unable to determine SOURCE_DATE_EPOCH")
-
-            with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
-                fh.write(f"SOURCE_DATE_EPOCH={epoch}\n")
-PY
+          python scripts/export_source_date_epoch.py
 
       - name: Install build dependencies
         shell: pwsh
@@ -312,45 +236,7 @@ PY
         shell: bash
         run: |
           set -euo pipefail
-          python - <<'PY'
-            import os
-            import pathlib
-            import subprocess
-
-            workspace = pathlib.Path(os.environ["GITHUB_WORKSPACE"])
-            (workspace / ".pyinstaller").mkdir(parents=True, exist_ok=True)
-
-            ref_candidates = []
-            ref = os.environ.get("GITHUB_REF")
-            if ref:
-                ref_candidates.append(ref)
-            ref_name = os.environ.get("GITHUB_REF_NAME")
-            if ref_name:
-                ref_candidates.append(f"refs/tags/{ref_name}")
-            ref_candidates.append("HEAD")
-
-            epoch = None
-            for candidate in ref_candidates:
-                try:
-                    value = subprocess.check_output([
-                        "git",
-                        "log",
-                        "-1",
-                        "--format=%ct",
-                        candidate,
-                    ], text=True).strip()
-                except subprocess.CalledProcessError:
-                    continue
-                if value:
-                    epoch = value
-                    break
-
-            if epoch is None:
-                raise SystemExit("Unable to determine SOURCE_DATE_EPOCH")
-
-            with open(os.environ["GITHUB_ENV"], "a", encoding="utf-8") as fh:
-                fh.write(f"SOURCE_DATE_EPOCH={epoch}\n")
-PY
+          python scripts/export_source_date_epoch.py
 
       - name: Install build dependencies
         shell: bash

--- a/scripts/export_source_date_epoch.py
+++ b/scripts/export_source_date_epoch.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Compute SOURCE_DATE_EPOCH and export it for GitHub Actions."""
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import sys
+from typing import Iterable, Mapping, Optional
+
+
+def _candidate_refs(env: Mapping[str, str]) -> Iterable[str]:
+    ref = env.get("GITHUB_REF")
+    if ref:
+        yield ref
+
+    ref_name = env.get("GITHUB_REF_NAME")
+    if ref_name:
+        yield f"refs/tags/{ref_name}"
+
+    yield "HEAD"
+
+
+def _resolve_epoch(refs: Iterable[str]) -> Optional[str]:
+    for candidate in refs:
+        try:
+            value = subprocess.check_output(
+                ["git", "log", "-1", "--format=%ct", candidate],
+                text=True,
+            ).strip()
+        except subprocess.CalledProcessError:
+            continue
+        if value:
+            return value
+    return None
+
+
+def main() -> int:
+    env = os.environ
+
+    workspace_raw = env.get("GITHUB_WORKSPACE")
+    if not workspace_raw:
+        raise SystemExit("GITHUB_WORKSPACE environment variable is not set")
+
+    workspace = pathlib.Path(workspace_raw)
+    (workspace / ".pyinstaller").mkdir(parents=True, exist_ok=True)
+
+    epoch = _resolve_epoch(_candidate_refs(env))
+    if epoch is None:
+        raise SystemExit("Unable to determine SOURCE_DATE_EPOCH")
+
+    github_env_path = env.get("GITHUB_ENV")
+    if not github_env_path:
+        raise SystemExit("GITHUB_ENV environment variable is not set")
+
+    github_env = pathlib.Path(github_env_path)
+    with github_env.open("a", encoding="utf-8") as fh:
+        fh.write(f"SOURCE_DATE_EPOCH={epoch}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a reusable Python script that writes SOURCE_DATE_EPOCH to the GitHub Actions environment file
- update the release workflow to call the new script instead of an inline here-document

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df017fb3308320bfef387cf5f30849