### PR TITLE
Adapter la documentation pour la release v0.4.0 en préparation

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,5 +10,5 @@ identifiers:
   - type: url
     value: https://github.com/francis18georges-png/Watcher/releases/tag/v0.4.0
     description: Version v0.4.0 publiée le 20 septembre 2025
-repository-code: https://github.com/francis18georges-png/Watcher
+repository-code: "À venir — l'URL de la release GitHub sera ajoutée lorsque le tag v0.4.0 sera disponible"
 version: 0.4.0

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -8,22 +8,29 @@ référençant les pages GitHub Releases correspondantes.
 
 | Version | Date | Points clés | Lien GitHub Releases |
 | --- | --- | --- | --- |
-| v0.4.0 | 20 septembre 2025 | - Configurer les versions Python ciblées par Nox et CI.<br>- Ajouter des property tests compatibles numpy-stub.<br>- Améliorer les workflows de release et de conteneurisation. | [Release v0.4.0 (GitHub)](https://github.com/francis18georges-png/Watcher/releases/tag/v0.4.0) |
+| v0.4.0 | À venir | - Configurer les versions Python ciblées par Nox et CI.<br>- Ajouter des property tests compatibles numpy-stub.<br>- Améliorer les workflows de release et de conteneurisation. | À venir |
 
 !!! info "Suivre les prochaines versions"
     Ajoutez une nouvelle ligne à ce tableau et un bloc dédié dès qu'un tag `vMAJOR.MINOR.PATCH`
     est poussé.
 
-## v0.4.0 — 2025-09-20
+## v0.4.0 — en préparation
+
+!!! warning "Release GitHub en préparation"
+    La publication officielle de la version `v0.4.0` n'est pas encore disponible sur GitHub.
+    Les liens directs et la date finale seront ajoutés dès que le tag sera créé.
 
 - 🛠️ Configuration explicite des versions Python ciblées par Nox et par la CI.
 - ✅ Ajout de property tests compatibles avec les stubs numpy.
 - 🚀 Optimisations des workflows de release et de build de conteneurs.
 - 📚 Documentation du blocage réseau dans la configuration par défaut.
 
-➤ [Consulter la release GitHub](https://github.com/francis18georges-png/Watcher/releases/tag/v0.4.0)
+➤ Lien GitHub : à venir
 
 ### Vérifier les artefacts de la release v0.4.0
+
+Ces vérifications seront possibles une fois que la publication GitHub sera en ligne. Les
+commandes ci-dessous sont conservées à titre de checklist.
 
 1. Téléchargez les binaires et métadonnées depuis la release officielle :
 


### PR DESCRIPTION
## Summary
- indiquer dans la fiche de citation que l’URL du dépôt pour la release v0.4.0 reste à venir
- signaler dans les notes de version que la publication GitHub v0.4.0 est en préparation et retirer le lien cassé
- conserver les instructions de vérification en les présentant comme une checklist à activer lors de la sortie

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df018060c48320887552da2d3cb5e1