### PR TITLE
Add QEMU setup to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:


### PR DESCRIPTION
## Summary
- add a QEMU setup step to ensure binfmt is registered before configuring Buildx
- retain multi-architecture build targets for amd64 and arm64 in the docker build step

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68df0449eacc83208246a1c188e9f7f9