### PR TITLE
Add workflow lint job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,34 @@ env:
   TRIVY_CACHE_DIR: .trivy
 
 jobs:
+  workflow-lint:
+    name: Workflow lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install actionlint
+        shell: bash
+        run: >-
+          bash <(curl -sSfL
+          https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
+      - name: Install yamllint
+        run: |
+          python3 -m pip install --user --upgrade yamllint
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run actionlint
+        run: ./actionlint -color
+
+      - name: Run yamllint
+        run: yamllint .github/workflows
+
   determine-python:
     name: Determine Python versions
+    needs:
+      - workflow-lint
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.python-versions.outputs.matrix }}
@@ -44,6 +70,8 @@ jobs:
 
   scorecard:
     name: Scorecard gate
+    needs:
+      - workflow-lint
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/QA.md
+++ b/QA.md
@@ -35,6 +35,16 @@
 
 ## Continuous Integration
 
+* Le job `Workflow lint` valide tous les workflows via `actionlint` et `yamllint` avant
+  d'autoriser les autres jobs. Reproduisez-le localement avec :
+
+  ```bash
+  bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+  python3 -m pip install --user --upgrade yamllint
+  ./actionlint -color
+  yamllint .github/workflows
+  ```
+
 * Le job `Scorecard gate` rejoue l'analyse OpenSSF Scorecard pour chaque Pull Request via
   `ossf/scorecard-action@v2`. La CI échoue dès que le score global descend sous `7` afin de
   bloquer la fusion tant que les recommandations critiques ne sont pas appliquées.


### PR DESCRIPTION
## Summary
- add a workflow lint job that runs actionlint and yamllint before other checks
- document how to reproduce the workflow lint job locally in QA notes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df044a3354832088dbd50d49db4305