### PR TITLE
feat: add offline CLI workflow and documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export WATCHER_TRAINING__SEED
 export CUBLAS_WORKSPACE_CONFIG
 export TORCH_DETERMINISTIC
 
-.PHONY: format lint type security test check nox
+.PHONY: format lint type security test check nox demo-offline
 
 format:
 > ruff --fix .
@@ -34,4 +34,10 @@ check:
 
 nox:
 > nox -s lint typecheck security tests build
+
+demo-offline:
+> mkdir -p .artifacts/demo-offline
+> WATCHER_PATHS__BASE_DIR=$$(pwd)/.artifacts/demo-offline \
+> WATCHER_INTELLIGENCE__MODE=offline \
+> python -m app.cli run --offline --prompt "Présente Watcher en une phrase."
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ Mémoire vectorielle, curriculum adaptatif, A/B + bench et quality gate sécurit
 
 Les binaires et paquets signés sont publiés sur la page
 [GitHub Releases](https://github.com/francis18georges-png/Watcher/releases/latest).
-La version stable actuelle est `v0.4.0` ; utilisez toujours ce lien `releases/latest`
-pour éviter les 404 lorsque de nouvelles versions sont mises en ligne.
+Le premier tag `vMAJOR.MINOR.PATCH` déclenche automatiquement la release ;
+tant qu'aucun tag n'est publié, le lien `releases/latest` renvoie `404`, ce qui est
+attendu.
 
 - 🗒️ Notes complètes : voir le [CHANGELOG](CHANGELOG.md) et la [page de notes de version](docs/release_notes.md).
 - ✅ Instructions de vérification (signatures, provenance, empreintes) : détaillées ci-dessous et à
@@ -45,6 +46,19 @@ pour éviter les 404 lorsque de nouvelles versions sont mises en ligne.
    La commande appelle le backend `llama.cpp` local, la mémoire vectorielle SQLite et les
    outils sandboxés (`app/core/sandbox.py`). Les traces sont visibles dans `logs/`.
 
+   Pour vérifier ce parcours dans un environnement vierge, la recette `make demo-offline`
+   prépare automatiquement un espace isolé dans `.artifacts/demo-offline/` avant de lancer
+   `watcher run --offline`.
+
+### Commandes CLI stables
+
+- `watcher run` : exécute un scénario minimaliste (prompt libre) en respectant le mode
+  offline. Le drapeau `--model` permet de basculer dynamiquement vers un autre fichier GGUF.
+- `watcher ask "question"` : interroge l'index vectoriel local (namespace configurable) et
+  renvoie une réponse déterministe, y compris sans réseau grâce au fallback `Echo`.
+- `watcher ingest chemin/` : ajoute un ou plusieurs fichiers Markdown/TXT dans la mémoire
+  vectorielle persistée (`memory/vector-store.db`) en lots contrôlés via `--batch-size`.
+
 ## Citer Watcher
 
 Merci de citer ce dépôt lorsque vous réutilisez son code, ses jeux de données ou sa
@@ -60,8 +74,9 @@ cffconvert --validate --format bibtex --outfile watcher.bib
 ## Documentation
 
 La documentation technique est générée avec [MkDocs Material](https://squidfunk.github.io/mkdocs-material/)
-et publiée via l'environnement **github-pages** du dépôt. Consultez la dernière version compilée sur
-[https://francis18georges-png.github.io/Watcher/](https://francis18georges-png.github.io/Watcher/),
+et publiée via l'environnement **github-pages** du dépôt. Activez GitHub Pages (source :
+"GitHub Actions") pour rendre le site public, puis consultez
+[https://francis18georges-png.github.io/Watcher/](https://francis18georges-png.github.io/Watcher/)
 déployée automatiquement par `deploy-docs.yml`.
 
 Pour la prévisualiser localement :
@@ -103,10 +118,9 @@ des exécutables Windows, Linux et macOS, un SBOM CycloneDX par plateforme et un
 
 ### Artefacts publiés
 
-Les artefacts générés par le workflow `release.yml` seront listés ici dès la mise en ligne de la release
-`v0.4.0`. Chaque build fournit :
+Chaque tag `vMAJOR.MINOR.PATCH` produit les artefacts suivants :
 
-| Fichier (à venir) | Description |
+| Fichier | Description |
 | --- | --- |
 | `Watcher-Setup.zip` | Archive PyInstaller Windows signée et empaquetée. |
 | `Watcher-Setup.zip.sigstore` | Bundle Sigstore pour vérifier la signature du binaire Windows (`sigstore verify identity --bundle ...`). |
@@ -121,7 +135,7 @@ Les artefacts générés par le workflow `release.yml` seront listés ici dès l
 
 ### Vérifier les artefacts publiés
 
-Une fois la release `v0.4.0` publiée, validez l'authenticité et l'intégrité des binaires téléchargés :
+Validez l'authenticité et l'intégrité des artefacts téléchargés pour un tag donné :
 
 ```bash
 # 1. Télécharger tous les fichiers nécessaires (binaire + SBOM + provenance)
@@ -149,7 +163,7 @@ slsa-verifier verify-artifact \
 sha256sum Watcher-Setup.zip Watcher-linux-x86_64.tar.gz Watcher-macos-x86_64.zip
 ```
 
-- Remplacez `<VERSION>` par le tag SemVer effectivement publié (ex. `v0.4.0`).
+- Remplacez `<VERSION>` par le tag SemVer effectivement publié (ex. `v0.4.1`).
 - Pour Linux/macOS, comparez le `sha256sum` obtenu avec les empreintes publiées dans la release.
 - Les SBOM (`Watcher-*-sbom.json`) peuvent être explorés avec `jq`, importés dans un scanner CycloneDX ou
   validés via `cyclonedx-py validate Watcher-sbom.json`.

--- a/app/cli.py
+++ b/app/cli.py
@@ -3,14 +3,17 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import suppress
 from importlib import resources
 from pathlib import Path
-from typing import Sequence
+from typing import Iterable, Sequence
 
 from config import get_settings
 
 from app.core.engine import Engine
 from app.core.reproducibility import set_seed
+from app.embeddings.store import SimpleVectorStore
+from app.llm import rag
 from app.tools import plugins
 
 
@@ -101,6 +104,56 @@ def main(argv: Sequence[str] | None = None) -> int:
         help="Nom du modèle local à utiliser (optionnel).",
     )
 
+    ask_parser = sub.add_parser(
+        "ask",
+        help="Poser une question avec RAG local et obtenir une réponse déterministe",
+    )
+    ask_parser.add_argument("question", help="Question à poser à l'assistant.")
+    ask_parser.add_argument(
+        "--top-k",
+        type=int,
+        default=3,
+        help="Nombre de passages récupérés depuis la mémoire vectorielle.",
+    )
+    ask_parser.add_argument(
+        "--namespace",
+        default="default",
+        help="Espace de noms de la base vectorielle locale à interroger.",
+    )
+    ask_parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Force l'exécution hors-ligne avant la génération.",
+    )
+
+    ingest_parser = sub.add_parser(
+        "ingest",
+        help="Ingestion de fichiers locaux dans la mémoire vectorielle",
+    )
+    ingest_parser.add_argument(
+        "sources",
+        nargs="+",
+        help="Fichiers ou dossiers contenant du texte à indexer.",
+    )
+    ingest_parser.add_argument(
+        "--namespace",
+        default="default",
+        help="Espace de noms cible dans la base vectorielle.",
+    )
+    ingest_parser.add_argument(
+        "--pattern",
+        action="append",
+        dest="patterns",
+        default=None,
+        help="Patron glob à utiliser lors de l'exploration récursive (par défaut: *.md, *.txt).",
+    )
+    ingest_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=32,
+        help="Nombre maximum de documents traités par lot.",
+    )
+
     args = parser.parse_args(argv)
 
     set_seed(args.seed)
@@ -135,8 +188,80 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(answer)
         return 0
 
+    if args.command == "ask":
+        if args.top_k < 1:
+            parser.error("--top-k doit être un entier strictement positif")
+        engine = Engine()
+        offline = args.offline or settings.intelligence.mode.lower() == "offline"
+        if offline:
+            engine.set_offline(True)
+        store = SimpleVectorStore(namespace=args.namespace)
+        answer = rag.answer_question(
+            args.question,
+            k=args.top_k,
+            client=engine.client,
+            store=store,
+        )
+        print(answer)
+        return 0
+
+    if args.command == "ingest":
+        if args.batch_size < 1:
+            parser.error("--batch-size doit être >= 1")
+        patterns = args.patterns or ["*.md", "*.txt"]
+        sources = [_resolve_source(Path(raw)) for raw in args.sources]
+        store = SimpleVectorStore(namespace=args.namespace)
+        total = 0
+        batch_texts: list[str] = []
+        batch_meta: list[dict[str, str]] = []
+        for file in _iter_source_files(sources, patterns):
+            try:
+                text = file.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                text = file.read_text(encoding="utf-8", errors="ignore")
+            text = text.strip()
+            if not text:
+                continue
+            batch_texts.append(text)
+            batch_meta.append({"path": str(file)})
+            total += 1
+            if len(batch_texts) >= args.batch_size:
+                store.add(batch_texts, batch_meta)
+                batch_texts.clear()
+                batch_meta.clear()
+        if batch_texts:
+            store.add(batch_texts, batch_meta)
+        print(
+            f"Ingestion terminée: {total} document(s) indexé(s) dans le namespace '{args.namespace}'."
+        )
+        return 0
+
     parser.error("unknown command")
     return 2
+
+
+def _resolve_source(path: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(f"Source introuvable: {path}")
+    return resolved
+
+
+def _iter_source_files(paths: Iterable[Path], patterns: Sequence[str]) -> Iterable[Path]:
+    for base in paths:
+        if base.is_file():
+            yield base
+            continue
+        if base.is_dir():
+            for pattern in patterns:
+                for candidate in base.rglob(pattern):
+                    if candidate.is_file():
+                        yield candidate
+            continue
+        with suppress(FileNotFoundError):
+            resolved = base.resolve()
+            if resolved.is_file():
+                yield resolved
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation helper

--- a/app/configuration.py
+++ b/app/configuration.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Mapping
 
+import logging
+
 from pydantic import Field, field_validator
 from pydantic_settings import (
     BaseSettings,

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -10,7 +10,6 @@ model = "smollm-135m-instruct-Q4_0"
 host = "127.0.0.1:11434"
 model_path = "models/llm/smollm-135m-instruct.Q4_0.gguf"
 ctx = 2048
-threads = null
 max_tokens = 256
 temperature = 0.2
 system_prompt = "Tu es Watcher, un assistant de développement Python fonctionnant hors ligne. Fournis des réponses concises et fiables."

--- a/docs/offline_guide.md
+++ b/docs/offline_guide.md
@@ -7,7 +7,7 @@ contrôles d'intégrité.
 
 ## 1. Préparer le kit hors-ligne sur une machine connectée
 
-1. **Téléchargez les artefacts de release** depuis GitHub pour le tag ciblé (le lien [releases/latest](https://github.com/francis18georges-png/Watcher/releases/latest) pointe toujours vers la version en cours) :
+1. **Téléchargez les artefacts de release** depuis GitHub pour le tag ciblé (le lien [releases/latest](https://github.com/francis18georges-png/Watcher/releases/latest) pointe vers la dernière version publiée ; tant qu'aucune release n'est disponible le lien renvoie 404) :
 
    ```bash
    mkdir -p ~/watcher-offline-kit/artifacts
@@ -25,7 +25,7 @@ contrôles d'intégrité.
    Le CLI `gh` facilite le téléchargement groupé ; à défaut, récupérez les mêmes fichiers via
    l'interface web ou `curl -L -O`.
 
-2. **Constituez un miroir PyPI minimal** contenant les dépendances Python nécessaires :
+2. **Constituez un miroir PyPI minimal** contenant les dépendances Python nécessaires et préparez les modèles hors-ligne :
 
    ```bash
    cd ~/watcher-offline-kit
@@ -34,6 +34,10 @@ contrôles d'intégrité.
    pip install --upgrade pip wheel
    pip download -r /workspace/Watcher/requirements.txt --dest ./pypi-mirror
    pip download -r /workspace/Watcher/requirements-dev.txt --dest ./pypi-mirror
+   cd /workspace/Watcher
+   scripts/setup-local-models.sh \
+     --model-dir ~/watcher-offline-kit/models/llm \
+     --embeddings-dir ~/watcher-offline-kit/models/embeddings
    deactivate
    ```
 
@@ -122,13 +126,15 @@ artefacts validés.
    - Linux : `tar -xzf Watcher-linux-x86_64.tar.gz -C /opt/watcher` puis `ln -sf /opt/watcher/Watcher /usr/local/bin/watcher`.
    - macOS : `unzip Watcher-macos-x86_64.zip` et placez l'application dans `/Applications`.
 
-3. **Configurer l'environnement** :
+3. **Configurer l'environnement et initialiser les index locaux** :
 
    - Dupliquez `example.env` en `.env` et renseignez les clés API locales.
    - Mettez à jour les chemins de stockage dans `config/settings.yaml` pour pointer vers des
      répertoires internes à l'enclave.
    - Activez, si nécessaire, le mode `offline` dans la configuration afin de désactiver les
-     intégrations nécessitant Internet.
+     intégrations nécessitant Internet (`watcher mode offline`).
+   - Lancez `watcher ingest /chemin/vers/docs --namespace production` pour indexer vos
+     documents avant d'utiliser `watcher ask` hors-ligne.
 
 ## 4. Mettre à jour le kit hors-ligne
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 pythonpath = .
+markers =
+    e2e_offline: Tests end-to-end offline execution without accès réseau.
 

--- a/scripts/setup-local-models.sh
+++ b/scripts/setup-local-models.sh
@@ -71,6 +71,16 @@ if downloaded.resolve() != target.resolve():
         target.unlink()
     downloaded.rename(target)
 PY
+  python - <<'PY'
+from hashlib import sha256
+from pathlib import Path
+
+target = Path("${LLM_TARGET}")
+digest = sha256(target.read_bytes()).hexdigest()
+sha_file = target.with_suffix(target.suffix + ".sha256")
+sha_file.write_text(f"{digest}  {target.name}\n", encoding="utf-8")
+print(f"SHA256({target.name})={digest}")
+PY
 else
   echo "Modèle llama.cpp déjà présent (${LLM_TARGET})."
 fi

--- a/tests/test_e2e_offline.py
+++ b/tests/test_e2e_offline.py
@@ -1,0 +1,35 @@
+"""End-to-end smoke tests executed in offline mode."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.e2e_offline
+def test_cli_run_offline(tmp_path):
+    """`watcher run --offline` returns the deterministic fallback response."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    env = os.environ.copy()
+    env["WATCHER_PATHS__BASE_DIR"] = str(tmp_path)
+    env["WATCHER_MEMORY__DB_PATH"] = "memory/e2e.db"
+    env["WATCHER_INTELLIGENCE__MODE"] = "offline"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "app.cli", "run", "--offline", "--prompt", "Ping?"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    stdout = result.stdout.strip()
+    expected = "Voici quelques détails supplémentaires., manque de politesse"
+    assert stdout in {expected, f"Echo: Ping?"}

--- a/tests/test_watcher_cli.py
+++ b/tests/test_watcher_cli.py
@@ -22,6 +22,7 @@ def _stub_cli_settings(monkeypatch):
     settings = SimpleNamespace(
         llm=SimpleNamespace(backend="stub-backend", model="stub-model"),
         training=SimpleNamespace(seed=42),
+        intelligence=SimpleNamespace(mode="offline"),
     )
     monkeypatch.setattr(cli, "get_settings", lambda: settings)
     return settings
@@ -76,3 +77,114 @@ def test_plugin_list_imported_without_root_manifest(tmp_path, capsys):
             _assert_lists_hello(capsys, module.main(["plugin", "list"]))
     finally:
         importlib.reload(module)
+
+
+def test_run_command_sets_offline_and_uses_engine(monkeypatch, capsys):
+    class DummyClient:
+        backend = "llama.cpp"
+
+        def __init__(self) -> None:
+            self.model_path = Path("/tmp/model.gguf")
+
+    class DummyEngine:
+        def __init__(self) -> None:
+            self.client = DummyClient()
+            self.offline = False
+            self.prompt = None
+
+        def set_offline(self, value: bool) -> None:
+            self.offline = bool(value)
+
+        def chat(self, prompt: str) -> str:
+            self.prompt = prompt
+            return "stub-answer"
+
+    engine = DummyEngine()
+    monkeypatch.setattr(cli, "Engine", lambda: engine)
+
+    exit_code = cli.main(["run", "--prompt", "Salut", "--offline"])
+
+    assert exit_code == 0
+    assert engine.offline is True
+    assert engine.prompt == "Salut"
+    captured = capsys.readouterr()
+    assert "stub-answer" in captured.out
+
+
+def test_ask_command_uses_rag(monkeypatch, capsys):
+    class DummyEngine:
+        def __init__(self) -> None:
+            self.offline = False
+            self.client = object()
+
+        def set_offline(self, value: bool) -> None:
+            self.offline = bool(value)
+
+    engine = DummyEngine()
+    monkeypatch.setattr(cli, "Engine", lambda: engine)
+
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_answer(question: str, *, client, store, k: int) -> str:
+        captured_kwargs.update(
+            {"question": question, "client": client, "store": store, "k": k}
+        )
+        return "réponse déterministe"
+
+    monkeypatch.setattr(cli.rag, "answer_question", _fake_answer)
+
+    class DummyStore:
+        def __init__(self, namespace: str) -> None:
+            self.namespace = namespace
+
+    monkeypatch.setattr(cli, "SimpleVectorStore", DummyStore)
+
+    exit_code = cli.main(["ask", "Que fais-tu?", "--top-k", "2", "--namespace", "docs"])
+
+    assert exit_code == 0
+    assert engine.offline is True  # hérite de l'environnement offline par défaut
+    assert captured_kwargs["question"] == "Que fais-tu?"
+    assert captured_kwargs["k"] == 2
+    assert isinstance(captured_kwargs["store"], DummyStore)
+    assert captured_kwargs["store"].namespace == "docs"
+    captured = capsys.readouterr()
+    assert "réponse déterministe" in captured.out
+
+
+def test_ingest_command_reads_files(monkeypatch, tmp_path, capsys):
+    file_a = tmp_path / "a.md"
+    file_a.write_text("Contenu A", encoding="utf-8")
+    dir_b = tmp_path / "docs"
+    dir_b.mkdir()
+    file_b = dir_b / "b.txt"
+    file_b.write_text("Contenu B", encoding="utf-8")
+
+    added: list[tuple[list[str], list[dict[str, str]]]] = []
+
+    class DummyStore:
+        def __init__(self, namespace: str) -> None:
+            self.namespace = namespace
+
+        def add(self, texts, metas) -> None:  # pragma: no cover - runtime validated
+            added.append((list(texts), list(metas)))
+
+    monkeypatch.setattr(cli, "SimpleVectorStore", DummyStore)
+
+    exit_code = cli.main(
+        [
+            "ingest",
+            str(file_a),
+            str(dir_b),
+            "--namespace",
+            "tests",
+            "--batch-size",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    flat_texts = [text for batch, _ in added for text in batch]
+    assert "Contenu A" in flat_texts
+    assert "Contenu B" in flat_texts
+    captured = capsys.readouterr()
+    assert "namespace 'tests'" in captured.out


### PR DESCRIPTION
## Summary
- add offline-friendly CLI flows including `watcher ask` and `watcher ingest`
- document offline setup, demo recipe, and GitHub Pages requirements
- provide deterministic offline smoke test and hash export for local models

## Testing
- pytest tests/test_watcher_cli.py tests/test_e2e_offline.py

------
https://chatgpt.com/codex/tasks/task_e_68df8b47d5888320939f95e36ab002c6