### PR TITLE
Add static policy check session for offline readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
+      id-token: write
     steps:
       - name: Validate SemVer tag
         run: |
@@ -88,6 +90,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      packages: write
     outputs:
       artifact-sha256: ${{ steps.artifact-digest.outputs.sha256 }}
     steps:
@@ -186,6 +189,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
+      packages: write
     env:
       APPLE_CODESIGN_P12: ${{ secrets.APPLE_CODESIGN_P12 }}
       APPLE_CODESIGN_P12_PASSWORD: ${{ secrets.APPLE_CODESIGN_P12_PASSWORD }}
@@ -389,6 +393,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/QA.md
+++ b/QA.md
@@ -52,6 +52,8 @@
   `pytest --cov-fail-under=90` exécuté dans la session Nox `tests`.
 * Le rapport de couverture différentiel doit rester à `100 %`. Le job `coverage` échoue si
   `diff-cover` détecte une baisse (seuil configuré avec `DIFF_COVER_FAIL_UNDER=100`).
+* Exécutez `nox -s policy` pour valider hors-ligne les exigences de diffusion : cohérence de version,
+  documentation offline, configuration multi-arch Docker et permissions de token pour la release.
 * The Windows job invokes `./installer.ps1 -SkipOllama` to validate that the PowerShell installer succeeds
   without the Ollama models.
 * Immediately afterwards the workflow launches `./run.ps1` with an empty `DISPLAY` variable to emulate

--- a/noxfile.py
+++ b/noxfile.py
@@ -45,7 +45,7 @@ SBOM_DIRECTORY = SBOM_PATH.parent
 DEFAULT_COMPARE_BRANCH = "origin/main"
 DIFF_COVER_FAIL_UNDER = 100
 
-nox.options.sessions = ("lint", "typecheck", "tests", "coverage", "build", "security")
+nox.options.sessions = ("lint", "typecheck", "tests", "coverage", "build", "security", "policy")
 nox.options.reuse_existing_virtualenvs = True
 
 
@@ -201,3 +201,10 @@ def build(session: nox.Session) -> None:
     """Build the project wheel and source distribution."""
     install_project(session, "build")
     session.run("python", "-m", "build")
+
+
+@nox.session(python="3.12")
+def policy(session: nox.Session) -> None:
+    """Run static policy checks covering offline and release requirements."""
+
+    session.run("python", "scripts/static_policy_checks.py")

--- a/scripts/static_policy_checks.py
+++ b/scripts/static_policy_checks.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+"""Static validations for release, offline, and distribution policies."""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    message: str
+    hint: str | None = None
+
+
+def read_text(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def ensure(condition: bool, name: str, message: str, hint: str | None = None) -> CheckResult:
+    return CheckResult(name=name, passed=bool(condition), message=message, hint=hint)
+
+
+def check_version_alignment() -> CheckResult:
+    """Ensure the changelog version matches the project metadata."""
+    import tomllib  # Python 3.11+
+
+    pyproject = tomllib.loads(read_text("pyproject.toml"))
+    version = pyproject["project"]["version"]
+    changelog = read_text("CHANGELOG.md")
+    match = re.search(r"^## \[(v?\d+\.\d+\.\d+)\]", changelog, flags=re.MULTILINE)
+    expected = f"v{version}"
+    return ensure(
+        bool(match) and match.group(1) == expected,
+        "Version alignment",
+        f"Latest changelog entry should match project version ({expected}).",
+        "Update CHANGELOG.md to point to the current pyproject version or bump the metadata.",
+    )
+
+
+def check_readme_offline_instructions() -> CheckResult:
+    content = read_text("README.md")
+    pattern = r"watcher run --offline"
+    return ensure(
+        re.search(pattern, content) is not None,
+        "README offline quickstart",
+        "README must document the offline CLI invocation.",
+        "Document an offline command example (watcher run --offline --prompt ...).",
+    )
+
+
+def check_offline_doc_page() -> CheckResult:
+    mkdocs = read_text("mkdocs.yml")
+    doc_exists = (REPO_ROOT / "docs" / "offline_guide.md").exists()
+    return ensure(
+        "offline_guide.md" in mkdocs and doc_exists,
+        "Offline guide page",
+        "MkDocs configuration should expose the offline guide.",
+        "Reference docs/offline_guide.md from mkdocs.yml and keep the file present.",
+    )
+
+
+def check_offline_e2e_test() -> CheckResult:
+    tests = read_text("tests/test_e2e_offline.py")
+    markers = "@pytest.mark.e2e_offline" in tests
+    command = "watcher run --offline" in tests
+    return ensure(
+        markers and command,
+        "Offline E2E test",
+        "Offline pytest scenario must exist and call watcher run --offline.",
+        "Add a pytest.mark.e2e_offline test covering watcher run --offline",
+    )
+
+
+def check_docker_multiarch() -> CheckResult:
+    workflow = read_text(".github/workflows/docker.yml")
+    return ensure(
+        "platforms: linux/amd64,linux/arm64" in workflow,
+        "Docker multi-arch",
+        "Docker workflow must publish both amd64 and arm64 manifests.",
+        "Configure docker/build-push-action with --platform linux/amd64,linux/arm64.",
+    )
+
+
+def check_release_permissions() -> CheckResult:
+    workflow = read_text(".github/workflows/release.yml")
+    has_contents = "contents: write" in workflow
+    has_packages = "packages: write" in workflow
+    has_id_token = "id-token: write" in workflow
+    return ensure(
+        has_contents and has_packages and has_id_token,
+        "Release token permissions",
+        "Release workflow should request contents, packages and id-token writes.",
+        "Set permissions for contents, packages and id-token in release.yml jobs.",
+    )
+
+
+def check_model_hash_generation() -> CheckResult:
+    script = read_text("scripts/setup-local-models.sh")
+    return ensure(
+        "sha256(" in script,
+        "Model hashing",
+        "Local model bootstrap must generate SHA256 checksums.",
+        "Add a SHA256 checksum generation step to scripts/setup-local-models.sh.",
+    )
+
+
+def check_metrics_directory() -> CheckResult:
+    exists = (REPO_ROOT / "metrics").is_dir()
+    return ensure(
+        exists,
+        "Metrics directory",
+        "metrics/ directory should exist for benchmark exports.",
+        "Create a metrics/ directory committed to the repository for evaluation outputs.",
+    )
+
+
+def check_coverage_gate() -> CheckResult:
+    tests = read_text("noxfile.py")
+    return ensure(
+        "--cov-fail-under=90" in tests and "DIFF_COVER_FAIL_UNDER = 100" in tests,
+        "Coverage gates",
+        "Nox sessions must enforce coverage >=90% and diff coverage 100%.",
+        "Update noxfile.py to set --cov-fail-under=90 and DIFF_COVER_FAIL_UNDER=100.",
+    )
+
+
+def main() -> int:
+    checks = [
+        check_version_alignment(),
+        check_readme_offline_instructions(),
+        check_offline_doc_page(),
+        check_offline_e2e_test(),
+        check_docker_multiarch(),
+        check_release_permissions(),
+        check_model_hash_generation(),
+        check_metrics_directory(),
+        check_coverage_gate(),
+    ]
+
+    failures = [check for check in checks if not check.passed]
+
+    for check in checks:
+        status = "PASS" if check.passed else "FAIL"
+        print(f"[{status}] {check.name}: {check.message}")
+        if not check.passed and check.hint:
+            print(f"    Hint: {check.hint}")
+
+    if failures:
+        print(f"\n{len(failures)} check(s) failed.")
+        return 1
+
+    print("\nAll static policy checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a static policy checker to cover offline documentation, version alignment, and distribution settings
- expose the check through a new default Nox session and document how to run it
- request the required package and id-token permissions in the release workflow

## Testing
- python scripts/static_policy_checks.py

------
https://chatgpt.com/codex/tasks/task_e_68df9291b8f48320a6d083860c712de4