### PR TITLE
Add autopilot scheduler and CLI controls

### DIFF
--- a/app/autopilot/__init__.py
+++ b/app/autopilot/__init__.py
@@ -1,0 +1,19 @@
+"""Autopilot orchestration utilities."""
+
+from .scheduler import (
+    AutopilotError,
+    AutopilotLogEntry,
+    AutopilotScheduler,
+    AutopilotState,
+    ResourceProbe,
+    ResourceUsage,
+)
+
+__all__ = [
+    "AutopilotError",
+    "AutopilotLogEntry",
+    "AutopilotScheduler",
+    "AutopilotState",
+    "ResourceProbe",
+    "ResourceUsage",
+]

--- a/app/autopilot/scheduler.py
+++ b/app/autopilot/scheduler.py
@@ -1,0 +1,329 @@
+"""Supervised autopilot scheduler enforcing policy constraints."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, time
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+from app.policy.manager import PolicyError, PolicyManager
+from app.policy.schema import Policy, TimeWindow, _parse_window
+
+try:  # pragma: no cover - optional dependency
+    import psutil  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - fallback
+    from app.utils import psutil_stub as psutil  # type: ignore[assignment]
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ResourceUsage:
+    """Snapshot of host resource usage."""
+
+    cpu_percent: float
+    ram_mb: float
+
+
+class ResourceProbe:
+    """Callable helper returning :class:`ResourceUsage` snapshots."""
+
+    def snapshot(self) -> ResourceUsage:
+        mem = psutil.virtual_memory()
+        return ResourceUsage(
+            cpu_percent=float(psutil.cpu_percent(interval=None)),
+            ram_mb=float(mem.used / (1024 * 1024)),
+        )
+
+
+@dataclass
+class AutopilotLogEntry:
+    """In-memory representation of a scheduler log entry."""
+
+    timestamp: str
+    level: str
+    message: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"timestamp": self.timestamp, "level": self.level, "message": self.message}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, str]) -> "AutopilotLogEntry":
+        return cls(
+            timestamp=str(data.get("timestamp", "")),
+            level=str(data.get("level", "INFO")),
+            message=str(data.get("message", "")),
+        )
+
+
+@dataclass
+class AutopilotState:
+    """Persisted autopilot scheduler state."""
+
+    enabled: bool = False
+    online: bool = False
+    queue: list[str] = field(default_factory=list)
+    current_topic: str | None = None
+    last_check: str | None = None
+    last_reason: str | None = None
+    logs: list[AutopilotLogEntry] = field(default_factory=list)
+    last_cpu_percent: float | None = None
+    last_ram_mb: float | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "enabled": self.enabled,
+            "online": self.online,
+            "queue": list(self.queue),
+            "current_topic": self.current_topic,
+            "last_check": self.last_check,
+            "last_reason": self.last_reason,
+            "logs": [entry.to_dict() for entry in self.logs],
+            "last_cpu_percent": self.last_cpu_percent,
+            "last_ram_mb": self.last_ram_mb,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> "AutopilotState":
+        logs = [
+            AutopilotLogEntry.from_dict(item)
+            for item in data.get("logs", [])  # type: ignore[arg-type]
+        ]
+        return cls(
+            enabled=bool(data.get("enabled", False)),
+            online=bool(data.get("online", False)),
+            queue=list(data.get("queue", [])),  # type: ignore[arg-type]
+            current_topic=data.get("current_topic"),  # type: ignore[arg-type]
+            last_check=data.get("last_check"),  # type: ignore[arg-type]
+            last_reason=data.get("last_reason"),  # type: ignore[arg-type]
+            logs=logs,
+            last_cpu_percent=data.get("last_cpu_percent"),  # type: ignore[arg-type]
+            last_ram_mb=data.get("last_ram_mb"),  # type: ignore[arg-type]
+        )
+
+
+class AutopilotError(RuntimeError):
+    """Raised when the autopilot scheduler cannot continue."""
+
+
+class AutopilotScheduler:
+    """Plan and toggle network access according to the user policy."""
+
+    def __init__(
+        self,
+        *,
+        policy_loader: Callable[[], Policy] | None = None,
+        policy_manager: PolicyManager | None = None,
+        state_path: Path | None = None,
+        resource_probe: ResourceProbe | None = None,
+        clock: Callable[[], datetime] | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        if policy_loader is None:
+            if policy_manager is None:
+                policy_manager = PolicyManager()
+            policy_loader = policy_manager._read_policy
+        self._policy_loader = policy_loader
+        self._policy_manager = policy_manager
+        if state_path is None:
+            base_dir = (
+                policy_manager.config_dir
+                if policy_manager is not None
+                else Path.home() / ".watcher"
+            )
+            state_path = base_dir / "autopilot-state.json"
+        self.state_path = state_path
+        self.state_path.parent.mkdir(parents=True, exist_ok=True)
+        self._resource_probe = resource_probe or ResourceProbe()
+        self._clock = clock or datetime.utcnow
+        self._logger = logger or LOGGER
+        self.state = self._load_state()
+
+    # ------------------------------------------------------------------
+    # Public API
+
+    def enable(
+        self,
+        topics: Sequence[str] | str,
+        *,
+        engine=None,
+        now: datetime | None = None,
+    ) -> AutopilotState:
+        normalised = self._normalise_topics(topics)
+        if not normalised:
+            raise AutopilotError("aucun sujet fourni")
+        for topic in normalised:
+            if topic not in self.state.queue:
+                self.state.queue.append(topic)
+        self.state.enabled = True
+        self._log("info", f"Activation avec {', '.join(normalised)}")
+        return self.evaluate(engine=engine, now=now)
+
+    def disable(
+        self,
+        topics: Sequence[str] | str | None = None,
+        *,
+        engine=None,
+        now: datetime | None = None,
+    ) -> AutopilotState:
+        normalised = self._normalise_topics(topics) if topics else []
+        if normalised:
+            removed = {topic for topic in normalised if topic in self.state.queue}
+            if removed:
+                self._log("info", f"Sujets retirés: {', '.join(sorted(removed))}")
+            self.state.queue = [topic for topic in self.state.queue if topic not in removed]
+        else:
+            if self.state.queue:
+                self._log("info", "File d'attente vidée.")
+            self.state.queue.clear()
+        if self.state.enabled:
+            self.state.enabled = False
+            self.state.online = False
+            self.state.current_topic = None
+            self.state.last_reason = "désactivé"
+            self._log("info", "Autopilot désactivé.")
+        now = now or self._clock()
+        self.state.last_check = self._timestamp(now)
+        self._save_state()
+        if engine is not None:
+            engine.set_offline(True)
+        return self.state
+
+    def evaluate(
+        self,
+        *,
+        engine=None,
+        now: datetime | None = None,
+    ) -> AutopilotState:
+        now = now or self._clock()
+        self.state.last_check = self._timestamp(now)
+        if not self.state.enabled:
+            self.state.online = False
+            self.state.current_topic = None
+            self.state.last_reason = "désactivé"
+            if engine is not None:
+                engine.set_offline(True)
+            self._save_state()
+            return self.state
+        try:
+            policy = self._policy_loader()
+        except PolicyError as exc:
+            message = f"policy.yaml invalide: {exc}"
+            self._log("error", message)
+            self.state.enabled = False
+            self.state.online = False
+            self.state.last_reason = "policy introuvable"
+            self.state.current_topic = None
+            self._save_state()
+            if engine is not None:
+                engine.set_offline(True)
+            raise AutopilotError(message) from exc
+        usage = self._resource_probe.snapshot()
+        self.state.last_cpu_percent = usage.cpu_percent
+        self.state.last_ram_mb = usage.ram_mb
+        allowed = self._is_within_window(policy.network.allowed_windows, now)
+        budgets_ok = self._within_budgets(policy, usage)
+        if self.state.queue:
+            self.state.current_topic = self.state.queue[0]
+        else:
+            self.state.current_topic = None
+        reason = None
+        should_online = allowed and budgets_ok and bool(self.state.queue)
+        if not allowed:
+            reason = "hors fenêtre réseau"
+        elif not budgets_ok:
+            reason = "budgets dépassés"
+        elif not self.state.queue:
+            reason = "file d'attente vide"
+        if should_online:
+            if not self.state.online:
+                self._log("info", "Autopilot en ligne – exécution autorisée.")
+            self.state.online = True
+            self.state.last_reason = "ok"
+            if engine is not None:
+                engine.set_offline(False)
+        else:
+            if self.state.online or self.state.last_reason != reason:
+                level = "info" if reason == "file d'attente vide" else "warning"
+                self._log(level, f"Autopilot hors ligne ({reason}).")
+            self.state.online = False
+            self.state.last_reason = reason
+            self.state.current_topic = None if reason != "file d'attente vide" else self.state.current_topic
+            if engine is not None:
+                engine.set_offline(True)
+        self._save_state()
+        return self.state
+
+    # ------------------------------------------------------------------
+    # Helpers
+
+    def _load_state(self) -> AutopilotState:
+        if self.state_path.exists():
+            data = json.loads(self.state_path.read_text(encoding="utf-8"))
+            state = AutopilotState.from_dict(data)
+            return state
+        state = AutopilotState()
+        self._save_state(state)
+        return state
+
+    def _save_state(self, state: AutopilotState | None = None) -> None:
+        state = state or self.state
+        payload = state.to_dict()
+        self.state_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+    def _log(self, level: str, message: str) -> None:
+        timestamp = self._timestamp(self._clock())
+        entry = AutopilotLogEntry(timestamp=timestamp, level=level.upper(), message=message)
+        self.state.logs.append(entry)
+        if len(self.state.logs) > 100:
+            self.state.logs = self.state.logs[-100:]
+        level_value = getattr(logging, level.upper(), logging.INFO)
+        self._logger.log(level_value, message)
+
+    def _timestamp(self, value: datetime) -> str:
+        return value.replace(microsecond=0).isoformat()
+
+    def _normalise_topics(self, topics: Sequence[str] | str | None) -> list[str]:
+        if topics is None:
+            return []
+        if isinstance(topics, str):
+            raw_items: Iterable[str] = topics.split(",")
+        else:
+            raw_items = []
+            for topic in topics:
+                raw_items.extend(str(topic).split(","))
+        cleaned: list[str] = []
+        for item in raw_items:
+            normalised = item.strip()
+            if not normalised:
+                continue
+            if normalised not in cleaned:
+                cleaned.append(normalised)
+        return cleaned
+
+    def _is_within_window(self, windows: Sequence[TimeWindow], now: datetime) -> bool:
+        if not windows:
+            return False
+        weekday = now.strftime("%a").lower()[:3]
+        current = now.time().replace(second=0, microsecond=0)
+        for window in windows:
+            if weekday not in window.days:
+                continue
+            start, end = self._parse_window(window.window)
+            if start <= current < end:
+                return True
+        return False
+
+    def _parse_window(self, value: str) -> tuple[time, time]:
+        start, end = _parse_window(value)
+        return start, end
+
+    def _within_budgets(self, policy: Policy, usage: ResourceUsage) -> bool:
+        cpu_ok = usage.cpu_percent <= policy.budgets.cpu_percent
+        ram_ok = usage.ram_mb <= policy.budgets.ram_mb
+        return cpu_ok and ram_ok
+

--- a/tests/test_autopilot.py
+++ b/tests/test_autopilot.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from app.autopilot import AutopilotError, AutopilotScheduler, ResourceProbe, ResourceUsage
+from app.policy.schema import (
+    Budgets,
+    Categories,
+    Defaults,
+    ModelEntry,
+    ModelsSection,
+    NetworkSection,
+    Policy,
+    Subject,
+    TimeWindow,
+)
+
+
+class DummyEngine:
+    def __init__(self) -> None:
+        self.offline: list[bool] = []
+
+    def set_offline(self, value: bool) -> None:  # pragma: no cover - executed in tests
+        self.offline.append(bool(value))
+
+
+class DummyProbe(ResourceProbe):
+    def __init__(self, usage: ResourceUsage) -> None:
+        self._usage = usage
+
+    def snapshot(self) -> ResourceUsage:  # pragma: no cover - executed in tests
+        return self._usage
+
+    def set_usage(self, usage: ResourceUsage) -> None:
+        self._usage = usage
+
+
+def _policy() -> Policy:
+    now = datetime(2024, 1, 1, 10, 0, 0)
+    return Policy(
+        version=1,
+        subject=Subject(hostname="test-host", generated_at=now),
+        defaults=Defaults(),
+        network=NetworkSection(
+            allowed_windows=[TimeWindow(days=["mon", "tue"], window="08:00-20:00")],
+            bandwidth_mb=500,
+            time_budget_minutes=120,
+            allowlist=[],
+        ),
+        budgets=Budgets(cpu_percent=50, ram_mb=1024),
+        categories=Categories(allowed=[]),
+        models=ModelsSection(
+            llm=ModelEntry(name="llm", sha256="abc", license="MIT"),
+            embedding=ModelEntry(name="embed", sha256="def", license="MIT"),
+        ),
+    )
+
+
+def test_scheduler_enables_and_tracks_queue(tmp_path):
+    usage = ResourceUsage(cpu_percent=10, ram_mb=256)
+    probe = DummyProbe(usage)
+    engine = DummyEngine()
+    scheduler = AutopilotScheduler(
+        policy_loader=_policy,
+        state_path=tmp_path / "state.json",
+        resource_probe=probe,
+    )
+
+    state = scheduler.enable(["docs"], engine=engine, now=datetime(2024, 1, 1, 10, 0, 0))
+
+    assert state.enabled is True
+    assert state.online is True
+    assert state.queue == ["docs"]
+    assert state.current_topic == "docs"
+    assert state.last_reason == "ok"
+    assert engine.offline[-1] is False
+    assert state.logs, "Logs should record activation"
+
+    reloaded = AutopilotScheduler(
+        policy_loader=_policy,
+        state_path=tmp_path / "state.json",
+        resource_probe=probe,
+    )
+    assert reloaded.state.queue == ["docs"]
+
+
+def test_scheduler_respects_time_windows(tmp_path):
+    usage = ResourceUsage(cpu_percent=10, ram_mb=256)
+    probe = DummyProbe(usage)
+    engine = DummyEngine()
+    scheduler = AutopilotScheduler(
+        policy_loader=_policy,
+        state_path=tmp_path / "state.json",
+        resource_probe=probe,
+    )
+
+    scheduler.enable(["docs"], engine=engine, now=datetime(2024, 1, 1, 9, 0, 0))
+    state = scheduler.evaluate(engine=engine, now=datetime(2024, 1, 1, 22, 0, 0))
+
+    assert state.online is False
+    assert state.last_reason == "hors fenêtre réseau"
+    assert engine.offline[-1] is True
+
+
+def test_scheduler_respects_resource_budgets(tmp_path):
+    probe = DummyProbe(ResourceUsage(cpu_percent=10, ram_mb=256))
+    engine = DummyEngine()
+    scheduler = AutopilotScheduler(
+        policy_loader=_policy,
+        state_path=tmp_path / "state.json",
+        resource_probe=probe,
+    )
+
+    scheduler.enable(["docs"], engine=engine, now=datetime(2024, 1, 1, 10, 0, 0))
+    probe.set_usage(ResourceUsage(cpu_percent=80, ram_mb=256))
+    state = scheduler.evaluate(engine=engine, now=datetime(2024, 1, 1, 10, 5, 0))
+
+    assert state.online is False
+    assert state.last_reason == "budgets dépassés"
+    assert engine.offline[-1] is True
+
+
+def test_enable_requires_topics(tmp_path):
+    scheduler = AutopilotScheduler(
+        policy_loader=_policy,
+        state_path=tmp_path / "state.json",
+        resource_probe=DummyProbe(ResourceUsage(cpu_percent=10, ram_mb=256)),
+    )
+
+    with pytest.raises(AutopilotError):
+        scheduler.enable([], now=datetime(2024, 1, 1, 10, 0, 0))

--- a/tests/test_cli_autopilot.py
+++ b/tests/test_cli_autopilot.py
@@ -1,0 +1,114 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app import cli
+from app.autopilot import AutopilotState
+
+
+class DummyEngine:
+    def __init__(self) -> None:
+        self.offline: list[bool] = []
+
+    def set_offline(self, value: bool) -> None:  # pragma: no cover - executed in tests
+        self.offline.append(bool(value))
+
+
+class DummyScheduler:
+    def __init__(
+        self,
+        *,
+        enable_state: AutopilotState | None = None,
+        disable_state: AutopilotState | None = None,
+        evaluate_state: AutopilotState | None = None,
+    ) -> None:
+        self.enable_calls: list[list[str]] = []
+        self.disable_calls: list[list[str] | None] = []
+        self.evaluate_calls = 0
+        self._enable_state = enable_state or AutopilotState(enabled=True, online=True, queue=["foo"], last_reason="ok")
+        self._disable_state = disable_state or AutopilotState(enabled=False, online=False, queue=[])
+        self._evaluate_state = evaluate_state or self._enable_state
+
+    def enable(self, topics, *, engine=None, now=None):  # pragma: no cover - executed in tests
+        values = list(topics)
+        self.enable_calls.append(values)
+        if engine is not None:
+            engine.set_offline(not self._enable_state.online)
+        state = AutopilotState(**self._enable_state.to_dict())
+        state.queue = list(values)
+        state.current_topic = values[0] if values else None
+        return state
+
+    def disable(self, topics=None, *, engine=None, now=None):  # pragma: no cover - executed in tests
+        values = list(topics) if topics else None
+        self.disable_calls.append(values)
+        if engine is not None:
+            engine.set_offline(True)
+        return AutopilotState(**self._disable_state.to_dict())
+
+    def evaluate(self, *, engine=None, now=None):  # pragma: no cover - executed in tests
+        self.evaluate_calls += 1
+        if engine is not None:
+            engine.set_offline(not self._evaluate_state.online)
+        return AutopilotState(**self._evaluate_state.to_dict())
+
+
+@pytest.fixture(autouse=True)
+def _stub_cli_settings(monkeypatch):
+    settings = SimpleNamespace(
+        llm=SimpleNamespace(backend="stub", model="stub-model"),
+        training=SimpleNamespace(seed=42),
+        intelligence=SimpleNamespace(mode="offline"),
+    )
+    monkeypatch.setattr(cli, "get_settings", lambda: settings)
+    return settings
+
+
+def test_cli_autopilot_enable(monkeypatch, capsys):
+    engine = DummyEngine()
+    enable_state = AutopilotState(enabled=True, online=True, queue=["foo", "bar"], last_reason="ok")
+    scheduler = DummyScheduler(enable_state=enable_state)
+    monkeypatch.setattr(cli, "AutopilotScheduler", lambda: scheduler)
+    monkeypatch.setattr(cli, "Engine", lambda: engine)
+
+    exit_code = cli.main(["autopilot", "enable", "--topics", "foo,bar"])
+
+    assert exit_code == 0
+    assert scheduler.enable_calls == [["foo", "bar"]]
+    assert engine.offline[-1] is False
+    captured = capsys.readouterr()
+    assert "Autopilot activé (en ligne)" in captured.out
+    assert "foo, bar" in captured.out
+
+
+def test_cli_autopilot_status_offline(monkeypatch, capsys):
+    engine = DummyEngine()
+    status_state = AutopilotState(enabled=True, online=False, queue=["foo"], last_reason="hors fenêtre réseau")
+    scheduler = DummyScheduler(evaluate_state=status_state)
+    monkeypatch.setattr(cli, "AutopilotScheduler", lambda: scheduler)
+    monkeypatch.setattr(cli, "Engine", lambda: engine)
+
+    exit_code = cli.main(["autopilot", "status", "--topics", "bar"])
+
+    assert exit_code == 0
+    assert scheduler.evaluate_calls == 1
+    assert engine.offline[-1] is True
+    captured = capsys.readouterr()
+    assert "Autopilot hors ligne (hors fenêtre réseau)" in captured.out
+    assert "Sujets absents de la file: bar" in captured.out
+
+
+def test_cli_autopilot_disable(monkeypatch, capsys):
+    engine = DummyEngine()
+    disable_state = AutopilotState(enabled=False, online=False, queue=[])
+    scheduler = DummyScheduler(disable_state=disable_state)
+    monkeypatch.setattr(cli, "AutopilotScheduler", lambda: scheduler)
+    monkeypatch.setattr(cli, "Engine", lambda: engine)
+
+    exit_code = cli.main(["autopilot", "disable"])
+
+    assert exit_code == 0
+    assert scheduler.disable_calls == [None]
+    assert engine.offline[-1] is True
+    captured = capsys.readouterr()
+    assert "Autopilot désactivé" in captured.out


### PR DESCRIPTION
## Summary
- introduce an autopilot scheduler that enforces policy network windows and CPU/RAM budgets while persisting state and logs
- extend the watcher CLI with `autopilot` enable/disable/status commands wired to the scheduler and Engine offline mode
- cover the new behaviour with scheduler and CLI tests simulating policy windows and resource budgets

## Testing
- pytest tests/test_autopilot.py tests/test_cli_autopilot.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe2f877b083208d4bad107702135c