### PR TITLE
Add HTTP scraper infrastructure with robots and caching

### DIFF
--- a/app/scrapers/__init__.py
+++ b/app/scrapers/__init__.py
@@ -1,0 +1,12 @@
+"""Scraper utilities for HTTP, sitemaps and GitHub sources."""
+
+from .http import HTTPScraper, ScrapeResult
+from .sitemap import SitemapScraper
+from .github import GitHubScraper
+
+__all__ = [
+    "HTTPScraper",
+    "ScrapeResult",
+    "SitemapScraper",
+    "GitHubScraper",
+]

--- a/app/scrapers/github.py
+++ b/app/scrapers/github.py
@@ -1,0 +1,77 @@
+"""Lightweight helpers to gather GitHub repository metadata."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+from .http import HTTPScraper
+
+
+@dataclass
+class RepositoryInfo:
+    """Summary of a GitHub repository."""
+
+    repository: str
+    url: str
+    license: Optional[str]
+    metadata: Dict[str, object]
+
+
+class GitHubScraper:
+    """Fetch metadata from the GitHub REST API."""
+
+    def __init__(self, http: HTTPScraper, *, api_base: str = "https://api.github.com") -> None:
+        self.http = http
+        self.api_base = api_base.rstrip("/")
+
+    def fetch_repository(self, repo: str) -> Optional[RepositoryInfo]:
+        """Return metadata for *repo* (``owner/name`` or URL)."""
+
+        owner, name = self._parse_repository(repo)
+        if owner is None or name is None:
+            return None
+        api_url = f"{self.api_base}/repos/{owner}/{name}"
+        payload = self.http.fetch_raw(api_url, respect_robots=False)
+        if payload is None:
+            return None
+        raw, _ = payload
+        try:
+            data = json.loads(raw.decode("utf-8"))
+        except json.JSONDecodeError:
+            return None
+
+        license_name: Optional[str] = None
+        license_info = data.get("license") if isinstance(data, dict) else None
+        if isinstance(license_info, dict):
+            license_name = (
+                license_info.get("spdx_id")
+                or license_info.get("name")
+                or license_info.get("key")
+            )
+        return RepositoryInfo(
+            repository=f"{owner}/{name}",
+            url=f"https://github.com/{owner}/{name}",
+            license=license_name,
+            metadata=data if isinstance(data, dict) else {},
+        )
+
+    def _parse_repository(self, repo: str) -> tuple[Optional[str], Optional[str]]:
+        if "/" not in repo or repo.endswith("/"):
+            parsed = urlparse(repo)
+            if not parsed.netloc:
+                return None, None
+            parts = parsed.path.strip("/").split("/")
+        else:
+            parts = repo.strip("/").split("/")
+        if len(parts) < 2:
+            return None, None
+        owner, name = parts[0], parts[1]
+        if not owner or not name:
+            return None, None
+        return owner, name
+
+
+__all__ = ["GitHubScraper", "RepositoryInfo"]

--- a/app/scrapers/http.py
+++ b/app/scrapers/http.py
@@ -1,0 +1,323 @@
+"""HTTP scraping helpers with robots.txt, caching and content extraction."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, Mapping, MutableMapping, Optional
+from urllib import request as urllib_request
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlparse
+from urllib.robotparser import RobotFileParser
+import time
+
+try:  # pragma: no cover - optional dependency
+    import trafilatura  # type: ignore
+except Exception:  # pragma: no cover - fallback when unavailable
+    trafilatura = None
+
+try:  # pragma: no cover - optional dependency
+    from readability import Document  # type: ignore
+except Exception:  # pragma: no cover - fallback when unavailable
+    Document = None
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_USER_AGENT = "WatcherScraper/1.0"
+DEFAULT_TIMEOUT = 10
+DEFAULT_THROTTLE = 1.0
+
+
+class CaseInsensitiveDict(MutableMapping[str, str]):
+    """Minimal case-insensitive mapping for HTTP headers."""
+
+    def __init__(self, data: Optional[Mapping[str, str]] = None) -> None:
+        self._store: Dict[str, str] = {}
+        if data:
+            for key, value in data.items():
+                self[key] = value
+
+    def __getitem__(self, key: str) -> str:
+        return self._store[key.lower()]
+
+    def __setitem__(self, key: str, value: str) -> None:
+        self._store[key.lower()] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._store[key.lower()]
+
+    def __iter__(self) -> Iterable[str]:
+        return iter(self._store)
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        return self._store.get(key.lower(), default)
+
+    def items(self):  # pragma: no cover - forwarding helper
+        return self._store.items()
+
+    def copy(self) -> "CaseInsensitiveDict":  # pragma: no cover - helper
+        return CaseInsensitiveDict(self._store)
+
+
+@dataclass
+class ScrapeResult:
+    """Container for a scraped HTTP document."""
+
+    url: str
+    content: Optional[str]
+    raw_content: bytes
+    content_hash: Optional[str]
+    license: Optional[str]
+    headers: Mapping[str, str]
+    etag: Optional[str]
+    last_modified: Optional[str]
+    is_duplicate: bool = False
+
+
+@dataclass
+class CachedResponse:
+    """Metadata stored for a cached HTTP response."""
+
+    url: str
+    raw_content: bytes
+    headers: CaseInsensitiveDict
+    etag: Optional[str]
+    last_modified: Optional[str]
+    content: Optional[str] = None
+    content_hash: Optional[str] = None
+    license: Optional[str] = None
+    is_duplicate: bool = False
+
+    def to_result(self) -> ScrapeResult:
+        return ScrapeResult(
+            url=self.url,
+            content=self.content,
+            raw_content=self.raw_content,
+            content_hash=self.content_hash,
+            license=self.license,
+            headers=dict(self.headers.items()),
+            etag=self.etag,
+            last_modified=self.last_modified,
+            is_duplicate=self.is_duplicate,
+        )
+
+
+class HTTPScraper:
+    """High level HTTP scraper with caching and politeness controls."""
+
+    def __init__(
+        self,
+        *,
+        user_agent: str = DEFAULT_USER_AGENT,
+        timeout: int = DEFAULT_TIMEOUT,
+        throttle_delay: float = DEFAULT_THROTTLE,
+        opener: Optional[Callable[..., object]] = None,
+        time_func: Callable[[], float] | None = None,
+        sleep_func: Callable[[float], None] | None = None,
+    ) -> None:
+        self.user_agent = user_agent
+        self.timeout = timeout
+        self.throttle_delay = max(0.0, throttle_delay)
+        self._opener = opener or urllib_request.urlopen
+        self._time = time_func or time.monotonic
+        self._sleep = sleep_func or time.sleep
+        self._robots: Dict[str, RobotFileParser] = {}
+        self._cache: Dict[str, CachedResponse] = {}
+        self._url_hash: Dict[str, str] = {}
+        self._hash_urls: Dict[str, set[str]] = defaultdict(set)
+        self._last_request: Dict[str, float] = {}
+
+    def fetch(self, url: str, *, respect_robots: bool = True) -> Optional[ScrapeResult]:
+        """Fetch *url* and return a :class:`ScrapeResult` when successful."""
+
+        cached = self._get_cached(url)
+
+        response = self._perform_request(url, respect_robots=respect_robots)
+        if response is None:
+            return cached.to_result() if cached else None
+
+        if response.content is None:
+            decoded = self._decode_content(response.raw_content, response.headers)
+            response.content = self._extract_content(decoded)
+            response.content_hash = self._store_hash(url, response.content)
+            response.is_duplicate = self._hash_is_duplicate(response.content_hash)
+            response.license = detect_license(response.headers, response.content)
+
+        return response.to_result()
+
+    def fetch_raw(
+        self, url: str, *, respect_robots: bool = True
+    ) -> Optional[tuple[bytes, Mapping[str, str]]]:
+        """Fetch *url* and return the raw payload alongside headers."""
+
+        response = self._perform_request(url, respect_robots=respect_robots)
+        if response is None:
+            return None
+        return response.raw_content, dict(response.headers.items())
+
+    def _perform_request(self, url: str, *, respect_robots: bool) -> Optional[CachedResponse]:
+        if respect_robots and not self._is_allowed(url):
+            logger.info("blocked by robots.txt: %s", url)
+            return None
+
+        cached = self._get_cached(url)
+
+        domain = urlparse(url).netloc
+        self._throttle(domain)
+
+        headers = {"User-Agent": self.user_agent}
+        if cached:
+            if cached.etag:
+                headers["If-None-Match"] = cached.etag
+            if cached.last_modified:
+                headers["If-Modified-Since"] = cached.last_modified
+
+        request = urllib_request.Request(url, headers=headers)
+
+        try:
+            with self._opener(request, timeout=self.timeout) as response:  # type: ignore[arg-type]
+                raw = response.read()
+                header_map = CaseInsensitiveDict(dict(response.headers.items()))
+                etag = header_map.get("etag")
+                last_modified = header_map.get("last-modified")
+        except HTTPError as error:
+            if error.code == 304 and cached:
+                logger.debug("not modified: %s", url)
+                return cached
+            logger.warning("failed to fetch %s: %s", url, error)
+            return None
+        except URLError as error:
+            logger.warning("failed to fetch %s: %s", url, error.reason)
+            return None
+
+        response_cache = CachedResponse(
+            url=url,
+            raw_content=raw,
+            headers=header_map,
+            etag=etag,
+            last_modified=last_modified,
+        )
+        self._cache[url] = response_cache
+        return response_cache
+
+    def _get_cached(self, url: str) -> Optional[CachedResponse]:
+        cached = self._cache.get(url)
+        if cached and cached.content_hash:
+            cached.is_duplicate = self._hash_is_duplicate(cached.content_hash)
+        return cached
+
+    def _is_allowed(self, url: str) -> bool:
+        parsed = urlparse(url)
+        key = parsed.netloc
+        parser = self._robots.get(key)
+        if parser is None:
+            parser = self._fetch_robots(parsed.scheme, parsed.netloc)
+            self._robots[key] = parser
+        try:
+            return parser.can_fetch(self.user_agent, url)
+        except Exception:  # pragma: no cover - defensive
+            return True
+
+    def _fetch_robots(self, scheme: str, netloc: str) -> RobotFileParser:
+        robots_url = urljoin(f"{scheme}://{netloc}", "robots.txt")
+        parser = RobotFileParser()
+        request = urllib_request.Request(robots_url, headers={"User-Agent": self.user_agent})
+        try:
+            with self._opener(request, timeout=self.timeout) as response:  # type: ignore[arg-type]
+                body = response.read().decode("utf-8", errors="ignore")
+        except Exception:
+            parser.parse([])
+            return parser
+        parser.parse(body.splitlines())
+        return parser
+
+    def _throttle(self, domain: str) -> None:
+        if self.throttle_delay <= 0:
+            return
+        now = self._time()
+        last = self._last_request.get(domain)
+        if last is not None:
+            wait_for = self.throttle_delay - (now - last)
+            if wait_for > 0:
+                self._sleep(wait_for)
+                now = self._time()
+        self._last_request[domain] = now
+
+    def _decode_content(self, raw: bytes, headers: Mapping[str, str]) -> str:
+        content_type = headers.get("content-type", "")
+        match = re.search(r"charset=([\\w-]+)", content_type)
+        encoding = match.group(1) if match else "utf-8"
+        try:
+            return raw.decode(encoding, errors="replace")
+        except LookupError:  # pragma: no cover - rare codec issue
+            return raw.decode("utf-8", errors="replace")
+
+    def _extract_content(self, text: str) -> str:
+        if trafilatura is not None:
+            try:
+                extracted = trafilatura.extract(text)
+                if extracted:
+                    return extracted.strip()
+            except Exception:  # pragma: no cover - library failure
+                logger.debug("trafilatura failed to extract content", exc_info=True)
+        if Document is not None:
+            try:
+                document = Document(text)
+                summary = document.summary()
+                if summary:
+                    return self._strip_tags(summary)
+            except Exception:  # pragma: no cover - library failure
+                logger.debug("Readability failed to extract content", exc_info=True)
+        return text
+
+    def _strip_tags(self, html: str) -> str:
+        return re.sub(r"<[^>]+>", " ", html).strip()
+
+    def _store_hash(self, url: str, content: str) -> str:
+        digest = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        previous = self._url_hash.get(url)
+        if previous and previous in self._hash_urls:
+            urls = self._hash_urls[previous]
+            urls.discard(url)
+            if not urls:
+                del self._hash_urls[previous]
+        self._url_hash[url] = digest
+        self._hash_urls[digest].add(url)
+        return digest
+
+    def _hash_is_duplicate(self, digest: Optional[str]) -> bool:
+        if not digest:
+            return False
+        urls = self._hash_urls.get(digest)
+        return bool(urls and len(urls) > 1)
+
+
+def detect_license(headers: Mapping[str, str], content: str) -> Optional[str]:
+    """Attempt to infer a license from headers or page content."""
+
+    header_keys = ["license", "x-license", "content-license"]
+    for key in header_keys:
+        value = headers.get(key)
+        if value:
+            return value.strip()
+
+    text = content.lower()
+    patterns = {
+        "mit license": "MIT License",
+        "apache license": "Apache License",
+        "creative commons": "Creative Commons",
+        "gpl": "GNU General Public License",
+    }
+    for needle, name in patterns.items():
+        if needle in text:
+            return name
+    return None
+
+
+__all__ = ["HTTPScraper", "ScrapeResult", "detect_license"]

--- a/app/scrapers/sitemap.py
+++ b/app/scrapers/sitemap.py
@@ -1,0 +1,38 @@
+"""Utilities to work with XML sitemaps."""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import List
+
+from .http import HTTPScraper
+
+
+class SitemapScraper:
+    """Parse sitemap XML documents into URL lists."""
+
+    def __init__(self, http: HTTPScraper) -> None:
+        self.http = http
+
+    def fetch(self, sitemap_url: str) -> List[str]:
+        """Download *sitemap_url* and return contained URLs."""
+
+        payload = self.http.fetch_raw(sitemap_url, respect_robots=False)
+        if payload is None:
+            return []
+        raw, _ = payload
+        try:
+            root = ET.fromstring(raw)
+        except ET.ParseError:
+            return []
+
+        urls: List[str] = []
+        for loc in root.findall(".//{*}loc"):
+            if loc.text:
+                candidate = loc.text.strip()
+                if candidate:
+                    urls.append(candidate)
+        return urls
+
+
+__all__ = ["SitemapScraper"]

--- a/tests/test_http_scraper.py
+++ b/tests/test_http_scraper.py
@@ -1,0 +1,116 @@
+import json
+from collections import defaultdict
+from typing import Dict, List, Mapping
+from urllib.error import HTTPError
+
+from app.scrapers.http import HTTPScraper
+
+
+class FakeResponse:
+    def __init__(self, body: str, headers: Mapping[str, str] | None = None, status: int = 200):
+        self._body = body.encode("utf-8")
+        self.status = status
+        self.headers = defaultdict(str)
+        if headers:
+            for key, value in headers.items():
+                self.headers[key] = value
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "FakeResponse":  # pragma: no cover - context manager boilerplate
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - context manager boilerplate
+        return None
+
+
+def build_urlopen(responses: Dict[str, List[object]], recorded: List[Dict[str, object]]):
+    def _urlopen(request, timeout=None):  # pragma: no cover - helper in tests
+        url = getattr(request, "full_url", request)
+        headers = {k.lower(): v for k, v in getattr(request, "headers", {}).items()}
+        recorded.append({"url": url, "headers": headers, "timeout": timeout})
+        queue = responses.get(url)
+        if not queue:
+            raise AssertionError(f"No response queued for {url}")
+        response = queue.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    return _urlopen
+
+
+def test_headers_and_conditional_requests(monkeypatch):
+    responses: Dict[str, List[object]] = defaultdict(list)
+    records: List[Dict[str, object]] = []
+    url = "https://example.com/article"
+    responses[url].append(
+        FakeResponse(
+            "<html><body>Example Article</body></html>",
+            headers={
+                "Content-Type": "text/html; charset=utf-8",
+                "ETag": "abc123",
+                "Last-Modified": "Mon, 01 Jan 2024 00:00:00 GMT",
+                "X-License": "MIT",
+            },
+        )
+    )
+    responses[url].append(HTTPError(url, 304, "Not Modified", hdrs=None, fp=None))
+
+    scraper = HTTPScraper(opener=build_urlopen(responses, records), timeout=5)
+
+    first = scraper.fetch(url)
+    assert first is not None
+    assert "Example Article" in first.content
+    assert first.license == "MIT"
+
+    second = scraper.fetch(url)
+    assert second is not None
+    assert second.content == first.content
+    assert len(records) == 3
+    assert records[0]["headers"]["user-agent"] == scraper.user_agent
+    assert records[0]["timeout"] == 5
+    assert records[1]["headers"]["user-agent"] == scraper.user_agent
+    assert records[1]["headers"].get("if-none-match") is None
+    assert records[2]["headers"]["if-none-match"] == "abc123"
+    assert (
+        records[2]["headers"]["if-modified-since"] == "Mon, 01 Jan 2024 00:00:00 GMT"
+    )
+
+
+def test_deduplication_detects_duplicate_content(monkeypatch):
+    responses: Dict[str, List[object]] = defaultdict(list)
+    records: List[Dict[str, object]] = []
+    url_one = "https://example.com/one"
+    url_two = "https://example.com/two"
+    html = "<html><body>Same Content</body></html>"
+    headers = {"Content-Type": "text/html; charset=utf-8"}
+    responses[url_one].append(FakeResponse(html, headers=headers))
+    responses[url_two].append(FakeResponse(html, headers=headers))
+
+    scraper = HTTPScraper(opener=build_urlopen(responses, records))
+
+    first = scraper.fetch(url_one)
+    second = scraper.fetch(url_two)
+
+    assert first is not None
+    assert second is not None
+    assert first.content_hash == second.content_hash
+    assert second.is_duplicate is True
+
+
+def test_fetch_raw_returns_payload(monkeypatch):
+    responses: Dict[str, List[object]] = defaultdict(list)
+    records: List[Dict[str, object]] = []
+    url = "https://example.com/data.json"
+    payload = json.dumps({"hello": "world"})
+    responses[url].append(FakeResponse(payload, headers={"Content-Type": "application/json"}))
+
+    scraper = HTTPScraper(opener=build_urlopen(responses, records))
+
+    raw = scraper.fetch_raw(url)
+    assert raw is not None
+    body, headers = raw
+    assert json.loads(body.decode("utf-8")) == {"hello": "world"}
+    assert headers["content-type"] == "application/json"

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -1,0 +1,123 @@
+from collections import defaultdict
+from typing import Dict, List
+from urllib.error import URLError
+
+import pytest
+
+from app.scrapers.http import HTTPScraper
+
+
+class FakeResponse:
+    def __init__(self, body: str, headers=None):
+        self._body = body.encode("utf-8")
+        self.headers = defaultdict(str)
+        if headers:
+            for key, value in headers.items():
+                self.headers[key] = value
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "FakeResponse":  # pragma: no cover
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover
+        return None
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.slept: List[float] = []
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, delay: float) -> None:
+        self.slept.append(delay)
+        self.now += delay
+
+    def advance(self, delta: float) -> None:
+        self.now += delta
+
+
+def build_urlopen(responses: Dict[str, List[object]], recorded: List[Dict[str, object]]):
+    def _urlopen(request, timeout=None):  # pragma: no cover - helper
+        url = getattr(request, "full_url", request)
+        headers = {k.lower(): v for k, v in getattr(request, "headers", {}).items()}
+        recorded.append({"url": url, "headers": headers, "timeout": timeout})
+        queue = responses.get(url)
+        if not queue:
+            raise AssertionError(f"No response queued for {url}")
+        response = queue.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    return _urlopen
+
+
+def test_robots_disallow_blocks_fetch():
+    responses: Dict[str, List[object]] = defaultdict(list)
+    records: List[Dict[str, object]] = []
+    robots_url = "https://example.com/robots.txt"
+    responses[robots_url].append(
+        FakeResponse("User-agent: *\nDisallow: /private")
+    )
+
+    scraper = HTTPScraper(opener=build_urlopen(responses, records))
+
+    result = scraper.fetch("https://example.com/private/page.html")
+    assert result is None
+    assert records[0]["url"] == robots_url
+
+
+def test_missing_robots_allows_fetch():
+    responses: Dict[str, List[object]] = defaultdict(list)
+    records: List[Dict[str, object]] = []
+    robots_url = "https://example.com/robots.txt"
+    responses[robots_url].append(URLError("no robots"))
+    page_url = "https://example.com/index.html"
+    responses[page_url].append(
+        FakeResponse("<html><body>Hello</body></html>", headers={"Content-Type": "text/html"})
+    )
+
+    scraper = HTTPScraper(opener=build_urlopen(responses, records))
+
+    result = scraper.fetch(page_url)
+    assert result is not None
+    assert "Hello" in result.content
+
+
+def test_throttling_waits_between_requests():
+    responses: Dict[str, List[object]] = defaultdict(list)
+    records: List[Dict[str, object]] = []
+    robots_url = "https://example.com/robots.txt"
+    responses[robots_url].append(FakeResponse("User-agent: *\nAllow: /"))
+    page_url = "https://example.com/data"
+    responses[page_url].append(
+        FakeResponse("<html><body>Payload</body></html>", headers={"Content-Type": "text/html"})
+    )
+    responses[page_url].append(
+        FakeResponse("<html><body>Payload</body></html>", headers={"Content-Type": "text/html"})
+    )
+
+    clock = FakeClock()
+    scraper = HTTPScraper(
+        opener=build_urlopen(responses, records),
+        throttle_delay=1.0,
+        time_func=clock.time,
+        sleep_func=clock.sleep,
+    )
+
+    first = scraper.fetch_raw(page_url)
+    assert first is not None
+    clock.advance(0.3)
+    second = scraper.fetch_raw(page_url)
+    assert second is not None
+
+    assert clock.slept
+    assert pytest.approx(clock.slept[0], rel=1e-3) == 0.7
+    assert records[0]["url"] == robots_url
+    assert records[1]["url"] == page_url
+    assert records[2]["url"] == page_url


### PR DESCRIPTION
## Summary
- add a reusable HTTP scraper that enforces robots.txt, throttling and conditional requests while extracting content
- provide sitemap and GitHub helpers on top of the HTTP scraper
- cover the new behaviour with unit tests for header handling, deduplication and throttling

## Testing
- pytest tests/test_http_scraper.py tests/test_robots.py

------
https://chatgpt.com/codex/tasks/task_e_68dfe2f973948320915dc3f3e5e6cc85