### PR TITLE
Handle first-run sentinel and bootstrap configuration

### DIFF
--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -1,0 +1,23 @@
+"""Startup helpers that ensure the user environment is initialised."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from app.core.first_run import FirstRunConfigurator
+
+
+def auto_configure_if_needed(home: Path | None = None) -> None:
+    """Run the first-run configurator when the sentinel is present."""
+
+    configurator = FirstRunConfigurator(home=home)
+    if not configurator.sentinel_path.exists():
+        return
+
+    skip_models = os.environ.get("WATCHER_BOOTSTRAP_SKIP_MODELS") == "1"
+    configurator.run(auto=True, download_models=not skip_models)
+
+
+__all__ = ["auto_configure_if_needed"]
+

--- a/app/cli.py
+++ b/app/cli.py
@@ -11,6 +11,7 @@ from typing import Iterable, Sequence
 
 from config import get_settings
 
+from app.bootstrap import auto_configure_if_needed
 from app.autopilot import AutopilotError, AutopilotScheduler
 from app.core.engine import Engine
 from app.core.first_run import FirstRunConfigurator
@@ -55,6 +56,7 @@ def _iter_plugins() -> list[plugins.Plugin]:
 def main(argv: Sequence[str] | None = None) -> int:
     """Entry point for the :mod:`watcher` command."""
 
+    auto_configure_if_needed()
     settings = get_settings()
     parser = argparse.ArgumentParser(
         prog="watcher",

--- a/tests/test_policy_manager.py
+++ b/tests/test_policy_manager.py
@@ -13,7 +13,7 @@ def test_policy_manager_approve_and_revoke(tmp_path: Path) -> None:
     home.mkdir()
 
     configurator = FirstRunConfigurator(home=home)
-    configurator.run(fully_auto=True, download_models=False)
+    configurator.run(auto=True, download_models=False)
 
     manager = PolicyManager(home=home)
     manager.approve(
@@ -35,8 +35,9 @@ def test_policy_manager_approve_and_revoke(tmp_path: Path) -> None:
         .strip()
         .splitlines()
     )
-    assert len(ledger_lines) == 2
-    assert '"action": "approve"' in ledger_lines[1]
+    assert len(ledger_lines) == 3
+    assert '"action": "init"' in ledger_lines[1]
+    assert '"action": "approve"' in ledger_lines[2]
 
     manager.revoke("example.com")
 


### PR DESCRIPTION
## Summary
- extend the first-run configurator to manage the ~/.watcher/first_run sentinel, generate a sealed .env file, and log the initial consent entry
- add a bootstrap helper that runs the configurator automatically when the sentinel is present and invoke it from the CLI
- expand the first-run and policy manager tests to cover sentinel removal, .env creation, and the initial ledger entry

## Testing
- pytest tests/test_first_run.py tests/test_policy_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68dff49f744883209bb7c2c2e23075de