### PR TITLE
Add cross-platform autopilot autostart routine

### DIFF
--- a/app/core/first_run.py
+++ b/app/core/first_run.py
@@ -15,6 +15,8 @@ import shutil
 import textwrap
 
 from app.core.model_registry import ensure_models, select_models
+from app.policy.manager import PolicyError, PolicyManager
+from app.utils.autostart import configure_autostart
 
 @dataclass(slots=True)
 class HardwareProfile:
@@ -90,6 +92,15 @@ class FirstRunConfigurator:
         self._write_config(profile, selection)
         self._write_policy(selection)
         self._ensure_consent_ledger()
+        if fully_auto:
+            consent = True
+            try:
+                policy = PolicyManager(home=self.home)._read_policy()
+            except PolicyError:
+                consent = False
+            else:
+                consent = not policy.defaults.require_consent
+            configure_autostart(home=self.home, consent_granted=consent)
         return self.config_path
 
     # ------------------------------------------------------------------

--- a/app/utils/autostart.py
+++ b/app/utils/autostart.py
@@ -1,0 +1,194 @@
+"""Helpers to configure OS-level autostart for the autopilot scheduler."""
+
+from __future__ import annotations
+
+import os
+import platform
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable
+
+from config import _CONFIG_DIR
+
+DEFAULT_TASK_NAME = "Watcher Autopilot"
+SERVICE_NAME = "watcher-autopilot.service"
+TIMER_NAME = "watcher-autopilot.timer"
+RUN_ONCE_KEY = r"HKCU\Software\Microsoft\Windows\CurrentVersion\RunOnce"
+RUN_ONCE_VALUE = "WatcherAutopilot"
+KILL_SWITCH_FILENAME = "autostart.disable"
+
+
+class AutostartError(RuntimeError):
+    """Raised when the autostart configuration cannot be applied."""
+
+
+def _command_parts() -> list[str]:
+    """Return the command used to evaluate the autopilot scheduler."""
+
+    return [sys.executable, "-m", "watcher", "autopilot", "status"]
+
+
+def _windows_command() -> str:
+    parts = _command_parts()
+    quoted = [f'"{parts[0]}"'] + parts[1:]
+    return " ".join(quoted)
+
+
+def _systemd_command() -> str:
+    return " ".join(shlex.quote(part) for part in _command_parts())
+
+
+def _ensure_directory(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _read_env(env_path: Path) -> tuple[list[str], dict[str, str]]:
+    comments: list[str] = []
+    values: dict[str, str] = {}
+    if not env_path.exists():
+        return comments, values
+    for line in env_path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in line:
+            comments.append(line)
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return comments, values
+
+
+def _write_env(env_path: Path, *, comments: Iterable[str], values: dict[str, str]) -> None:
+    lines = list(comments)
+    for key, value in values.items():
+        lines.append(f"{key}={value}")
+    env_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def get_kill_switch_path(home: Path | None = None) -> Path:
+    base = home or Path.home()
+    return base / ".watcher" / KILL_SWITCH_FILENAME
+
+
+def is_autostart_disabled(*, home: Path | None = None) -> bool:
+    kill_switch = get_kill_switch_path(home)
+    disable_env = os.environ.get("WATCHER_DISABLE")
+    if disable_env:
+        normalised = disable_env.strip().lower()
+        if normalised in {"1", "true", "yes", "on"}:
+            return True
+        candidate = Path(disable_env).expanduser()
+        if candidate.exists():
+            return True
+    if kill_switch.exists():
+        return True
+    return False
+
+
+def _configure_windows(command: str) -> None:
+    create_task = [
+        "schtasks",
+        "/Create",
+        "/TN",
+        DEFAULT_TASK_NAME,
+        "/TR",
+        command,
+        "/SC",
+        "MINUTE",
+        "/MO",
+        "5",
+        "/F",
+    ]
+    subprocess.run(create_task, check=True)
+
+    run_once = [
+        "reg",
+        "add",
+        RUN_ONCE_KEY,
+        "/v",
+        RUN_ONCE_VALUE,
+        "/d",
+        command,
+        "/f",
+    ]
+    subprocess.run(run_once, check=True)
+
+
+def _configure_systemd(home: Path, command: str) -> None:
+    systemd_dir = home / ".config" / "systemd" / "user"
+    _ensure_directory(systemd_dir)
+
+    service_path = systemd_dir / SERVICE_NAME
+    timer_path = systemd_dir / TIMER_NAME
+
+    service_content = f"""[Unit]
+Description=Watcher Autopilot scheduler
+
+[Service]
+Type=oneshot
+ExecStart={command}
+"""
+    timer_content = f"""[Unit]
+Description=Watcher Autopilot periodic trigger
+
+[Timer]
+OnBootSec=1min
+OnUnitActiveSec=5min
+Unit={SERVICE_NAME}
+
+[Install]
+WantedBy=default.target
+"""
+
+    service_path.write_text(service_content, encoding="utf-8")
+    timer_path.write_text(timer_content, encoding="utf-8")
+
+    subprocess.run(
+        ["systemctl", "--user", "enable", "--now", TIMER_NAME],
+        check=True,
+    )
+
+
+def configure_autostart(
+    *,
+    home: Path | None = None,
+    env_path: Path | None = None,
+    consent_granted: bool = True,
+) -> bool:
+    """Configure scheduled execution of the autopilot if permitted.
+
+    Returns :data:`True` when the configuration succeeded, :data:`False`
+    otherwise.  The ``.env`` file is updated with ``WATCHER_AUTOSTART`` and
+    ``WATCHER_DISABLE`` entries in all cases.
+    """
+
+    base_home = home or Path.home()
+    env_file = env_path or (_CONFIG_DIR.parent / ".env")
+    kill_switch = get_kill_switch_path(base_home)
+
+    comments, values = _read_env(env_file)
+
+    success = False
+    if consent_granted and not is_autostart_disabled(home=base_home):
+        command = _windows_command()
+        system = platform.system().lower()
+        try:
+            if system.startswith("win"):
+                _configure_windows(command)
+            else:
+                _configure_systemd(base_home, _systemd_command())
+            success = True
+        except subprocess.CalledProcessError as exc:  # pragma: no cover - defensive
+            raise AutostartError(str(exc)) from exc
+
+    values["WATCHER_DISABLE"] = str(kill_switch)
+    values["WATCHER_AUTOSTART"] = "1" if success else "0"
+    _write_env(env_file, comments=comments, values=values)
+
+    if "WATCHER_DISABLE" not in os.environ:
+        os.environ["WATCHER_DISABLE"] = str(kill_switch)
+    os.environ["WATCHER_AUTOSTART"] = "1" if success else "0"
+
+    return success
+

--- a/tests/test_autostart_config.py
+++ b/tests/test_autostart_config.py
@@ -1,0 +1,90 @@
+"""Tests for the autostart helper routines."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import platform
+import subprocess
+
+import pytest
+
+from app.utils import autostart
+
+
+@pytest.fixture(autouse=True)
+def _reset_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WATCHER_DISABLE", raising=False)
+    monkeypatch.delenv("WATCHER_AUTOSTART", raising=False)
+
+
+def test_configure_autostart_windows(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    commands: list[list[str]] = []
+
+    def _fake_run(cmd, check):
+        commands.append(list(cmd))
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr(platform, "system", lambda: "Windows")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    env_path = tmp_path / ".env"
+
+    result = autostart.configure_autostart(home=home, env_path=env_path, consent_granted=True)
+
+    assert result is True
+    assert commands[0][:4] == ["schtasks", "/Create", "/TN", autostart.DEFAULT_TASK_NAME]
+    assert "watcher autopilot status" in " ".join(commands[0])
+    assert commands[1][:4] == ["reg", "add", autostart.RUN_ONCE_KEY, "/v"]
+    env_content = env_path.read_text(encoding="utf-8")
+    assert "WATCHER_AUTOSTART=1" in env_content
+    assert "WATCHER_DISABLE=" in env_content
+
+
+def test_configure_autostart_systemd(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    commands: list[list[str]] = []
+
+    def _fake_run(cmd, check):
+        commands.append(list(cmd))
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+
+    home = tmp_path / "home"
+    home.mkdir()
+    env_path = tmp_path / ".env"
+
+    result = autostart.configure_autostart(home=home, env_path=env_path, consent_granted=True)
+
+    assert result is True
+    systemd_dir = home / ".config" / "systemd" / "user"
+    service = systemd_dir / autostart.SERVICE_NAME
+    timer = systemd_dir / autostart.TIMER_NAME
+    assert service.exists()
+    assert timer.exists()
+    service_text = service.read_text(encoding="utf-8")
+    assert "watcher autopilot status" in service_text
+    assert commands == [["systemctl", "--user", "enable", "--now", autostart.TIMER_NAME]]
+    env_content = env_path.read_text(encoding="utf-8")
+    assert "WATCHER_AUTOSTART=1" in env_content
+    assert "WATCHER_DISABLE=" in env_content
+
+
+def test_autostart_respects_kill_switch(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: None)
+    monkeypatch.setattr(platform, "system", lambda: "Linux")
+
+    home = tmp_path / "home"
+    kill_switch = home / ".watcher" / autostart.KILL_SWITCH_FILENAME
+    kill_switch.parent.mkdir(parents=True)
+    kill_switch.write_text("", encoding="utf-8")
+    env_path = tmp_path / ".env"
+
+    result = autostart.configure_autostart(home=home, env_path=env_path, consent_granted=True)
+
+    assert result is False
+    assert not (home / ".config" / "systemd" / "user" / autostart.SERVICE_NAME).exists()
+    env_content = env_path.read_text(encoding="utf-8")
+    assert "WATCHER_AUTOSTART=0" in env_content
+    assert "WATCHER_DISABLE=" in env_content

--- a/tests/test_first_run.py
+++ b/tests/test_first_run.py
@@ -23,6 +23,14 @@ def test_first_run_creates_expected_files(tmp_path: Path, monkeypatch: pytest.Mo
     home.mkdir()
     configurator = FirstRunConfigurator(home=home)
 
+    recorded: dict[str, object] = {}
+
+    def _fake_autostart(**kwargs):
+        recorded.update(kwargs)
+        return True
+
+    monkeypatch.setattr("app.core.first_run.configure_autostart", _fake_autostart)
+
     config_path = configurator.run(fully_auto=True, download_models=False)
 
     assert config_path == home / ".watcher" / "config.toml"
@@ -40,6 +48,9 @@ def test_first_run_creates_expected_files(tmp_path: Path, monkeypatch: pytest.Mo
     assert ledger_path.exists()
     ledger_content = ledger_path.read_text(encoding="utf-8")
     assert '"type": "metadata"' in ledger_content
+
+    assert recorded.get("home") == home
+    assert recorded.get("consent_granted") is False
 
 
 def test_user_config_overrides_settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- add an autostart utility that registers the autopilot scheduler on Windows and systemd and persists env toggles
- invoke the autostart helper from the automated first-run path and gate it on consent while wiring a kill-switch check into the scheduler
- cover the new helper and kill-switch flow with cross-platform unit tests

## Testing
- pytest tests/test_autostart_config.py tests/test_autopilot.py tests/test_first_run.py

------
https://chatgpt.com/codex/tasks/task_e_68dff4a0ac888320a315917646bcbd29