### PR TITLE
Refine policy schema and defaults

### DIFF
--- a/app/policy/ledger.py
+++ b/app/policy/ledger.py
@@ -41,13 +41,22 @@ class ConsentLedger:
     def metadata(self) -> dict[str, object]:
         return dict(self._metadata)
 
-    def record(self, *, action: str, domain: str, scope: str, policy_hash: str) -> None:
+    def record(
+        self,
+        *,
+        action: str,
+        domain: str,
+        scope: str,
+        policy_version: int,
+        policy_hash: str,
+    ) -> None:
         payload = {
             "type": "entry",
             "timestamp": datetime.utcnow().isoformat(timespec="seconds") + "Z",
             "action": action,
             "domain": domain,
             "scope": scope,
+            "policy_version": policy_version,
             "policy_hash": policy_hash,
         }
         message = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")

--- a/tests/test_autopilot.py
+++ b/tests/test_autopilot.py
@@ -11,7 +11,9 @@ from app.policy.schema import (
     Defaults,
     ModelEntry,
     ModelsSection,
+    NetworkBudget,
     NetworkSection,
+    NetworkWindow,
     Policy,
     Subject,
     TimeWindow,
@@ -41,19 +43,24 @@ def _policy() -> Policy:
     now = datetime(2024, 1, 1, 10, 0, 0)
     return Policy(
         version=1,
+        autostart=False,
         subject=Subject(hostname="test-host", generated_at=now),
         defaults=Defaults(),
         network=NetworkSection(
-            allowed_windows=[TimeWindow(days=["mon", "tue"], window="08:00-20:00")],
-            bandwidth_mb=500,
-            time_budget_minutes=120,
+            network_windows=[
+                NetworkWindow(
+                    cidrs=["0.0.0.0/0"],
+                    windows=[TimeWindow(days=["mon", "tue"], window="08:00-20:00")],
+                )
+            ],
             allowlist=[],
+            budgets=NetworkBudget(bandwidth_mb=500, time_budget_minutes=120),
         ),
         budgets=Budgets(cpu_percent=50, ram_mb=1024),
         categories=Categories(allowed=[]),
         models=ModelsSection(
-            llm=ModelEntry(name="llm", sha256="abc", license="MIT"),
-            embedding=ModelEntry(name="embed", sha256="def", license="MIT"),
+            llm=ModelEntry(name="llm", sha256="a" * 64, license="MIT"),
+            embedding=ModelEntry(name="embed", sha256="b" * 64, license="MIT"),
         ),
     )
 

--- a/tests/test_policy_manager.py
+++ b/tests/test_policy_manager.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from app.core.first_run import FirstRunConfigurator
@@ -27,6 +28,14 @@ def test_policy_manager_approve_and_revoke(tmp_path: Path) -> None:
     policy_data = yaml.safe_load(
         (home / ".watcher" / "policy.yaml").read_text(encoding="utf-8")
     )
+    assert policy_data["autostart"] is False
+    assert policy_data["defaults"]["offline_default"] is True
+    assert policy_data["defaults"]["require_corroboration"] is True
+    assert policy_data["defaults"]["kill_switch_file"].startswith(str(home / ".watcher"))
+    windows = policy_data["network"]["network_windows"]
+    assert windows and windows[0]["cidrs"] == ["0.0.0.0/0", "::/0"]
+    assert windows[0]["windows"][0]["window"] == "09:00-18:00"
+
     allowlist = policy_data["network"]["allowlist"]
     assert any(entry["domain"] == "example.com" for entry in allowlist)
 
@@ -37,6 +46,7 @@ def test_policy_manager_approve_and_revoke(tmp_path: Path) -> None:
     )
     assert len(ledger_lines) == 2
     assert '"action": "approve"' in ledger_lines[1]
+    assert '"policy_version": 1' in ledger_lines[1]
 
     manager.revoke("example.com")
 
@@ -44,3 +54,87 @@ def test_policy_manager_approve_and_revoke(tmp_path: Path) -> None:
         (home / ".watcher" / "policy.yaml").read_text(encoding="utf-8")
     )
     assert not policy_data["network"]["allowlist"]
+
+
+def test_policy_schema_requires_absolute_kill_switch() -> None:
+    from pydantic import ValidationError
+
+    policy = {
+        "version": 1,
+        "autostart": False,
+        "subject": {
+            "hostname": "test",
+            "generated_at": "2024-01-01T00:00:00Z",
+        },
+        "defaults": {
+            "offline_default": True,
+            "require_consent": True,
+            "require_corroboration": True,
+            "kill_switch_file": "relative/path",
+        },
+        "network": {
+            "network_windows": [
+                {
+                    "cidrs": ["0.0.0.0/0"],
+                    "windows": [
+                        {"days": ["mon"], "window": "00:00-23:59"},
+                    ],
+                }
+            ],
+            "allowlist": [],
+            "budgets": {"bandwidth_mb": 1, "time_budget_minutes": 1},
+        },
+        "budgets": {"cpu_percent": 10, "ram_mb": 10},
+        "categories": {"allowed": []},
+        "models": {
+            "llm": {"name": "x", "sha256": "a" * 64, "license": "MIT"},
+            "embedding": {"name": "y", "sha256": "b" * 64, "license": "MIT"},
+        },
+    }
+
+    from app.policy.schema import Policy
+
+    with pytest.raises(ValidationError):
+        Policy.model_validate(policy)
+
+
+def test_policy_schema_rejects_invalid_cidr() -> None:
+    from pydantic import ValidationError
+
+    from app.policy.schema import Policy
+
+    policy = {
+        "version": 1,
+        "autostart": False,
+        "subject": {
+            "hostname": "test",
+            "generated_at": "2024-01-01T00:00:00Z",
+        },
+        "defaults": {
+            "offline_default": True,
+            "require_consent": True,
+            "require_corroboration": True,
+            "kill_switch_file": "/tmp/kill",
+        },
+        "network": {
+            "network_windows": [
+                {
+                    "cidrs": ["invalid"],
+                    "windows": [
+                        {"days": ["mon"], "window": "00:00-23:59"},
+                    ],
+                }
+            ],
+            "allowlist": [],
+            "budgets": {"bandwidth_mb": 1, "time_budget_minutes": 1},
+        },
+        "budgets": {"cpu_percent": 10, "ram_mb": 10},
+        "categories": {"allowed": []},
+        "models": {
+            "llm": {"name": "x", "sha256": "a" * 64, "license": "MIT"},
+            "embedding": {"name": "y", "sha256": "b" * 64, "license": "MIT"},
+        },
+    }
+
+    with pytest.raises(ValidationError):
+        Policy.model_validate(policy)


### PR DESCRIPTION
## Summary
- extend the policy schema to cover autostart, offline defaults, CIDR-based network windows, and stricter validation (kill-switch path, model hashes, domain scope)
- update first-run configuration, policy manager, ledger, and scheduler to emit and consume the richer schema while logging policy version information
- refresh policy-related tests (including new schema validation cases) and autopilot fixtures to match the new structure

## Testing
- pytest tests/test_policy_manager.py tests/test_autopilot.py


------
https://chatgpt.com/codex/tasks/task_e_68dff4a130f48320a8fc1f4a7dfd831d