### PR TITLE
Add autopilot orchestration with policy guardrails

### DIFF
--- a/app/autopilot/__init__.py
+++ b/app/autopilot/__init__.py
@@ -1,5 +1,14 @@
 """Autopilot orchestration utilities."""
 
+from .controller import (
+    AutopilotController,
+    AutopilotRunResult,
+    ConsentGate,
+    DiscoveryResult,
+    LedgerView,
+    MultiSourceVerifier,
+    ReportGenerator,
+)
 from .scheduler import (
     AutopilotError,
     AutopilotLogEntry,
@@ -10,10 +19,17 @@ from .scheduler import (
 )
 
 __all__ = [
+    "AutopilotController",
     "AutopilotError",
+    "AutopilotRunResult",
     "AutopilotLogEntry",
     "AutopilotScheduler",
     "AutopilotState",
+    "ConsentGate",
+    "DiscoveryResult",
+    "LedgerView",
+    "MultiSourceVerifier",
+    "ReportGenerator",
     "ResourceProbe",
     "ResourceUsage",
 ]

--- a/app/autopilot/controller.py
+++ b/app/autopilot/controller.py
@@ -1,0 +1,566 @@
+"""Autopilot orchestration pipeline linking discovery, scraping and ingestion."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Iterator, Mapping, MutableMapping, Protocol, Sequence
+from urllib.parse import urlparse
+
+from app.autopilot.scheduler import AutopilotError, AutopilotScheduler
+from app.ingest.pipeline import IngestPipeline, IngestValidationError, RawDocument
+from app.policy.manager import PolicyError
+from app.policy.schema import DomainRule, Policy
+from app.scrapers.http import HTTPScraper, ScrapeResult
+
+LOGGER = logging.getLogger(__name__)
+
+__all__ = [
+    "AutopilotController",
+    "AutopilotRunResult",
+    "ConsentGate",
+    "DiscoveryResult",
+    "LedgerView",
+    "MultiSourceVerifier",
+    "ReportGenerator",
+]
+
+
+# ---------------------------------------------------------------------------
+# Protocols & dataclasses
+
+
+@dataclass(slots=True)
+class DiscoveryResult:
+    """Result coming from the discovery crawler."""
+
+    url: str
+    title: str
+    summary: str
+    licence: str | None = None
+    published_at: datetime | None = None
+
+
+class DiscoveryCrawler(Protocol):
+    """Protocol expected from discovery implementations."""
+
+    def discover(
+        self,
+        topics: Sequence[str],
+        rules: Sequence[DomainRule],
+    ) -> Iterable[DiscoveryResult]:
+        """Yield discovery results for the provided *topics* and *rules*."""
+
+
+class Scraper(Protocol):
+    """Protocol for scraping engines."""
+
+    def fetch(self, url: str, *, respect_robots: bool = True) -> ScrapeResult | None:
+        """Return a :class:`ScrapeResult` for *url* or ``None`` when unavailable."""
+
+
+@dataclass(slots=True)
+class AutopilotRunResult:
+    """Summary returned after an autopilot orchestration cycle."""
+
+    ingested: int
+    skipped: list[str] = field(default_factory=list)
+    blocked: list[str] = field(default_factory=list)
+    reason: str | None = None
+
+
+class ConsentGate:
+    """Gatekeeper enforcing allowlist and consent ledger rules."""
+
+    def __init__(
+        self,
+        *,
+        allowed: Mapping[str, DomainRule],
+        consented: Mapping[str, str],
+        require_consent: bool,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._allowed = allowed
+        self._consented = consented
+        self._require_consent = require_consent
+        self._logger = logger or LOGGER
+        self._blocked: set[str] = set()
+
+    def allow(self, url: str) -> bool:
+        domain = _domain_from_url(url)
+        if not domain:
+            return False
+        if domain in self._allowed:
+            return True
+        if not self._require_consent:
+            return False
+        if domain not in self._consented:
+            if domain not in self._blocked:
+                self._logger.warning(
+                    "Domaine %s suspendu – consentement manquant.",
+                    domain,
+                )
+            self._blocked.add(domain)
+            return False
+        # Single-use consent: consume immediately
+        del self._consented[domain]
+        self._logger.info(
+            "Consentement unique consommé pour %s.",
+            domain,
+        )
+        return True
+
+    @property
+    def blocked(self) -> list[str]:
+        return sorted(self._blocked)
+
+
+class MultiSourceVerifier:
+    """Ensure that documents are corroborated by multiple sources."""
+
+    def __init__(self, *, min_sources: int) -> None:
+        self._min_sources = max(2, min_sources)
+
+    def filter(self, documents: Sequence[tuple[RawDocument, str]]) -> list[tuple[RawDocument, str]]:
+        grouped: MutableMapping[str, list[tuple[RawDocument, str]]] = defaultdict(list)
+        for document, digest in documents:
+            grouped[digest].append((document, digest))
+        validated: list[tuple[RawDocument, str]] = []
+        for digest, items in grouped.items():
+            domains = {_domain_from_url(item[0].url) for item in items}
+            if len(domains) < self._min_sources:
+                continue
+            validated.extend(items)
+        return validated
+
+
+class VectorStoreTransaction:
+    """Best-effort transactional guard for vector store mutations."""
+
+    def __init__(self, store) -> None:
+        self._store = store
+        self._committed = False
+        self._token = None
+        self._path = Path(getattr(store, "path", "")) if getattr(store, "path", None) else None
+
+    def __enter__(self) -> "VectorStoreTransaction":
+        self._snapshot()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if exc_type is not None or not self._committed:
+            self.rollback()
+
+    def commit(self) -> None:
+        self._committed = True
+
+    # ------------------------------------------------------------------
+
+    def _snapshot(self) -> None:
+        if hasattr(self._store, "snapshot"):
+            self._token = self._store.snapshot()
+            return
+        if self._path and self._path.exists():
+            self._token = self._path.read_bytes()
+
+    def rollback(self) -> None:
+        if hasattr(self._store, "restore"):
+            if self._token is not None:
+                self._store.restore(self._token)
+            return
+        if self._path is None:
+            return
+        if self._token is None:
+            if self._path.exists():
+                self._path.unlink()
+            return
+        self._path.write_bytes(self._token)
+
+
+class LedgerView:
+    """Read access helper for the consent ledger."""
+
+    def __init__(self, path: Path | None) -> None:
+        self.path = path
+
+    def approvals(self) -> dict[str, str]:
+        records = self._load_entries()
+        approvals: dict[str, str] = {}
+        for entry in records:
+            action = entry.get("action")
+            domain = entry.get("domain")
+            if not isinstance(domain, str):
+                continue
+            if action == "approve":
+                approvals[domain] = entry.get("timestamp", "")
+            elif action == "revoke":
+                approvals.pop(domain, None)
+        return approvals
+
+    def revocations_since(self, since: datetime) -> list[str]:
+        records = self._load_entries()
+        revoked: list[str] = []
+        since_norm = _normalise_datetime(since)
+        for entry in records:
+            if entry.get("action") != "revoke":
+                continue
+            timestamp = self._parse_timestamp(entry.get("timestamp"))
+            if timestamp is None:
+                continue
+            if _normalise_datetime(timestamp) < since_norm:
+                continue
+            domain = entry.get("domain")
+            if isinstance(domain, str):
+                revoked.append(domain)
+        return revoked
+
+    def _load_entries(self) -> Iterator[dict[str, str]]:
+        if self.path is None or not self.path.exists():
+            return iter(())
+        with self.path.open("r", encoding="utf-8") as handle:
+            lines = handle.readlines()
+        if not lines:
+            return iter(())
+        entries: list[dict[str, str]] = []
+        for line in lines[1:]:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(data, dict):
+                continue
+            entries.append({str(k): v for k, v in data.items()})
+        return iter(entries)
+
+    @staticmethod
+    def _parse_timestamp(value: object) -> datetime | None:
+        if not isinstance(value, str):
+            return None
+        try:
+            if value.endswith("Z"):
+                value = value[:-1] + "+00:00"
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return None
+
+
+class ReportGenerator:
+    """Persist weekly HTML report about ingested and revoked sources."""
+
+    def __init__(self, output_path: Path) -> None:
+        self.output_path = output_path
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        self._history_path = output_path.with_suffix(".json")
+
+    def record(
+        self,
+        *,
+        ingested: Sequence[str],
+        revoked: Sequence[str],
+        timestamp: datetime,
+    ) -> None:
+        history = self._load_history()
+        now_iso = timestamp.isoformat()
+        for url in ingested:
+            history.append({"type": "ingested", "value": url, "timestamp": now_iso})
+        for domain in revoked:
+            history.append({"type": "revoked", "value": domain, "timestamp": now_iso})
+        self._save_history(history)
+        self._write_report(history, timestamp)
+
+    def _load_history(self) -> list[dict[str, str]]:
+        if not self._history_path.exists():
+            return []
+        try:
+            data = json.loads(self._history_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            return []
+        if not isinstance(data, list):
+            return []
+        return [item for item in data if isinstance(item, dict)]
+
+    def _save_history(self, history: Sequence[dict[str, str]]) -> None:
+        self._history_path.write_text(
+            json.dumps(list(history), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def _write_report(self, history: Sequence[Mapping[str, str]], now: datetime) -> None:
+        window_start = now - timedelta(days=7)
+        since_norm = _normalise_datetime(window_start)
+        ingested: list[str] = []
+        revoked: list[str] = []
+        for entry in history:
+            timestamp = LedgerView._parse_timestamp(entry.get("timestamp"))
+            if timestamp is None:
+                continue
+            if _normalise_datetime(timestamp) < since_norm:
+                continue
+            if entry.get("type") == "ingested":
+                ingested.append(str(entry.get("value", "")))
+            elif entry.get("type") == "revoked":
+                revoked.append(str(entry.get("value", "")))
+        html = [
+            "<html>",
+            "  <head>",
+            "    <meta charset='utf-8'>",
+            "    <title>Ce qui a été appris</title>",
+            "  </head>",
+            "  <body>",
+            f"    <h1>Ce qui a été appris – semaine du {window_start.date()}</h1>",
+        ]
+        html.append("    <h2>Sources ingérées</h2>")
+        if ingested:
+            html.append("    <ul>")
+            html.extend(f"      <li>{item}</li>" for item in sorted(set(ingested)))
+            html.append("    </ul>")
+        else:
+            html.append("    <p>Aucune nouvelle source.</p>")
+        html.append("    <h2>Sources révoquées</h2>")
+        if revoked:
+            html.append("    <ul>")
+            html.extend(f"      <li>{item}</li>" for item in sorted(set(revoked)))
+            html.append("    </ul>")
+        else:
+            html.append("    <p>Aucune révocation enregistrée.</p>")
+        html.extend(["  </body>", "</html>"])
+        self.output_path.write_text("\n".join(html), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Controller implementation
+
+
+class AutopilotController:
+    """High level coordinator chaining discovery, scraping and ingestion."""
+
+    def __init__(
+        self,
+        *,
+        scheduler: AutopilotScheduler,
+        pipeline: IngestPipeline,
+        crawler: DiscoveryCrawler,
+        scraper: Scraper | None = None,
+        throttle_seconds: float = 1.0,
+        report_path: Path | None = None,
+        logger: logging.Logger | None = None,
+        sleep_func: callable | None = None,
+        clock: callable | None = None,
+    ) -> None:
+        self.scheduler = scheduler
+        self.pipeline = pipeline
+        self.crawler = crawler
+        self.scraper = scraper or HTTPScraper()
+        self._throttle = max(0.0, float(throttle_seconds))
+        self._sleep = sleep_func or time.sleep
+        self._clock = clock or datetime.utcnow
+        self._logger = logger or LOGGER
+        policy_manager = scheduler._policy_manager  # type: ignore[attr-defined]
+        self._policy_loader = scheduler._policy_loader  # type: ignore[attr-defined]
+        self._config_dir = (
+            policy_manager.config_dir
+            if policy_manager is not None
+            else Path.home() / ".watcher"
+        )
+        self._ledger_path = (
+            policy_manager.ledger_path if policy_manager is not None else None
+        )
+        reports_dir = report_path or (self._config_dir / "reports" / "weekly.html")
+        self._reporter = ReportGenerator(Path(reports_dir))
+        self._ledger_view = LedgerView(self._ledger_path)
+        self._last_request: dict[str, float] = {}
+
+    # ------------------------------------------------------------------
+
+    def run(self, topics: Sequence[str] | None = None) -> AutopilotRunResult:
+        now = self._clock()
+        topics = list(topics or [])
+        if topics:
+            state = self.scheduler.enable(topics, now=now)
+        else:
+            state = self.scheduler.evaluate(now=now)
+        if not state.online:
+            reason = state.last_reason or "offline"
+            self._logger.info("Autopilot en pause (%s)", reason)
+            return AutopilotRunResult(ingested=0, reason=reason)
+        try:
+            policy = self._policy_loader()
+        except PolicyError as exc:  # pragma: no cover - defensive
+            raise AutopilotError(str(exc)) from exc
+        if policy.defaults.kill_switch:
+            self._logger.warning("Kill-switch actif – exécution interrompue.")
+            return AutopilotRunResult(ingested=0, reason="kill-switch")
+        if not policy.network.allowlist:
+            self._logger.warning("Aucun domaine autorisé – rien à faire.")
+            return AutopilotRunResult(ingested=0, reason="allowlist vide")
+
+        allowed = {rule.domain: rule for rule in policy.network.allowlist}
+        consented = self._ledger_view.approvals()
+        gate = ConsentGate(
+            allowed=allowed,
+            consented=consented,
+            require_consent=policy.defaults.require_consent,
+            logger=self._logger,
+        )
+        verifier = MultiSourceVerifier(min_sources=self.pipeline.min_sources)
+
+        discovered = list(self.crawler.discover(topics or state.queue, allowed.values()))
+        collected: list[tuple[RawDocument, str]] = []
+        skipped: list[str] = []
+
+        bandwidth_limit = float(policy.network.bandwidth_mb)
+        total_bandwidth = 0.0
+        per_domain_bandwidth: MutableMapping[str, float] = defaultdict(float)
+        start_time = now
+
+        for item in discovered:
+            if not gate.allow(item.url):
+                continue
+            domain = _domain_from_url(item.url)
+            if not domain:
+                skipped.append(item.url)
+                continue
+            rule = allowed.get(domain)
+            if rule is None:
+                # consent single-use without explicit rule
+                rule = DomainRule(
+                    domain=domain,
+                    categories=[],
+                    bandwidth_mb=policy.network.bandwidth_mb,
+                    time_budget_minutes=policy.network.time_budget_minutes,
+                    allow_subdomains=True,
+                    scope="web",
+                )
+            if self._exceeded_time(policy, rule, start_time):
+                self._logger.warning("Budget temporel dépassé pour %s.", domain)
+                break
+            self._throttle_domain(domain)
+            result = self.scraper.fetch(item.url, respect_robots=True)
+            if result is None or not result.content:
+                skipped.append(item.url)
+                continue
+            licence = result.license or item.licence
+            if licence is None or licence not in self.pipeline.allowed_licences:
+                skipped.append(item.url)
+                continue
+            text = result.content.strip()
+            if not text:
+                skipped.append(item.url)
+                continue
+            title = item.title or self._guess_title(text)
+            raw = RawDocument(
+                url=item.url,
+                title=title,
+                text=text,
+                licence=licence,
+                published_at=item.published_at,
+            )
+            digest = hashlib.sha256(text.encode("utf-8")).hexdigest()
+            collected.append((raw, digest))
+            payload_mb = _bytes_to_mb(len(result.raw_content))
+            total_bandwidth += payload_mb
+            per_domain_bandwidth[domain] += payload_mb
+            if total_bandwidth > bandwidth_limit:
+                self._logger.warning("Budget global dépassé (%s MB).", bandwidth_limit)
+                break
+            if per_domain_bandwidth[domain] > float(rule.bandwidth_mb):
+                self._logger.warning(
+                    "Budget de bande passante dépassé pour %s (%.2f MB).",
+                    domain,
+                    rule.bandwidth_mb,
+                )
+                break
+
+        verified = verifier.filter(collected)
+        if not verified:
+            self._logger.info("Aucun contenu corroboré à ingérer.")
+            return AutopilotRunResult(ingested=0, skipped=skipped, blocked=gate.blocked)
+
+        try:
+            with VectorStoreTransaction(self.pipeline.store) as transaction:
+                ingested = self.pipeline.ingest([item[0] for item in verified])
+                transaction.commit()
+        except IngestValidationError as exc:
+            self._logger.error("Ingestion interrompue: %s", exc)
+            return AutopilotRunResult(
+                ingested=0,
+                skipped=skipped,
+                blocked=gate.blocked,
+                reason="ingestion invalide",
+            )
+
+        recent_revoked = self._ledger_view.revocations_since(now - timedelta(days=7))
+        self._reporter.record(
+            ingested=[item[0].url for item in verified],
+            revoked=recent_revoked,
+            timestamp=now,
+        )
+        return AutopilotRunResult(
+            ingested=ingested,
+            skipped=skipped,
+            blocked=gate.blocked,
+        )
+
+    # ------------------------------------------------------------------
+
+    def _throttle_domain(self, domain: str) -> None:
+        if self._throttle <= 0:
+            return
+        now = time.monotonic()
+        last = self._last_request.get(domain)
+        if last is not None:
+            delta = now - last
+            if delta < self._throttle:
+                self._sleep(self._throttle - delta)
+        self._last_request[domain] = time.monotonic()
+
+    def _exceeded_time(
+        self,
+        policy: Policy,
+        rule: DomainRule,
+        start: datetime,
+    ) -> bool:
+        elapsed = (self._clock() - start).total_seconds() / 60
+        if elapsed > float(policy.network.time_budget_minutes):
+            return True
+        return elapsed > float(rule.time_budget_minutes)
+
+    @staticmethod
+    def _guess_title(text: str) -> str:
+        first_line = text.split("\n", 1)[0]
+        return first_line[:120].strip() or "Document"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+
+
+def _domain_from_url(url: str) -> str | None:
+    try:
+        parsed = urlparse(url)
+    except Exception:  # pragma: no cover - defensive
+        return None
+    hostname = parsed.hostname or ""
+    return hostname.lower() or None
+
+
+def _bytes_to_mb(size: int) -> float:
+    if size <= 0:
+        return 0.0
+    return round(size / (1024 * 1024), 4)
+
+
+def _normalise_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+

--- a/app/autopilot/scheduler.py
+++ b/app/autopilot/scheduler.py
@@ -222,6 +222,17 @@ class AutopilotScheduler:
             if engine is not None:
                 engine.set_offline(True)
             raise AutopilotError(message) from exc
+        if policy.defaults.kill_switch:
+            if self.state.enabled:
+                self._log("warning", "Kill-switch activé – autopilot suspendu.")
+            self.state.enabled = False
+            self.state.online = False
+            self.state.current_topic = None
+            self.state.last_reason = "kill-switch"
+            self._save_state()
+            if engine is not None:
+                engine.set_offline(True)
+            return self.state
         usage = self._resource_probe.snapshot()
         self.state.last_cpu_percent = usage.cpu_percent
         self.state.last_ram_mb = usage.ram_mb

--- a/tests/test_autopilot_controller.py
+++ b/tests/test_autopilot_controller.py
@@ -1,0 +1,355 @@
+"""End-to-end and guardrail tests for the autopilot controller."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import yaml
+
+from app.autopilot import (
+    AutopilotController,
+    ConsentGate,
+    DiscoveryResult,
+    MultiSourceVerifier,
+)
+from app.autopilot.scheduler import AutopilotScheduler, ResourceUsage
+from app.ingest import IngestPipeline
+from app.ingest.pipeline import IngestValidationError, RawDocument
+from app.policy.manager import PolicyManager
+from app.scrapers.http import ScrapeResult
+
+
+class ControlledClock:
+    def __init__(self, start: datetime) -> None:
+        self._now = start
+
+    def advance(self, *, minutes: int = 0, seconds: int = 0) -> None:
+        self._now += timedelta(minutes=minutes, seconds=seconds)
+
+    def set(self, new_value: datetime) -> None:
+        self._now = new_value
+
+    def __call__(self) -> datetime:
+        return self._now
+
+
+class SequenceProbe:
+    def __init__(self, values: Sequence[ResourceUsage]) -> None:
+        self._values = list(values)
+        self._index = 0
+
+    def snapshot(self) -> ResourceUsage:
+        value = self._values[min(self._index, len(self._values) - 1)]
+        self._index += 1
+        return value
+
+
+class MemoryVectorStore:
+    def __init__(self) -> None:
+        self.data: list[tuple[str, dict[str, object]]] = []
+
+    def add(self, texts: Sequence[str], metas: Sequence[dict[str, object]]) -> None:
+        for text, meta in zip(texts, metas, strict=True):
+            self.data.append((text, dict(meta)))
+
+    def snapshot(self) -> list[tuple[str, dict[str, object]]]:
+        return [
+            (text, dict(meta))
+            for text, meta in self.data
+        ]
+
+    def restore(self, snapshot: Sequence[tuple[str, dict[str, object]]]) -> None:
+        self.data = [
+            (text, dict(meta))
+            for text, meta in snapshot
+        ]
+
+
+class DummyCrawler:
+    def __init__(self) -> None:
+        self._batches: list[list[DiscoveryResult]] = []
+
+    def queue(self, results: Iterable[DiscoveryResult]) -> None:
+        self._batches.append(list(results))
+
+    def discover(
+        self,
+        topics: Sequence[str],
+        rules: Sequence,
+    ) -> Iterable[DiscoveryResult]:
+        if self._batches:
+            return self._batches.pop(0)
+        return []
+
+
+class DummyScraper:
+    def __init__(self, mapping: dict[str, ScrapeResult]) -> None:
+        self.mapping = mapping
+
+    def fetch(self, url: str, *, respect_robots: bool = True) -> ScrapeResult | None:  # noqa: D401
+        return self.mapping.get(url)
+
+
+class FaultyPipeline(IngestPipeline):
+    def ingest(self, documents: Sequence[RawDocument], *, seen_digests: set[str] | None = None) -> int:  # noqa: D401
+        super().ingest(documents, seen_digests=seen_digests)
+        raise IngestValidationError("rollback test")
+
+
+@dataclass
+class PolicyFiles:
+    policy_path: Path
+    ledger_path: Path
+
+
+def _prepare_policy(home: Path, now: datetime) -> PolicyFiles:
+    config_dir = home / ".watcher"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    policy_path = config_dir / "policy.yaml"
+    ledger_path = config_dir / "consent-ledger.jsonl"
+    window = {"days": [now.strftime("%a").lower()[:3]], "window": "09:00-10:00"}
+    allowlist = [
+        {
+            "domain": "allowed-one.test",
+            "categories": ["news"],
+            "bandwidth_mb": 15,
+            "time_budget_minutes": 30,
+            "allow_subdomains": True,
+            "scope": "web",
+            "last_approved": now.isoformat(),
+        },
+        {
+            "domain": "allowed-two.test",
+            "categories": ["news"],
+            "bandwidth_mb": 15,
+            "time_budget_minutes": 30,
+            "allow_subdomains": True,
+            "scope": "web",
+            "last_approved": now.isoformat(),
+        },
+    ]
+    policy = {
+        "version": 1,
+        "subject": {"hostname": "test", "generated_at": now.isoformat()},
+        "defaults": {"offline": False, "require_consent": True, "kill_switch": False},
+        "network": {
+            "allowed_windows": [window],
+            "allowlist": allowlist,
+            "bandwidth_mb": 50,
+            "time_budget_minutes": 60,
+        },
+        "budgets": {"cpu_percent": 80, "ram_mb": 1024},
+        "categories": {"allowed": ["news"]},
+        "models": {
+            "llm": {"name": "dummy", "sha256": "0", "license": "Apache-2.0"},
+            "embedding": {"name": "dummy", "sha256": "1", "license": "Apache-2.0"},
+        },
+    }
+    policy_path.write_text(yaml.safe_dump(policy, sort_keys=False), encoding="utf-8")
+    timestamp = now.isoformat(timespec="seconds") + "Z"
+    ledger_content = "\n".join(
+        [
+            json.dumps({"type": "metadata", "secret_hex": "00" * 32}),
+            json.dumps(
+                {
+                    "type": "entry",
+                    "timestamp": timestamp,
+                    "action": "approve",
+                    "domain": "oneshot.test",
+                    "scope": "web",
+                    "policy_hash": "abc",
+                    "signature": "sig",
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "entry",
+                    "timestamp": timestamp,
+                    "action": "revoke",
+                    "domain": "revoked.test",
+                    "scope": "web",
+                    "policy_hash": "abc",
+                    "signature": "sig",
+                }
+            ),
+        ]
+    )
+    ledger_path.write_text(ledger_content + "\n", encoding="utf-8")
+    return PolicyFiles(policy_path=policy_path, ledger_path=ledger_path)
+
+
+def _scrape(url: str, text: str) -> ScrapeResult:
+    payload = text.encode("utf-8")
+    return ScrapeResult(
+        url=url,
+        content=text,
+        raw_content=payload,
+        content_hash=hashlib.sha256(payload).hexdigest(),
+        license="CC-BY-4.0",
+        headers={},
+        etag=None,
+        last_modified=None,
+        is_duplicate=False,
+    )
+
+
+def test_autopilot_controller_end_to_end(tmp_path: Path) -> None:
+    start = datetime(2024, 1, 2, 9, 5, 0)
+    files = _prepare_policy(tmp_path, start)
+    clock = ControlledClock(start)
+    probe = SequenceProbe(
+        [
+            ResourceUsage(cpu_percent=20, ram_mb=256),
+            ResourceUsage(cpu_percent=95, ram_mb=256),
+            ResourceUsage(cpu_percent=20, ram_mb=256),
+            ResourceUsage(cpu_percent=20, ram_mb=256),
+        ]
+    )
+    store = MemoryVectorStore()
+    pipeline = IngestPipeline(store, chunk_size=256, min_sources=2, allowed_licences={"CC-BY-4.0"})
+
+    crawler = DummyCrawler()
+    text = "Le contenu valide partagé."
+    crawler.queue(
+        [
+            DiscoveryResult(
+                url="https://allowed-one.test/article",
+                title="Article A",
+                summary="",
+                licence="CC-BY-4.0",
+            ),
+            DiscoveryResult(
+                url="https://allowed-two.test/article",
+                title="Article B",
+                summary="",
+                licence="CC-BY-4.0",
+            ),
+            DiscoveryResult(
+                url="https://blocked.test/info",
+                title="Bloqué",
+                summary="",
+                licence="CC-BY-4.0",
+            ),
+            DiscoveryResult(
+                url="https://oneshot.test/update",
+                title="Consentement",
+                summary="",
+                licence="CC-BY-4.0",
+            ),
+        ]
+    )
+    crawler.queue(
+        [
+            DiscoveryResult(
+                url="https://allowed-one.test/article",
+                title="Article A",
+                summary="",
+                licence="CC-BY-4.0",
+            ),
+            DiscoveryResult(
+                url="https://allowed-two.test/article",
+                title="Article B",
+                summary="",
+                licence="CC-BY-4.0",
+            ),
+        ]
+    )
+
+    scraper = DummyScraper(
+        {
+            "https://allowed-one.test/article": _scrape("https://allowed-one.test/article", text),
+            "https://allowed-two.test/article": _scrape("https://allowed-two.test/article", text),
+            "https://oneshot.test/update": _scrape("https://oneshot.test/update", text),
+        }
+    )
+
+    manager = PolicyManager(home=tmp_path)
+    scheduler = AutopilotScheduler(
+        policy_manager=manager,
+        state_path=files.policy_path.parent / "autopilot-state.json",
+        resource_probe=probe,
+        clock=clock,
+    )
+    controller = AutopilotController(
+        scheduler=scheduler,
+        pipeline=pipeline,
+        crawler=crawler,
+        scraper=scraper,
+        throttle_seconds=0.0,
+        clock=clock,
+        sleep_func=lambda _: None,
+        report_path=files.policy_path.parent / "reports" / "weekly.html",
+    )
+
+    result = controller.run(["veille"])
+    assert result.ingested == 1
+    assert "blocked.test" in result.blocked
+    assert store.data, "store must contain ingested entries"
+
+    # Budgets exceeded – autopilot pauses before scraping
+    clock.advance(minutes=1)
+    result_budget = controller.run()
+    assert result_budget.reason == "budgets dépassés"
+    assert len(store.data) == 1
+
+    # Outside allowed window
+    clock.set(datetime(2024, 1, 2, 11, 0, 0))
+    result_window = controller.run()
+    assert result_window.reason == "hors fenêtre réseau"
+    assert len(store.data) == 1
+
+    # Rollback when ingestion fails
+    clock.set(datetime(2024, 1, 2, 9, 5, 0))
+    crawler.queue(
+        [
+            DiscoveryResult(
+                url="https://allowed-one.test/article",
+                title="Article A",
+                summary="",
+                licence="CC-BY-4.0",
+            ),
+            DiscoveryResult(
+                url="https://allowed-two.test/article",
+                title="Article B",
+                summary="",
+                licence="CC-BY-4.0",
+            ),
+        ]
+    )
+    controller.pipeline = FaultyPipeline(store, chunk_size=256, min_sources=2, allowed_licences={"CC-BY-4.0"})
+    result_fail = controller.run()
+    assert result_fail.reason == "ingestion invalide"
+    assert len(store.data) == 1, "store should be restored after failure"
+
+    report_path = files.policy_path.parent / "reports" / "weekly.html"
+    assert report_path.exists()
+    report_html = report_path.read_text(encoding="utf-8")
+    assert "Ce qui a été appris" in report_html
+    assert "revoked.test" in report_html
+
+
+def test_consent_gate_and_verifier() -> None:
+    gate = ConsentGate(
+        allowed={"allowed.test": object()},
+        consented={"oneshot.test": "now"},
+        require_consent=True,
+    )
+    assert gate.allow("https://allowed.test/foo")
+    assert gate.allow("https://oneshot.test/bar")
+    assert not gate.allow("https://oneshot.test/bar")
+    assert "oneshot.test" in gate.blocked
+
+    doc_a = RawDocument(url="https://a.test/1", title="A", text="same", licence="CC-BY-4.0")
+    doc_b = RawDocument(url="https://b.test/2", title="B", text="same", licence="CC-BY-4.0")
+    doc_c = RawDocument(url="https://c.test/3", title="C", text="unique", licence="CC-BY-4.0")
+    digest_same = hashlib.sha256("same".encode("utf-8")).hexdigest()
+    digest_unique = hashlib.sha256("unique".encode("utf-8")).hexdigest()
+    verifier = MultiSourceVerifier(min_sources=2)
+    result = verifier.filter([(doc_a, digest_same), (doc_b, digest_same), (doc_c, digest_unique)])
+    assert (doc_c, digest_unique) not in result
+    assert len(result) == 2


### PR DESCRIPTION
## Summary
- add an autopilot controller that chains discovery, scraping, verification, and ingestion while honouring consent, bandwidth, and time budgets
- extend the scheduler to honour the kill-switch flag and expose orchestration helpers from the autopilot package
- cover the controller with end-to-end and unit tests including rollback and consent guardrails, and generate weekly HTML reporting

## Testing
- pytest tests/test_autopilot_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68dff4a229fc8320bbd660a1568106a0