### PR TITLE
Update autostart command to invoke CLI module

### DIFF
--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,5 +1,6 @@
 from .np import np
 from .metrics import metrics, PerformanceMetrics
 from . import psutil_stub
+from . import autostart
 
-__all__ = ["np", "metrics", "PerformanceMetrics", "psutil_stub"]
+__all__ = ["np", "metrics", "PerformanceMetrics", "psutil_stub", "autostart"]

--- a/app/utils/autostart.py
+++ b/app/utils/autostart.py
@@ -1,0 +1,88 @@
+"""Helpers to build autostart definitions for the autopilot scheduler."""
+
+from __future__ import annotations
+
+import shlex
+import sys
+import textwrap
+from pathlib import Path
+from typing import Mapping
+
+CommandParts = list[str]
+
+
+def _command_parts() -> CommandParts:
+    """Return the command used to query the autopilot status.
+
+    The command calls the project CLI module directly so that it works both in
+    editable installs and in packaged distributions where the ``watcher`` entry
+    point may not be available (for example inside Windows scheduled tasks or
+    systemd units).
+    """
+
+    return [sys.executable, "-m", "app.cli", "autopilot", "status"]
+
+
+def _command_string() -> str:
+    """Return the command formatted as a shell-safe string."""
+
+    return shlex.join(_command_parts())
+
+
+def windows_task_definition(
+    working_directory: Path,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, object]:
+    """Build the action block for a Windows scheduled task.
+
+    Parameters
+    ----------
+    working_directory:
+        Directory from which the task should run.
+    env:
+        Optional environment variables to inject into the task.
+    """
+
+    command = _command_parts()
+    return {
+        "trigger": "logon",
+        "action": {
+            "path": command[0],
+            "arguments": command[1:],
+            "working_directory": str(working_directory),
+        },
+        "environment": dict(env or {}),
+    }
+
+
+def systemd_service_unit(
+    working_directory: Path,
+    env: Mapping[str, str] | None = None,
+) -> str:
+    """Render the systemd unit file that probes the autopilot status."""
+
+    env_block = ""
+    if env:
+        env_block = "".join(
+            f"Environment={key}={value}\n        " for key, value in env.items()
+        )
+
+    body = textwrap.dedent(
+        f"""
+        [Unit]
+        Description=Watcher Autopilot status probe
+        After=network-online.target
+
+        [Service]
+        Type=oneshot
+        WorkingDirectory={working_directory}
+        {env_block}ExecStart={_command_string()}
+
+        [Install]
+        WantedBy=multi-user.target
+        """
+    ).strip()
+
+    # Ensure there is a single trailing newline and no trailing whitespace.
+    body = "\n".join(line.rstrip() for line in body.splitlines())
+    return body + "\n"

--- a/tests/test_autostart_config.py
+++ b/tests/test_autostart_config.py
@@ -1,0 +1,25 @@
+"""Tests for OS-specific autostart helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.utils import autostart
+
+
+def test_systemd_unit_uses_cli_module(monkeypatch) -> None:
+    monkeypatch.setattr(autostart.sys, "executable", "/opt/python/bin/python3")
+    unit = autostart.systemd_service_unit(Path("/srv/watcher"))
+    assert "ExecStart=/opt/python/bin/python3 -m app.cli autopilot status" in unit
+
+
+def test_windows_task_uses_cli_module(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(autostart.sys, "executable", r"C:\\Python311\\python.exe")
+    definition = autostart.windows_task_definition(tmp_path)
+    assert definition["action"]["path"] == r"C:\\Python311\\python.exe"
+    assert definition["action"]["arguments"] == [
+        "-m",
+        "app.cli",
+        "autopilot",
+        "status",
+    ]


### PR DESCRIPTION
## Summary
- add an autostart utility that invokes the watcher CLI module for autopilot status checks
- expose the new autostart helpers from the utils package
- cover the Windows and systemd definitions with tests that verify the CLI-based command

## Testing
- pytest tests/test_autostart_config.py

------
https://chatgpt.com/codex/tasks/task_e_68e001598bc88320b34553f145b11972