### PR TITLE
Fix allowlist filtering for multi-scope approvals

### DIFF
--- a/app/policy/manager.py
+++ b/app/policy/manager.py
@@ -79,7 +79,9 @@ class PolicyManager:
             last_approved=datetime.utcnow(),
         )
         policy.network.allowlist = [
-            existing for existing in policy.network.allowlist if existing.domain != domain
+            existing
+            for existing in policy.network.allowlist
+            if existing.domain != domain or existing.scope != scope
         ]
         policy.network.allowlist.append(rule)
         self._write_policy(policy)

--- a/tests/test_policy_manager.py
+++ b/tests/test_policy_manager.py
@@ -45,3 +45,23 @@ def test_policy_manager_approve_and_revoke(tmp_path: Path) -> None:
         (home / ".watcher" / "policy.yaml").read_text(encoding="utf-8")
     )
     assert not policy_data["network"]["allowlist"]
+
+
+def test_policy_manager_multiple_scopes_same_domain(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    configurator = FirstRunConfigurator(home=home)
+    configurator.run(auto=True, download_models=False)
+
+    manager = PolicyManager(home=home)
+    manager.approve(domain="example.com", scope="web")
+    manager.approve(domain="example.com", scope="api")
+
+    policy_data = yaml.safe_load(
+        (home / ".watcher" / "policy.yaml").read_text(encoding="utf-8")
+    )
+    allowlist = policy_data["network"]["allowlist"]
+
+    scopes = {entry["scope"] for entry in allowlist if entry["domain"] == "example.com"}
+    assert scopes == {"web", "api"}


### PR DESCRIPTION
## Summary
- ensure PolicyManager.approve only removes existing rules that match both domain and scope when re-approving
- add a regression test covering multiple approvals for the same domain with different scopes

## Testing
- pytest tests/test_policy_manager.py

------
https://chatgpt.com/codex/tasks/task_e_68e0015ca8f48320aca3630487b5f0af