### PR TITLE
Add legacy policy migration logic

### DIFF
--- a/tests/fixtures/policy_legacy.yaml
+++ b/tests/fixtures/policy_legacy.yaml
@@ -1,0 +1,31 @@
+version: 1
+subject:
+  hostname: localhost
+  generated_at: 2024-01-01T00:00:00Z
+defaults:
+  offline: true
+  require_consent: true
+  kill_switch: false
+network:
+  allowed_windows:
+    - days: [mon, tue, wed, thu, fri]
+      window: "09:00-18:00"
+  allowlist: []
+  bandwidth_mb: 128
+  time_budget_minutes: 15
+budgets:
+  cpu_percent: 75
+  ram_mb: 4096
+categories:
+  allowed:
+    - documentation
+    - code
+models:
+  llm:
+    name: llama-test
+    sha256: deadbeef
+    license: example
+  embedding:
+    name: embed-test
+    sha256: feedface
+    license: example

--- a/tests/test_policy_manager.py
+++ b/tests/test_policy_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -45,3 +46,65 @@ def test_policy_manager_approve_and_revoke(tmp_path: Path) -> None:
         (home / ".watcher" / "policy.yaml").read_text(encoding="utf-8")
     )
     assert not policy_data["network"]["allowlist"]
+
+
+def test_read_policy_transforms_legacy_payload(tmp_path: Path, monkeypatch) -> None:
+    legacy_policy = (
+        Path(__file__).parent / "fixtures" / "policy_legacy.yaml"
+    ).read_text(encoding="utf-8")
+
+    home = tmp_path / "home"
+    config_dir = home / ".watcher"
+    config_dir.mkdir(parents=True)
+    (config_dir / "policy.yaml").write_text(legacy_policy, encoding="utf-8")
+
+    network_schema = {
+        "properties": {
+            "windows": {"type": "array"},
+            "allowlist": {"type": "array"},
+            "budgets": {"type": "object"},
+        }
+    }
+    defaults_schema = {
+        "properties": {
+            "autostart": {"default": False, "type": "boolean"},
+            "require_corroboration": {"default": True, "type": "boolean"},
+            "kill_switch": {"default": False, "type": "boolean"},
+        }
+    }
+
+    class FakePolicy:
+        @classmethod
+        def model_json_schema(cls) -> dict[str, Any]:  # type: ignore[override]
+            return {
+                "$defs": {
+                    "Defaults": defaults_schema,
+                    "NetworkSection": network_schema,
+                }
+            }
+
+        @classmethod
+        def model_validate(cls, data: dict[str, Any]) -> dict[str, Any]:
+            defaults = data["defaults"]
+            assert "offline" not in defaults
+            assert defaults["autostart"] is False
+            assert defaults["require_corroboration"] is True
+
+            network = data["network"]
+            assert "allowed_windows" not in network
+            assert "bandwidth_mb" not in network
+            assert "time_budget_minutes" not in network
+            assert network["budgets"] == {
+                "bandwidth_mb": 128,
+                "time_budget_minutes": 15,
+            }
+            assert network["windows"][0]["cidrs"] == ["0.0.0.0/0", "::/0"]
+            assert network["windows"][0]["name"] == "default"
+            assert network["windows"][0]["allowed_windows"]
+            return data
+
+    monkeypatch.setattr("app.policy.manager.Policy", FakePolicy)
+
+    manager = PolicyManager(home=home)
+    result = manager._read_policy()
+    assert result["defaults"]["autostart"] is False


### PR DESCRIPTION
## Summary
- add a normalization step in `PolicyManager` to upgrade legacy policy payloads before validation
- translate legacy defaults, network windows, and budgets into the new schema when the model expects it
- add a legacy `policy.yaml` fixture and a unit test covering the migration path

## Testing
- pytest tests/test_policy_manager.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e0015cd7308320887eb9f7bd4f5ec6