### PR TITLE
feat: persist autopilot queue scoring metadata

### DIFF
--- a/app/autopilot/__init__.py
+++ b/app/autopilot/__init__.py
@@ -17,6 +17,8 @@ from .scheduler import (
     AutopilotState,
     ResourceProbe,
     ResourceUsage,
+    TopicQueueEntry,
+    TopicScore,
 )
 
 __all__ = [
@@ -26,6 +28,8 @@ __all__ = [
     "AutopilotLogEntry",
     "AutopilotScheduler",
     "AutopilotState",
+    "TopicQueueEntry",
+    "TopicScore",
     "ConsentGate",
     "DefaultDiscoveryCrawler",
     "DiscoveryResult",

--- a/app/autopilot/controller.py
+++ b/app/autopilot/controller.py
@@ -417,7 +417,8 @@ class AutopilotController:
         )
         verifier = MultiSourceVerifier(min_sources=self.pipeline.min_sources)
 
-        discovered = list(self.crawler.discover(topics or state.queue, allowed.values()))
+        active_topics = topics or state.topics
+        discovered = list(self.crawler.discover(active_topics, allowed.values()))
         collected: list[tuple[RawDocument, str]] = []
         skipped: list[str] = []
 

--- a/app/cli.py
+++ b/app/cli.py
@@ -463,7 +463,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                     )
                 if args.topics:
                     topics = _parse_topics(args.topics)
-                    missing = [topic for topic in topics if topic not in state.queue]
+                    queue_topics = {entry.topic for entry in state.queue}
+                    missing = [topic for topic in topics if topic not in queue_topics]
                     if missing:
                         print(
                             "Sujets absents de la file: " + ", ".join(missing)
@@ -545,8 +546,17 @@ def _parse_topics(raw: str | Sequence[str] | None) -> list[str]:
     return topics
 
 
-def _format_queue(queue: Sequence[str]) -> str:
-    return ", ".join(queue) if queue else "vide"
+def _format_queue(queue) -> str:
+    if not queue:
+        return "vide"
+    labels: list[str] = []
+    for entry in queue:
+        topic = getattr(entry, "topic", None)
+        if isinstance(topic, str) and topic:
+            labels.append(topic)
+        else:
+            labels.append(str(entry))
+    return ", ".join(labels) if labels else "vide"
 
 
 def _format_autopilot_wait_message(state) -> str:

--- a/tests/test_cli_autopilot.py
+++ b/tests/test_cli_autopilot.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 import pytest
 
 from app import cli
-from app.autopilot import AutopilotRunResult, AutopilotState
+from app.autopilot import AutopilotRunResult, AutopilotState, TopicQueueEntry
 
 
 class DummyEngine:
@@ -25,7 +25,12 @@ class DummyScheduler:
         self.enable_calls: list[list[str]] = []
         self.disable_calls: list[list[str] | None] = []
         self.evaluate_calls = 0
-        self._enable_state = enable_state or AutopilotState(enabled=True, online=True, queue=["foo"], last_reason="ok")
+        self._enable_state = enable_state or AutopilotState(
+            enabled=True,
+            online=True,
+            queue=[TopicQueueEntry(topic="foo")],
+            last_reason="ok",
+        )
         self._disable_state = disable_state or AutopilotState(enabled=False, online=False, queue=[])
         self._evaluate_state = evaluate_state or self._enable_state
 
@@ -35,7 +40,7 @@ class DummyScheduler:
         if engine is not None:
             engine.set_offline(not self._enable_state.online)
         state = AutopilotState(**self._enable_state.to_dict())
-        state.queue = list(values)
+        state.queue = [TopicQueueEntry(topic=value) for value in values]
         state.current_topic = values[0] if values else None
         return state
 


### PR DESCRIPTION
## Summary
- add structured topic scoring to the autopilot scheduler and persist entries in state
- update CLI/controller helpers to operate on scored queue entries and surface topic names consistently
- extend autopilot test coverage for prioritisation, dequeueing, and legacy state migration

## Testing
- pytest tests/test_autopilot.py tests/test_cli_autopilot.py tests/test_autopilot_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68e03e8db3888320a37fc05514dab348