### PR TITLE
Rename consent ledger to consents.jsonl

### DIFF
--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -14,6 +14,8 @@ def auto_configure_if_needed(home: Path | None = None) -> None:
     configurator = FirstRunConfigurator(home=home)
     skip_models = os.environ.get("WATCHER_BOOTSTRAP_SKIP_MODELS") == "1"
 
+    configurator.migrate_legacy_state()
+
     if not configurator.sentinel_path.exists():
         configurator.ensure_pending()
 

--- a/app/policy/manager.py
+++ b/app/policy/manager.py
@@ -26,7 +26,15 @@ class PolicyManager:
         self.home = home or Path.home()
         self.config_dir = self.home / ".watcher"
         self.policy_path = self.config_dir / "policy.yaml"
-        self.ledger_path = self.config_dir / "consent-ledger.jsonl"
+        self.ledger_path = self.config_dir / "consents.jsonl"
+        legacy_ledger = self.config_dir / "consent-ledger.jsonl"
+        if legacy_ledger.exists() and not self.ledger_path.exists():
+            try:
+                legacy_ledger.replace(self.ledger_path)
+            except OSError:
+                # If the rename fails continue using the legacy path to avoid
+                # regressing behaviour for existing users.
+                self.ledger_path = legacy_ledger
 
     def _read_policy(self) -> Policy:
         if not self.policy_path.exists():

--- a/docs/autonomy_architecture.md
+++ b/docs/autonomy_architecture.md
@@ -194,7 +194,7 @@ class ConsentLedger:
 
     @classmethod
     def default(cls) -> "ConsentLedger":
-        ledger = Path("~/.watcher/consent-ledger.jsonl").expanduser()
+        ledger = Path("~/.watcher/consents.jsonl").expanduser()
         signer = DetachedSigner.from_env()
         return cls(ledger, signer)
 
@@ -350,6 +350,6 @@ watcher autopilot enable --topics "dev-docs,security" --profile dev-docs
 
 - **Index** : migration vers SQLite-VSS nécessite exécution de `alembic upgrade head` pour créer la table `documents` avec colonnes `licence`, `hash`, `score`.
 - **Configuration** : ancien `config.yaml` doit être remplacé par `~/.watcher/config.toml`. Un script `watcher migrate-config` convertira les clés.
-- **Consent Ledger** : créer `~/.watcher/consent-ledger.jsonl` et importer les consentements existants via `watcher policy approve --import legacy.json`.
+- **Consent Ledger** : créer `~/.watcher/consents.jsonl` et importer les consentements existants via `watcher policy approve --import legacy.json`.
 - **Scripts modèles** : utiliser `scripts/setup-local-models.sh`/`.ps1` pour télécharger et vérifier les GGUF par SHA256 ; les anciens chemins `models/` dans le repo sont obsolètes.
 ```

--- a/tests/test_autopilot_controller.py
+++ b/tests/test_autopilot_controller.py
@@ -111,7 +111,7 @@ def _prepare_policy(home: Path, now: datetime) -> PolicyFiles:
     config_dir = home / ".watcher"
     config_dir.mkdir(parents=True, exist_ok=True)
     policy_path = config_dir / "policy.yaml"
-    ledger_path = config_dir / "consent-ledger.jsonl"
+    ledger_path = config_dir / "consents.jsonl"
     window = {"days": [now.strftime("%a").lower()[:3]], "window": "09:00-10:00"}
     allowlist = [
         {

--- a/tests/test_first_run.py
+++ b/tests/test_first_run.py
@@ -42,7 +42,7 @@ def test_first_run_creates_expected_files(tmp_path: Path, monkeypatch: pytest.Mo
     content = policy_path.read_text(encoding="utf-8")
     assert "version: 1" in content
 
-    ledger_path = home / ".watcher" / "consent-ledger.jsonl"
+    ledger_path = home / ".watcher" / "consents.jsonl"
     assert ledger_path.exists()
     ledger_content = ledger_path.read_text(encoding="utf-8")
     assert '"type": "metadata"' in ledger_content

--- a/tests/test_policy_manager.py
+++ b/tests/test_policy_manager.py
@@ -32,7 +32,7 @@ def test_policy_manager_approve_and_revoke(tmp_path: Path) -> None:
     assert any(entry["domain"] == "example.com" for entry in allowlist)
 
     ledger_lines = (
-        (home / ".watcher" / "consent-ledger.jsonl").read_text(encoding="utf-8")
+        (home / ".watcher" / "consents.jsonl").read_text(encoding="utf-8")
         .strip()
         .splitlines()
     )


### PR DESCRIPTION
## Summary
- update the first-run configurator and policy manager to use consents.jsonl for the consent ledger
- migrate legacy consent-ledger.jsonl files automatically during bootstrap and policy operations
- refresh documentation and tests to reference the new ledger filename

## Testing
- pytest tests/test_first_run.py tests/test_policy_manager.py tests/test_autopilot_controller.py


------
https://chatgpt.com/codex/tasks/task_e_68e111a9e104832096c7469be627adb1