### PR TITLE
Add plug-and-play operations guides to documentation

### DIFF
--- a/docs/autopilot.md
+++ b/docs/autopilot.md
@@ -1,0 +1,39 @@
+# Cycle de vie de l'autopilote
+
+Ce document détaille la gouvernance du mode Autopilote de Watcher. Il structure l'exploitation en trois temps : préparation, exécution surveillée et clôture, sans passer par des scripts ou commandes externes.
+
+## Préparation
+
+1. Ouvrir la vue « Autopilote » et sélectionner « Configurer un nouveau scénario ».
+2. Choisir le périmètre fonctionnel (par exemple refonte d'un service, rédaction d'une analyse) et préciser la fenêtre temporelle souhaitée.
+3. Associer le scénario aux consentements pertinents en sélectionnant les fiches actives listées dans le volet latéral.
+4. Définir un budget de tâches et une limite de ressources (temps CPU, accès aux outils) via les curseurs proposés.
+5. Enregistrer le scénario. Il devient visible dans le tableau de bord avec l'état « Prêt ».
+
+## Exécution surveillée
+
+1. Pour démarrer, cliquer sur « Lancer ». L'autopilote entre dans la phase « Analyse » où il collecte les informations nécessaires.
+2. Examiner les hypothèses affichées. Approuver ou ajuster les hypothèses invalides avant de poursuivre vers la phase « Planification ».
+3. Durant la phase « Planification », l'assistant propose une liste d'actions. Désactiver les actions qui dépassent le périmètre ou exigent un consentement absent.
+4. Valider pour passer à la phase « Exécution ». Surveiller les notifications de sécurité ; un indicateur rouge implique une intervention humaine immédiate.
+5. À tout moment, utiliser « Mettre en pause » pour suspendre les actions restantes, ou « Arrêter » pour revenir au statut « Prêt » après justification dans le journal.
+
+## Contrôles intégrés
+
+- Les actions critiques déclenchent un double contrôle. L'autopilote sollicite un binôme pour confirmation avant de poursuivre.
+- Les ressources consommées sont agrégées en temps réel dans le widget « Budget ». Lorsque 80 % du budget est atteint, le système impose une revue intermédiaire.
+- Le moteur applique la politique de consentement pour filtrer les fichiers et sources non autorisés. Une tâche refusée passe automatiquement en revue manuelle.
+
+## Clôture et archivage
+
+1. À la fin de la phase « Synthèse », l'autopilote propose un rapport structuré.
+2. Examiner les sections « Actions réalisées », « Décisions humaines » et « Recommandations ». Ajouter des commentaires si nécessaire.
+3. Sélectionner « Approuver et archiver » pour générer le paquet d'audit contenant le journal, les artefacts signés et les hachages de référence.
+4. Exporter le paquet vers le coffre hors ligne ou sur la clé de contrôle conformément aux règles internes.
+
+## Entretien récurrent
+
+- Planifier des revues trimestrielles des scénarios pour s'assurer que les budgets et contraintes restent pertinents.
+- Utiliser la [procédure de vérification des artefacts](verifier-artefacts.md) afin de valider les livrables avant diffusion.
+- En cas d'incident, suivre la [procédure de dépannage](depannage.md) pour suspendre l'autopilote et diagnostiquer la cause racine.
+- Pour une mise en route rapide sans script, se référer au [Quickstart sans commande](quickstart-sans-commande.md).

--- a/docs/depannage.md
+++ b/docs/depannage.md
@@ -1,0 +1,38 @@
+# Dépannage plug-and-play
+
+Cette procédure fournit une méthode sans ligne de commande pour diagnostiquer les incidents Watcher en environnement isolé.
+
+## Symptômes courants
+
+- **Autopilote bloqué en phase Analyse** : le module attend une validation de consentement ou une ressource manquante.
+- **Échec de vérification des artefacts** : les hachages ne correspondent pas au registre de référence.
+- **Alertes de quota** : le budget de tâches défini a été dépassé ou une ressource critique est saturée.
+
+## Étapes de résolution
+
+1. Ouvrir le panneau « Surveillance » depuis le tableau de bord principal.
+2. Consulter la carte « Alertes actives ». Chaque alerte renvoie vers un diagnostic guidé.
+3. Si l'alerte concerne le consentement, accéder directement à la fiche via le lien fourni et appliquer le [guide de consentement](policy-consent.md).
+4. Pour un incident Autopilote, cliquer sur « Suspendre en sécurité ». Cette action met l'exécution en pause et enregistre l'état actuel.
+5. Examiner la chronologie des actions dans « Journal des événements ». Repérer l'étape fautive et vérifier les contraintes associées.
+6. Si un artefact est suspect, passer sur « Contrôles d'intégrité » et appliquer la [procédure de vérification des artefacts](verifier-artefacts.md).
+7. Documenter la résolution dans la zone « Compte rendu ». Ce rapport sera joint aux audits ultérieurs.
+
+## Escalade
+
+1. Lorsque la résolution locale échoue, sélectionner « Escalader vers l'équipe sécurité ».
+2. Choisir le type d'incident (panne fonctionnelle, suspicion de compromission, incident de consentement).
+3. Joindre les journaux pertinents et confirmer l'envoi. Le système crypte les données et les stocke sur le support sécurisé convenu.
+
+## Reprise contrôlée
+
+1. Une fois la cause identifiée, retourner sur la carte « Autopilote » et sélectionner « Reprendre après validation ».
+2. Indiquer quelles actions doivent être rejouées ou annulées.
+3. Lancer la reprise. Surveiller les premiers événements pour garantir la stabilité.
+
+## Prévention
+
+- Planifier des vérifications régulières via le [cycle de vie de l'autopilote](autopilot.md) afin d'anticiper les blocages.
+- Renforcer l'intégrité des livrables par la [vérification des artefacts](verifier-artefacts.md) à chaque itération.
+- Actualiser les consentements suivant le [processus dédié](policy-consent.md) pour éviter les suspensions préventives.
+- Intégrer le [Quickstart sans commande](quickstart-sans-commande.md) dans les formations afin de réduire les erreurs de manipulation.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,11 +6,14 @@ mode d'exploitation de la plate-forme.
 
 ## Parcours recommandé
 
-1. Comprendre la [vue d'ensemble de l'architecture](architecture.md) pour visualiser le dialogue entre
+1. Démarrer l'instance à l'aide du [Quickstart sans commande](quickstart-sans-commande.md) qui couvre la mise en service plug-and-play.
+2. Comprendre la [vue d'ensemble de l'architecture](architecture.md) pour visualiser le dialogue entre
    orchestrateur, agents spécialisés et mémoire vectorielle.
-2. Évaluer la surface d'attaque avec le [modèle de menaces](threat-model.md) et ses diagrammes Mermaid et
+3. Évaluer la surface d'attaque avec le [modèle de menaces](threat-model.md) et ses diagrammes Mermaid et
    PlantUML.
-3. Approfondir la gouvernance via la [charte éthique](ethics.md) et les politiques opérationnelles listées ci-dessous.
+4. Consolider la gouvernance en suivant le [guide de consentement](policy-consent.md) et la [charte éthique](ethics.md).
+5. Préparer les opérations récurrentes avec le [cycle de vie de l'autopilote](autopilot.md), la [vérification des artefacts](verifier-artefacts.md)
+   et la [procédure de dépannage](depannage.md).
 
 !!! tip "Navigation rapide"
     Les onglets Material en haut de page regroupent l'architecture, la sécurité et l'exploitation. Utilisez la barre de

--- a/docs/policy-consent.md
+++ b/docs/policy-consent.md
@@ -1,0 +1,42 @@
+# Collecte et gestion du consentement
+
+Ce guide décrit la procédure opérée par Watcher pour consigner les consentements des personnes affectées par l'automatisation. Aucun outil en ligne de commande n'est requis : toutes les opérations s'effectuent dans l'interface « Gouvernance ».
+
+## Principes généraux
+
+1. Toute personne dont les données ou la production peuvent être traitées doit être identifiée par son nom, sa fonction et le périmètre d'usage autorisé.
+2. Le consentement est valide pour une durée déterminée. L'échéance est définie dans la fiche et déclenche automatiquement une alerte à l'approche de la date butoir.
+3. Un retrait peut intervenir à tout moment. Il doit être consigné immédiatement et prend effet sur l'ensemble des pipelines.
+
+## Capture initiale
+
+1. Depuis le tableau de bord, ouvrir l'espace « Consentements » puis sélectionner « Nouvelle capture ».
+2. Choisir le modèle de fiche adapté (collaborateur interne, client externe, partenaire).
+3. Renseigner les champs obligatoires : identité, finalités acceptées, limitations imposées, date de fin.
+4. Ajouter les pièces justificatives en les déposant dans la zone prévue (scan signé, mention légale) pour qu'elles soient liées à la fiche.
+5. Valider. L'application génère automatiquement une entrée signée dans le registre JSONL stocké dans le coffre hors ligne.
+
+## Vérification et audit
+
+1. Accéder à l'onglet « Historique » pour consulter la chronologie des consentements et retraits.
+2. Utiliser le filtre « Statut » afin d'isoler les consentements expirés ou en attente d'approbation.
+3. Cliquer sur une fiche pour afficher la trace de signature et les hachages correspondants. Comparer ces informations avec le registre de référence lors des audits.
+
+## Gestion des mises à jour
+
+1. Lorsque les finalités évoluent, sélectionner la fiche concernée puis cliquer sur « Modifier ».
+2. Documenter la nouvelle portée dans la zone « Modifications ». L'application conserve la version précédente et incrémente le numéro de révision.
+3. Soumettre la fiche à validation managériale en choisissant « Demander une revue ». Un binôme différent doit approuver la modification.
+4. Une fois validée, la mise à jour se propage aux politiques d'accès et aux scénarios d'autopilote concernés.
+
+## Retrait et purge
+
+1. En cas de retrait, ouvrir la fiche et appuyer sur « Révoquer immédiatement ».
+2. Sélectionner les artefacts à purger : index vectoriel, copies locales, journaux de session.
+3. Confirmer l'opération. Le système planifie automatiquement une tâche d'assainissement et bloque tout nouveau traitement jusqu'à confirmation de purge complète.
+
+## Liaison avec les politiques d'exécution
+
+- Les consentements actifs sont exposés à l'autopilote comme contraintes. Une tâche ne peut s'exécuter que si son périmètre est couvert par un consentement valide.
+- Les retraits sont synchronisés avec la [procédure de dépannage](depannage.md) pour déclencher, si nécessaire, une suspension préventive.
+- La page [Quickstart sans commande](quickstart-sans-commande.md) résume la première capture à effectuer lors de l'onboarding.

--- a/docs/quickstart-sans-commande.md
+++ b/docs/quickstart-sans-commande.md
@@ -1,0 +1,44 @@
+# Quickstart sans commande
+
+Ce guide propose un démarrage immédiat de Watcher en respectant la philosophie « plug-and-play ». Toutes les étapes se déroulent via l'interface graphique et les assistants embarqués, sans recours à une invite de commande.
+
+## Prérequis matériels et sécurité
+
+1. Vérifier que la station est déconnectée d'Internet ou placée derrière un pare-feu qui bloque les connexions sortantes inattendues.
+2. Brancher le module matériel Watcher (NPU ou GPU local selon la configuration) et attendre que le voyant d'état passe au vert fixe.
+3. Insérer la clé USB de provisionnement contenant le bundle signé remis lors de la livraison.
+4. Ouvrir l'application Watcher depuis le menu « Applications locales » et confirmer l'identité de l'opérateur à l'aide du code PIN fourni.
+
+## Initialisation guidée
+
+1. À l'écran d'accueil, choisir « Activer l'espace isolé » pour monter le conteneur hors ligne et charger le profil matériel.
+2. Lire les avertissements de la charte éthique puis sélectionner « Poursuivre » pour accéder au tableau de bord.
+3. Dans le widget « Consentements », cliquer sur « Nouvelle capture » afin d'enregistrer les personnes concernées par l'assistant. Se référer au [guide de consentement](policy-consent.md) pour détailler cette étape.
+4. Dans la section « Politique d'exécution », activer le mode « Budget limité » qui plafonne le nombre de cycles autonomes avant revue humaine.
+
+## Chargement des connaissances locales
+
+1. Insérer les supports (dossiers projet, documents de référence) dans le dossier partagé « Sources approuvées ».
+2. Depuis le tableau de bord, choisir « Indexer maintenant ». L'assistant d'ingestion affiche une progression et signale les fichiers rejetés avec leur motif.
+3. Valider la suggestion de taxonomie proposée. En cas de doute, sélectionner « Révision humaine » pour reporter une décision.
+
+## Lancement d'un cycle pilote
+
+1. Ouvrir l'onglet « Autopilote » puis choisir « Créer un plan expérimental ».
+2. Confirmer les objectifs de la session (par exemple « Refactoriser le module d'observabilité ») et ajouter les contraintes de sécurité souhaitées.
+3. Laisser l'assistant générer les tâches. Revoir les actions proposées, décocher celles qui ne doivent pas être exécutées, puis valider.
+4. Surveiller la phase « Analyse », « Synthèse » et « Validation » dans l'ordre. Chaque transition nécessite une approbation explicite pour maintenir une supervision forte.
+
+## Revue finale
+
+1. À la fin du cycle, ouvrir la carte « Journal des décisions » et vérifier que toutes les interventions sont consignées.
+2. Consulter le rapport d'artefacts signés (voir [vérification des artefacts](verifier-artefacts.md)) afin de confirmer l'intégrité des sorties.
+3. Exporter le paquet de session sur la clé USB de contrôle pour archivage.
+4. Passer en mode veille en sélectionnant « Suspendre le conteneur » avant de débrancher le matériel.
+
+## Prochaines étapes
+
+- Approfondir la gouvernance avec le [guide de consentement détaillé](policy-consent.md).
+- Configurer l'autopilote durablement en suivant le [cycle de vie de l'autopilote](autopilot.md).
+- Apprendre à diagnostiquer les anomalies via la [procédure de dépannage](depannage.md).
+- Vérifier l'intégrité des éléments livrés grâce au [protocole de contrôle d'artefacts](verifier-artefacts.md).

--- a/docs/verifier-artefacts.md
+++ b/docs/verifier-artefacts.md
@@ -1,0 +1,34 @@
+# Vérification des artefacts Watcher
+
+La chaîne plug-and-play de Watcher produit des rapports signés et des paquets d'exécution. Cette procédure décrit comment vérifier leur intégrité sans recourir à des commandes en ligne. Toutes les opérations se déroulent dans les modules « Provenance » et « Audits » de l'interface.
+
+## Préparer l'espace de contrôle
+
+1. Insérer la clé de contrôle ou monter le coffre hors ligne contenant les fichiers d'attestation remis avec le bundle.
+2. Depuis le tableau de bord, ouvrir l'onglet « Provenance » puis sélectionner « Nouvelle vérification ».
+3. Choisir la source à valider : paquet d'autopilote, index de connaissances ou build applicative.
+
+## Vérification automatique
+
+1. Charger le paquet à contrôler via le sélecteur de fichiers intégré.
+2. L'interface calcule automatiquement l'empreinte SHA-256 et l'affiche à l'écran.
+3. L'application recherche la signature correspondante dans le registre `Watcher-Setup.intoto.jsonl`. Vérifier que l'indicateur « Signature valide » s'affiche en vert.
+4. Examiner le résumé CycloneDX associé pour confirmer la liste des dépendances, versions et licences.
+
+## Contrôles supplémentaires
+
+1. Ouvrir l'onglet « Comparaison » pour juxtaposer le paquet courant avec la référence précédente.
+2. Vérifier que les différences signalées correspondent aux modifications attendues (nouvelles fonctionnalités, correctifs de sécurité).
+3. Si une divergence inattendue apparaît, basculer sur « Escalade » afin de notifier l'équipe sécurité et figer la diffusion des artefacts.
+
+## Journalisation et conservation
+
+1. Valider la vérification pour consigner le résultat dans le journal append-only. Une entrée horodatée est ajoutée avec le détail des hachages contrôlés.
+2. Archiver le rapport PDF généré automatiquement sur le support sécurisé dédié.
+3. Associer la vérification à la session Autopilote concernée pour maintenir la traçabilité bout en bout.
+
+## Intégration dans les autres procédures
+
+- Le [Quickstart sans commande](quickstart-sans-commande.md) renvoie vers cette page à l'étape de revue finale.
+- Les contrôles de consentement décrits dans le [guide de politique de consentement](policy-consent.md) doivent être cohérents avec les artefacts validés.
+- En cas d'anomalie détectée, suivre la [procédure de dépannage](depannage.md) pour enclencher l'enquête et, si nécessaire, révoquer les livrables.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ extra:
 
 nav:
   - Accueil: index.md
+  - Quickstart sans commande: quickstart-sans-commande.md
   - Architecture:
       - Vue d'ensemble: architecture.md
       - Journal de conception:
@@ -85,7 +86,11 @@ nav:
       - Notes de version: release_notes.md
       - Guide hors-ligne: offline_guide.md
   - Exploitation:
+      - Gouvernance du consentement: policy-consent.md
       - Conventions de logging: logging.md
+      - Autopilote: autopilot.md
+      - Vérifier les artefacts: verifier-artefacts.md
+      - Dépannage plug-and-play: depannage.md
       - Feuille de route: ROADMAP.md
       - Journal des modifications: CHANGELOG.md
       - Politique de fusion: merge-policy.md


### PR DESCRIPTION
## Summary
- add command-free quickstart, consent, autopilot, artefact verification, and troubleshooting guides aligned with the plug-and-play flow
- surface the new guides in the MkDocs navigation and reference them from the main onboarding page

## Testing
- mkdocs build --strict *(fails: `mkdocs` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e111abaf388320b774a513810a9164